### PR TITLE
Enable documentation of CLI sub-command arguments

### DIFF
--- a/src/cli/mypy.ini
+++ b/src/cli/mypy.ini
@@ -40,3 +40,6 @@ ignore_missing_imports = True
 
 [mypy-memoization.*]
 ignore_missing_imports = True
+
+[mypy-docstring_parser.*]
+ignore_missing_imports = True

--- a/src/cli/onefuzz/templates/afl.py
+++ b/src/cli/onefuzz/templates/afl.py
@@ -47,7 +47,7 @@ class AFL(Command):
         tags: Optional[Dict[str, str]] = None,
         wait_for_running: bool = False,
         wait_for_files: Optional[List[ContainerType]] = None,
-        afl_version: Optional[Container] = None,
+        afl_container: Optional[Container] = None,
         existing_inputs: Optional[Container] = None,
         dryrun: bool = False,
         notification_config: Optional[NotificationConfig] = None,
@@ -55,7 +55,7 @@ class AFL(Command):
         """
         Basic AFL job
 
-        :param Container afl_version: Specify the AFL container to use in the job
+        :param Container afl_container: Specify the AFL container to use in the job
         """
 
         if existing_inputs:
@@ -110,16 +110,16 @@ class AFL(Command):
 
         target_exe_blob_name = helper.target_exe_blob_name(target_exe, setup_dir)
 
-        if afl_version is None:
-            afl_version = Container(
+        if afl_container is None:
+            afl_container = Container(
                 "afl-linux" if helper.platform == OS.linux else "afl-windows"
             )
 
         # verify the AFL container exists
-        self.onefuzz.containers.get(afl_version)
+        self.onefuzz.containers.get(afl_container)
 
         containers = [
-            (ContainerType.tools, afl_version),
+            (ContainerType.tools, afl_container),
             (ContainerType.setup, helper.containers[ContainerType.setup]),
             (ContainerType.crashes, helper.containers[ContainerType.crashes]),
             (ContainerType.inputs, helper.containers[ContainerType.inputs]),

--- a/src/cli/onefuzz/templates/afl.py
+++ b/src/cli/onefuzz/templates/afl.py
@@ -47,12 +47,16 @@ class AFL(Command):
         tags: Optional[Dict[str, str]] = None,
         wait_for_running: bool = False,
         wait_for_files: Optional[List[ContainerType]] = None,
-        fuzzer_setup_container: Optional[Container] = None,
+        afl_version: Optional[Container] = None,
         existing_inputs: Optional[Container] = None,
         dryrun: bool = False,
         notification_config: Optional[NotificationConfig] = None,
     ) -> None:
-        """ Basic AFL job """
+        """
+        Basic AFL job
+
+        :param Container afl_version: Specify the AFL container to use in the job
+        """
 
         if existing_inputs:
             self.onefuzz.containers.get(existing_inputs)
@@ -106,13 +110,16 @@ class AFL(Command):
 
         target_exe_blob_name = helper.target_exe_blob_name(target_exe, setup_dir)
 
-        if fuzzer_setup_container is None:
-            fuzzer_setup_container = Container(
+        if afl_version is None:
+            afl_version = Container(
                 "afl-linux" if helper.platform == OS.linux else "afl-windows"
             )
 
+        # verify the AFL container exists
+        self.onefuzz.containers.get(afl_version)
+
         containers = [
-            (ContainerType.tools, fuzzer_setup_container),
+            (ContainerType.tools, afl_version),
             (ContainerType.setup, helper.containers[ContainerType.setup]),
             (ContainerType.crashes, helper.containers[ContainerType.crashes]),
             (ContainerType.inputs, helper.containers[ContainerType.inputs]),

--- a/src/cli/requirements.txt
+++ b/src/cli/requirements.txt
@@ -10,5 +10,6 @@ pydantic~=1.6.1 --no-binary=pydantic
 memoization~=0.3.1
 azure-storage-blob~=12.3
 tenacity==6.2.0
+docstring_parser==0.7.3
 # onefuzztypes version is set during build
 onefuzztypes==0.0.0


### PR DESCRIPTION
## Summary of the Pull Request

This PR enables adding documentation to CLI sub-command arguments via docstring_parser.

## PR Checklist
* [X] Applies to work item: #7 
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/onefuzz) and sign the CLI.
* [X] Tests added/passed
* [ ] Requires documentation to be updated
* [X] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

1. This includes adding docstring_parser as a prereq to the CLI.
2. Adds  support for parsing the docstrings of functions, and optionally passing the help strings as argument documentation if the documentation doesn't already exist.

## Validation Steps Performed

Run `onefuzz template afl basic --help |grep -i afl`

Previously, the argument 'fuzzer_setup_container' wasn't documented beyond "CONTAINER".  Now, afl_container says "Specify the AFL container to use in the job"