### PR TITLE
Flush telemetry on supervisor agent error

### DIFF
--- a/src/agent/onefuzz-supervisor/src/main.rs
+++ b/src/agent/onefuzz-supervisor/src/main.rs
@@ -83,14 +83,13 @@ fn run(opt: RunOpt) -> Result<()> {
     let mut rt = tokio::runtime::Runtime::new()?;
     let result = rt.block_on(run_agent(config));
 
-    if let Err(err) = result {
+    if let Err(err) = &result {
         error!("error running supervisor agent: {}", err);
-        return Err(err);
     }
 
     onefuzz::telemetry::try_flush_and_close();
 
-    Ok(())
+    result
 }
 
 fn load_config(opt: RunOpt) -> Result<StaticConfig> {


### PR DESCRIPTION
## Summary of the Pull Request

Flush telemetry when supervisor agent exits due to an error.

## PR Checklist
* [x] Applies to work item: #20 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/onefuzz) and sign the CLI.
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Validation Steps Performed

- [x] Tested manually.
