### PR TITLE
finish scaleset state refactor

### DIFF
--- a/src/api-service/__app__/daily_events/__init__.py
+++ b/src/api-service/__app__/daily_events/__init__.py
@@ -9,6 +9,7 @@ import azure.functions as func
 from onefuzztypes.enums import VmState
 
 from ..onefuzzlib.proxy import Proxy
+from ..onefuzzlib.pools import Scaleset
 
 
 def main(mytimer: func.TimerRequest) -> None:  # noqa: F841
@@ -17,3 +18,8 @@ def main(mytimer: func.TimerRequest) -> None:  # noqa: F841
             logging.info("stopping proxy")
             proxy.state = VmState.stopping
             proxy.save()
+
+    scalesets = Scaleset.search()
+    for scaleset in scalesets:
+        logging.info("updating scaleset configs: %s", scaleset.scaleset_id)
+        scaleset.update_configs()

--- a/src/api-service/__app__/daily_events/__init__.py
+++ b/src/api-service/__app__/daily_events/__init__.py
@@ -8,8 +8,8 @@ import logging
 import azure.functions as func
 from onefuzztypes.enums import VmState
 
-from ..onefuzzlib.proxy import Proxy
 from ..onefuzzlib.pools import Scaleset
+from ..onefuzzlib.proxy import Proxy
 
 
 def main(mytimer: func.TimerRequest) -> None:  # noqa: F841

--- a/src/api-service/__app__/scaleset_events/__init__.py
+++ b/src/api-service/__app__/scaleset_events/__init__.py
@@ -30,8 +30,6 @@ def process_scaleset(scaleset: Scaleset) -> None:
         getattr(scaleset, scaleset.state.name)()
         return
 
-    scaleset.update_configs()
-
 
 def main(mytimer: func.TimerRequest, dashboard: func.Out[str]) -> None:  # noqa: F841
     scalesets = Scaleset.search()

--- a/src/api-service/__app__/scheduled_events/__init__.py
+++ b/src/api-service/__app__/scheduled_events/__init__.py
@@ -24,14 +24,6 @@ from ..onefuzzlib.tasks.main import Task
 
 
 def main(mytimer: func.TimerRequest, dashboard: func.Out[str]) -> None:  # noqa: F841
-    scalesets = Scaleset.search()
-    scalesets_needs_work = ScalesetState.needs_work()
-    for scaleset in scalesets:
-        logging.info("queueing scaleset updates: %s", scaleset.scaleset_id)
-        scaleset.queue(method=scaleset.update_configs)
-        if scaleset.state in scalesets_needs_work:
-            scaleset.queue()
-
     proxies = Proxy.search_states(states=VmState.needs_work())
     for proxy in proxies:
         logging.info("requeueing update proxy vm: %s", proxy.region)

--- a/src/api-service/__app__/scheduled_events/__init__.py
+++ b/src/api-service/__app__/scheduled_events/__init__.py
@@ -6,18 +6,11 @@
 import logging
 
 import azure.functions as func
-from onefuzztypes.enums import (
-    JobState,
-    NodeState,
-    PoolState,
-    ScalesetState,
-    TaskState,
-    VmState,
-)
+from onefuzztypes.enums import JobState, NodeState, PoolState, TaskState, VmState
 
 from ..onefuzzlib.dashboard import get_event
 from ..onefuzzlib.jobs import Job
-from ..onefuzzlib.pools import Node, Pool, Scaleset
+from ..onefuzzlib.pools import Node, Pool
 from ..onefuzzlib.proxy import Proxy
 from ..onefuzzlib.repro import Repro
 from ..onefuzzlib.tasks.main import Task


### PR DESCRIPTION
## Summary of the Pull Request

Finishes the pre-1.0 scaleset state refactor

## Info on Pull Request

1. Only executes `scaleset.update_configs` once every 24 hours, instead of once every 90 seconds.
2. Removes the ORM state-based event queuing that was replaced by `scaleset_events`

## Validation Steps Performed

1. Create a new pool
2. Create a scaleset as part of the new pool
3. Assign a task to the new pool, verify it gets executed