### PR TITLE
Redact work set fields

### DIFF
--- a/src/agent/onefuzz-supervisor/src/agent/tests.rs
+++ b/src/agent/onefuzz-supervisor/src/agent/tests.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use url::Url;
+use onefuzz::blob::BlobContainerUrl;
 use uuid::Uuid;
 
 use crate::coordinator::double::*;
@@ -68,8 +68,9 @@ impl Fixture {
         }
     }
 
-    pub fn setup_url(&self) -> Url {
-        "https://contoso.com/my-setup-container".parse().unwrap()
+    pub fn setup_url(&self) -> BlobContainerUrl {
+        let url = "https://contoso.com/my-setup-container";
+        BlobContainerUrl::parse(&url).unwrap()
     }
 
     pub fn work_unit(&self) -> WorkUnit {

--- a/src/agent/onefuzz-supervisor/src/agent/tests.rs
+++ b/src/agent/onefuzz-supervisor/src/agent/tests.rs
@@ -73,7 +73,7 @@ impl Fixture {
     }
 
     pub fn work_unit(&self) -> WorkUnit {
-        let config = r#"{ "hello": "world" }"#.into();
+        let config = r#"{ "hello": "world" }"#.to_owned().into();
 
         WorkUnit {
             job_id: self.job_id(),

--- a/src/agent/onefuzz-supervisor/src/auth.rs
+++ b/src/agent/onefuzz-supervisor/src/auth.rs
@@ -28,6 +28,12 @@ impl<T> fmt::Debug for Secret<T> {
     }
 }
 
+impl<T> fmt::Display for Secret<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "<REDACTED>")
+    }
+}
+
 #[derive(Clone, Deserialize, Eq, PartialEq)]
 pub struct AccessToken {
     secret: Secret<String>,

--- a/src/agent/onefuzz-supervisor/src/auth.rs
+++ b/src/agent/onefuzz-supervisor/src/auth.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use std::{fmt, ops};
+use std::fmt;
 
 use anyhow::Result;
 use url::Url;
@@ -9,6 +9,20 @@ use uuid::Uuid;
 
 #[derive(Clone, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Secret<T>(T);
+
+impl<T> Secret<T> {
+    pub fn expose(self) -> T {
+        self.0
+    }
+
+    pub fn expose_ref(&self) -> &T {
+        &self.0
+    }
+
+    pub fn expose_mut(&mut self) -> &mut T {
+        &mut self.0
+    }
+}
 
 impl<T> From<T> for Secret<T> {
     fn from(data: T) -> Self {
@@ -25,20 +39,6 @@ impl<T> fmt::Debug for Secret<T> {
 impl<T> fmt::Display for Secret<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "<REDACTED>")
-    }
-}
-
-impl<T> ops::Deref for Secret<T> {
-    type Target = T;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl<T> ops::DerefMut for Secret<T> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
     }
 }
 

--- a/src/agent/onefuzz-supervisor/src/auth.rs
+++ b/src/agent/onefuzz-supervisor/src/auth.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use std::fmt;
+use std::{fmt, ops};
 
 use anyhow::Result;
 use url::Url;
@@ -9,12 +9,6 @@ use uuid::Uuid;
 
 #[derive(Clone, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Secret<T>(T);
-
-impl<T> Secret<T> {
-    pub fn expose(&self) -> &T {
-        &self.0
-    }
-}
 
 impl<T> From<T> for Secret<T> {
     fn from(data: T) -> Self {
@@ -31,6 +25,20 @@ impl<T> fmt::Debug for Secret<T> {
 impl<T> fmt::Display for Secret<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "<REDACTED>")
+    }
+}
+
+impl<T> ops::Deref for Secret<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> ops::DerefMut for Secret<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
     }
 }
 

--- a/src/agent/onefuzz-supervisor/src/config.rs
+++ b/src/agent/onefuzz-supervisor/src/config.rs
@@ -126,7 +126,7 @@ impl Registration {
             let response = reqwest::Client::new()
                 .post(url.clone())
                 .header("Content-Length", "0")
-                .bearer_auth(&*token.secret())
+                .bearer_auth(token.secret().expose_ref())
                 .body("")
                 .send()
                 .await?
@@ -174,7 +174,7 @@ impl Registration {
 
         let response = reqwest::Client::new()
             .get(url)
-            .bearer_auth(&*token.secret())
+            .bearer_auth(token.secret().expose_ref())
             .send()
             .await?
             .error_for_status()?;

--- a/src/agent/onefuzz-supervisor/src/config.rs
+++ b/src/agent/onefuzz-supervisor/src/config.rs
@@ -126,7 +126,7 @@ impl Registration {
             let response = reqwest::Client::new()
                 .post(url.clone())
                 .header("Content-Length", "0")
-                .bearer_auth(token.secret().expose())
+                .bearer_auth(&*token.secret())
                 .body("")
                 .send()
                 .await?
@@ -174,7 +174,7 @@ impl Registration {
 
         let response = reqwest::Client::new()
             .get(url)
-            .bearer_auth(token.secret().expose())
+            .bearer_auth(&*token.secret())
             .send()
             .await?
             .error_for_status()?;

--- a/src/agent/onefuzz-supervisor/src/coordinator.rs
+++ b/src/agent/onefuzz-supervisor/src/coordinator.rs
@@ -242,7 +242,7 @@ impl Coordinator {
         let request = self
             .client
             .get(url)
-            .bearer_auth(&*self.token.secret())
+            .bearer_auth(self.token.secret().expose_ref())
             .json(&request)
             .build()?;
 
@@ -259,7 +259,7 @@ impl Coordinator {
         let request = self
             .client
             .delete(url)
-            .bearer_auth(&*self.token.secret())
+            .bearer_auth(self.token.secret().expose_ref())
             .json(&request)
             .build()?;
 
@@ -271,7 +271,7 @@ impl Coordinator {
         let request = self
             .client
             .post(url)
-            .bearer_auth(&*self.token.secret())
+            .bearer_auth(self.token.secret().expose_ref())
             .json(event)
             .build()?;
 
@@ -294,7 +294,7 @@ impl Coordinator {
         let request = self
             .client
             .get(url)
-            .bearer_auth(&*self.token.secret())
+            .bearer_auth(self.token.secret().expose_ref())
             .json(&task_search)
             .build()?;
 

--- a/src/agent/onefuzz-supervisor/src/coordinator.rs
+++ b/src/agent/onefuzz-supervisor/src/coordinator.rs
@@ -242,7 +242,7 @@ impl Coordinator {
         let request = self
             .client
             .get(url)
-            .bearer_auth(self.token.secret().expose())
+            .bearer_auth(&*self.token.secret())
             .json(&request)
             .build()?;
 
@@ -259,7 +259,7 @@ impl Coordinator {
         let request = self
             .client
             .delete(url)
-            .bearer_auth(self.token.secret().expose())
+            .bearer_auth(&*self.token.secret())
             .json(&request)
             .build()?;
 
@@ -271,7 +271,7 @@ impl Coordinator {
         let request = self
             .client
             .post(url)
-            .bearer_auth(self.token.secret().expose())
+            .bearer_auth(&*self.token.secret())
             .json(event)
             .build()?;
 
@@ -294,7 +294,7 @@ impl Coordinator {
         let request = self
             .client
             .get(url)
-            .bearer_auth(self.token.secret().expose())
+            .bearer_auth(&*self.token.secret())
             .json(&task_search)
             .build()?;
 

--- a/src/agent/onefuzz-supervisor/src/debug.rs
+++ b/src/agent/onefuzz-supervisor/src/debug.rs
@@ -4,6 +4,7 @@
 use std::path::PathBuf;
 
 use anyhow::Result;
+use onefuzz::blob::BlobContainerUrl;
 use structopt::StructOpt;
 use url::Url;
 use uuid::Uuid;
@@ -142,7 +143,7 @@ fn debug_run_worker(opt: RunWorkerOpt) -> Result<()> {
     };
     let work_set = WorkSet {
         reboot: false,
-        setup_url: opt.setup_url,
+        setup_url: BlobContainerUrl::new(opt.setup_url)?,
         script: opt.script,
         work_units: vec![work_unit],
     };

--- a/src/agent/onefuzz-supervisor/src/debug.rs
+++ b/src/agent/onefuzz-supervisor/src/debug.rs
@@ -136,7 +136,7 @@ fn debug_run_worker(opt: RunWorkerOpt) -> Result<()> {
     };
 
     let work_unit = WorkUnit {
-        config,
+        config: config.into(),
         job_id: Uuid::new_v4(),
         task_id,
     };

--- a/src/agent/onefuzz-supervisor/src/setup.rs
+++ b/src/agent/onefuzz-supervisor/src/setup.rs
@@ -7,7 +7,6 @@ use std::process::Stdio;
 use anyhow::Result;
 use downcast_rs::Downcast;
 use onefuzz::az_copy;
-use onefuzz::blob::BlobContainerUrl;
 use tokio::fs;
 use tokio::process::Command;
 
@@ -40,10 +39,8 @@ impl SetupRunner {
         info!("running setup for work set");
 
         // Download the setup container.
-        let setup_url = work_set.setup_url.clone();
-        let setup_url = BlobContainerUrl::new(setup_url)?;
-
-        let setup_dir = setup_url.container();
+        let setup_url = work_set.setup_url.url();
+        let setup_dir = work_set.setup_url.container();
         let setup_dir = onefuzz::fs::onefuzz_root()?
             .join("blob-containers")
             .join(setup_dir);

--- a/src/agent/onefuzz-supervisor/src/setup.rs
+++ b/src/agent/onefuzz-supervisor/src/setup.rs
@@ -47,7 +47,7 @@ impl SetupRunner {
 
         // `azcopy sync` requires the local dir to exist.
         fs::create_dir_all(&setup_dir).await?;
-        az_copy::sync(work_set.setup_url.to_string(), &setup_dir).await?;
+        az_copy::sync(setup_url.to_string(), &setup_dir).await?;
 
         verbose!(
             "synced setup container from {} to {}",

--- a/src/agent/onefuzz-supervisor/src/work.rs
+++ b/src/agent/onefuzz-supervisor/src/work.rs
@@ -9,6 +9,7 @@ use storage_queue::QueueClient;
 use url::Url;
 use uuid::Uuid;
 
+use crate::auth::Secret;
 use crate::config::Registration;
 
 pub type JobId = Uuid;
@@ -32,7 +33,7 @@ pub struct WorkUnit {
     pub task_id: TaskId,
 
     /// JSON-serialized task config.
-    pub config: String,
+    pub config: Secret<String>,
 }
 
 impl WorkUnit {

--- a/src/agent/onefuzz-supervisor/src/work.rs
+++ b/src/agent/onefuzz-supervisor/src/work.rs
@@ -5,8 +5,8 @@ use std::path::PathBuf;
 
 use anyhow::Result;
 use downcast_rs::Downcast;
+use onefuzz::blob::BlobContainerUrl;
 use storage_queue::QueueClient;
-use url::Url;
 use uuid::Uuid;
 
 use crate::auth::Secret;
@@ -19,7 +19,7 @@ pub type TaskId = Uuid;
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct WorkSet {
     pub reboot: bool,
-    pub setup_url: Url,
+    pub setup_url: BlobContainerUrl,
     pub script: bool,
     pub work_units: Vec<WorkUnit>,
 }

--- a/src/agent/onefuzz-supervisor/src/worker.rs
+++ b/src/agent/onefuzz-supervisor/src/worker.rs
@@ -199,7 +199,7 @@ impl IWorkerRunner for WorkerRunner {
 
         let config_path = work.config_path()?;
 
-        fs::write(&config_path, &work.config).await?;
+        fs::write(&config_path, &*work.config).await?;
 
         verbose!(
             "wrote worker config to config_path = {}",

--- a/src/agent/onefuzz-supervisor/src/worker.rs
+++ b/src/agent/onefuzz-supervisor/src/worker.rs
@@ -199,7 +199,7 @@ impl IWorkerRunner for WorkerRunner {
 
         let config_path = work.config_path()?;
 
-        fs::write(&config_path, &*work.config).await?;
+        fs::write(&config_path, work.config.expose_ref()).await?;
 
         verbose!(
             "wrote worker config to config_path = {}",

--- a/src/agent/onefuzz-supervisor/src/worker/tests.rs
+++ b/src/agent/onefuzz-supervisor/src/worker/tests.rs
@@ -11,7 +11,7 @@ impl Fixture {
     fn work(&self) -> WorkUnit {
         let job_id = "d4e6cb4a-917e-4826-8a44-7646938c80a8".parse().unwrap();
         let task_id = "1cfcdfe6-df10-42a5-aab7-1a45db0d0e48".parse().unwrap();
-        let config = r#"{ "some": "config" }"#.to_owned();
+        let config = r#"{ "some": "config" }"#.to_owned().into();
 
         WorkUnit {
             job_id,

--- a/src/agent/onefuzz/src/blob/url.rs
+++ b/src/agent/onefuzz/src/blob/url.rs
@@ -5,7 +5,7 @@ use std::fmt;
 
 use anyhow::Result;
 use reqwest::Url;
-use serde::de;
+use serde::{de, Serialize, Serializer};
 
 #[derive(Clone, Eq, PartialEq)]
 pub struct BlobUrl {
@@ -217,6 +217,16 @@ fn possible_blob_storage_url(url: &Url, container: bool) -> bool {
 
 fn possible_blob_container_url(url: &Url) -> bool {
     possible_blob_storage_url(url, true)
+}
+
+impl Serialize for BlobContainerUrl {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let url = self.url.to_string();
+        serializer.serialize_str(&url)
+    }
 }
 
 impl<'de> de::Deserialize<'de> for BlobContainerUrl {


### PR DESCRIPTION
## Summary of the Pull Request

- Provide full sets of `expose[..]` methods for `Secret`
- Redact serialized work unit config in logging
- Use `BlobContainerUrl` for work set setup URL