### PR TITLE
set ONEFUZZ_TARGET_SETUP_PATH prior to executing task setup

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -70,4 +70,4 @@ implementation level details on the types of tasks available.
 
 
 ## Environment Variables
-* `ONEFUZZ_TASK_SETUP_PATH`: An environment variable set prior to launching task-specific setup scripts.
+* `ONEFUZZ_TASK_SETUP_PATH`: An environment variable set prior to launching task-specific setup scripts that defines the path to the setup container.

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -67,3 +67,7 @@ include:
 
 See [task definitions](../src/api-service/__app__/onefuzzlib/tasks/defs.py) for
 implementation level details on the types of tasks available.
+
+
+## Environment Variables
+* `ONEFUZZ_TASK_SETUP_PATH`: An environment variable set prior to launching task-specific setup scripts.

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -70,4 +70,4 @@ implementation level details on the types of tasks available.
 
 
 ## Environment Variables
-* `ONEFUZZ_TASK_SETUP_PATH`: An environment variable set prior to launching task-specific setup scripts that defines the path to the setup container.
+* `ONEFUZZ_TARGET_SETUP_PATH`: An environment variable set prior to launching target-specific setup scripts that defines the path to the setup container.

--- a/src/agent/onefuzz-supervisor/src/setup.rs
+++ b/src/agent/onefuzz-supervisor/src/setup.rs
@@ -13,7 +13,7 @@ use tokio::process::Command;
 
 use crate::work::*;
 
-const SETUP_PATH_ENV: &str = "ONEFUZZ_TASK_SETUP_PATH";
+const SETUP_PATH_ENV: &str = "ONEFUZZ_TARGET_SETUP_PATH";
 
 #[async_trait]
 pub trait ISetupRunner: Downcast {


### PR DESCRIPTION
## Summary of the Pull Request

Adds an environment variable that exposes the task specific setup container as it exists on the fuzzing node

## PR Checklist
* [x] Applies to work item: #14 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/onefuzz) and sign the CLI.
* [x] Tests added/passed
* [x] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

This sets `ONEFUZZ_TASK_SETUP_PATH` to the path for the `setup` container in the work set.

## Validation Steps Performed

1. Execute a task with the following setup.sh: 

``` bash
set -ex
[ -f $ONEFUZZ_TASK_SETUP_PATH/setup.sh ]
```