### PR TITLE
set more detailed version information during builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,11 +251,11 @@ jobs:
           cp -r src/agent/script/win64/libfuzzer-coverage src/deployment/tools/win64/libfuzzer-coverage
           echo $GITHUB_RUN_ID | tee src/deployment/.build.id
           echo $GITHUB_SHA | tee src/deployment/.sha
-          cp CURRENT_VERSION src/deployment/VERSION
+          ./src/ci/get-version.sh > src/deployment/VERSION
           (cd src/deployment ; zip -r onefuzz-deployment-$(cat VERSION).zip . )
           cp src/deployment/onefuzz-deployment*zip release-artifacts
           cp -r artifacts/sdk release-artifacts
-          cp -r artifacts/windows-cli/onefuzz.exe release-artifacts/onefuzz-cli-$(cat CURRENT_VERSION).exe
+          cp -r artifacts/windows-cli/onefuzz.exe release-artifacts/onefuzz-cli-$(./src/ci/get-version.sh).exe
     - uses: actions/upload-artifact@v2.1.4
       with:
         name: release-artifacts

--- a/src/agent/onefuzz-agent/build.rs
+++ b/src/agent/onefuzz-agent/build.rs
@@ -1,8 +1,8 @@
+use std::env;
 use std::error::Error;
 use std::fs::File;
 use std::io::prelude::*;
 use std::process::Command;
-use std::env;
 
 fn run_cmd(args: &[&str]) -> Result<String, Box<dyn Error>> {
     let cmd = Command::new(args[0]).args(&args[1..]).output()?;
@@ -38,9 +38,9 @@ fn print_version(include_sha: bool) -> Result<(), Box<dyn Error>> {
         }
     }
 
-    println!("cargo:rustc-env=GIT_VERSION={}", sha);    
+    println!("cargo:rustc-env=GIT_VERSION={}", sha);
     println!("cargo:rustc-env=ONEFUZZ_VERSION={}", version);
- 
+
     Ok(())
 }
 
@@ -48,7 +48,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     // If we're built off of a tag, we accept CURRENT_VERSION as is.  Otherwise
     // modify it to indicate local build
     if let Ok(val) = env::var("GITHUB_REF") {
-        if val.starts_with("refs/tags/") { 
+        if val.starts_with("refs/tags/") {
             print_version(false)
         } else {
             print_version(true)

--- a/src/agent/onefuzz-agent/build.rs
+++ b/src/agent/onefuzz-agent/build.rs
@@ -30,7 +30,7 @@ fn print_version(include_sha: bool) -> Result<(), Box<dyn Error>> {
         version.push('-');
         version.push_str(&sha);
 
-        // if we're a non-release buil, check to see if git has
+        // if we're a non-release build, check to see if git has
         // unstaged changes
         if run_cmd(&["git", "diff", "--quiet"]).is_err() {
             version.push('.');
@@ -47,13 +47,10 @@ fn print_version(include_sha: bool) -> Result<(), Box<dyn Error>> {
 fn main() -> Result<(), Box<dyn Error>> {
     // If we're built off of a tag, we accept CURRENT_VERSION as is.  Otherwise
     // modify it to indicate local build
-    if let Ok(val) = env::var("GITHUB_REF") {
-        if val.starts_with("refs/tags/") {
-            print_version(false)
-        } else {
-            print_version(true)
-        }
+    let include_sha = if let Ok(val) = env::var("GITHUB_REF") {
+        !val.starts_with("refs/tags/")
     } else {
-        print_version(true)
-    }
+        true
+    };
+    print_version(include_sha)
 }

--- a/src/agent/onefuzz-agent/build.rs
+++ b/src/agent/onefuzz-agent/build.rs
@@ -2,11 +2,12 @@ use std::error::Error;
 use std::fs::File;
 use std::io::prelude::*;
 use std::process::Command;
+use std::env;
 
 fn run_cmd(args: &[&str]) -> Result<String, Box<dyn Error>> {
     let cmd = Command::new(args[0]).args(&args[1..]).output()?;
     if cmd.status.success() {
-        Ok(String::from_utf8_lossy(&cmd.stdout).to_string())
+        Ok(String::from_utf8_lossy(&cmd.stdout).trim().to_string())
     } else {
         Err(From::from("failed"))
     }
@@ -16,21 +17,43 @@ fn read_file(filename: &str) -> Result<String, Box<dyn Error>> {
     let mut file = File::open(filename)?;
     let mut contents = String::new();
     file.read_to_string(&mut contents)?;
+    contents = contents.trim().to_string();
 
     Ok(contents)
 }
 
-fn main() -> Result<(), Box<dyn Error>> {
+fn print_version(include_sha: bool) -> Result<(), Box<dyn Error>> {
+    let mut version = read_file("../../../CURRENT_VERSION")?;
     let sha = run_cmd(&["git", "rev-parse", "HEAD"])?;
-    let with_changes = if run_cmd(&["git", "diff", "--quiet"]).is_err() {
-        "-local_changes"
-    } else {
-        ""
-    };
-    println!("cargo:rustc-env=GIT_VERSION={}{}", sha, with_changes);
 
-    let version = read_file("../../../CURRENT_VERSION")?;
+    if include_sha {
+        version.push('-');
+        version.push_str(&sha);
+
+        // if we're a non-release buil, check to see if git has
+        // unstaged changes
+        if run_cmd(&["git", "diff", "--quiet"]).is_err() {
+            version.push('.');
+            version.push_str("localchanges");
+        }
+    }
+
+    println!("cargo:rustc-env=GIT_VERSION={}", sha);    
     println!("cargo:rustc-env=ONEFUZZ_VERSION={}", version);
-
+ 
     Ok(())
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    // If we're built off of a tag, we accept CURRENT_VERSION as is.  Otherwise
+    // modify it to indicate local build
+    if let Ok(val) = env::var("GITHUB_REF") {
+        if val.starts_with("refs/tags/") { 
+            print_version(false)
+        } else {
+            print_version(true)
+        }
+    } else {
+        print_version(true)
+    }
 }

--- a/src/agent/onefuzz-supervisor/build.rs
+++ b/src/agent/onefuzz-supervisor/build.rs
@@ -1,8 +1,8 @@
+use std::env;
 use std::error::Error;
 use std::fs::File;
 use std::io::prelude::*;
 use std::process::Command;
-use std::env;
 
 fn run_cmd(args: &[&str]) -> Result<String, Box<dyn Error>> {
     let cmd = Command::new(args[0]).args(&args[1..]).output()?;
@@ -38,9 +38,9 @@ fn print_version(include_sha: bool) -> Result<(), Box<dyn Error>> {
         }
     }
 
-    println!("cargo:rustc-env=GIT_VERSION={}", sha);    
+    println!("cargo:rustc-env=GIT_VERSION={}", sha);
     println!("cargo:rustc-env=ONEFUZZ_VERSION={}", version);
- 
+
     Ok(())
 }
 
@@ -48,7 +48,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     // If we're built off of a tag, we accept CURRENT_VERSION as is.  Otherwise
     // modify it to indicate local build
     if let Ok(val) = env::var("GITHUB_REF") {
-        if val.starts_with("refs/tags/") { 
+        if val.starts_with("refs/tags/") {
             print_version(false)
         } else {
             print_version(true)

--- a/src/agent/onefuzz-supervisor/build.rs
+++ b/src/agent/onefuzz-supervisor/build.rs
@@ -30,7 +30,7 @@ fn print_version(include_sha: bool) -> Result<(), Box<dyn Error>> {
         version.push('-');
         version.push_str(&sha);
 
-        // if we're a non-release buil, check to see if git has
+        // if we're a non-release build, check to see if git has
         // unstaged changes
         if run_cmd(&["git", "diff", "--quiet"]).is_err() {
             version.push('.');
@@ -47,13 +47,10 @@ fn print_version(include_sha: bool) -> Result<(), Box<dyn Error>> {
 fn main() -> Result<(), Box<dyn Error>> {
     // If we're built off of a tag, we accept CURRENT_VERSION as is.  Otherwise
     // modify it to indicate local build
-    if let Ok(val) = env::var("GITHUB_REF") {
-        if val.starts_with("refs/tags/") {
-            print_version(false)
-        } else {
-            print_version(true)
-        }
+    let include_sha = if let Ok(val) = env::var("GITHUB_REF") {
+        !val.starts_with("refs/tags/")
     } else {
-        print_version(true)
-    }
+        true
+    };
+    print_version(include_sha)
 }

--- a/src/agent/onefuzz-supervisor/build.rs
+++ b/src/agent/onefuzz-supervisor/build.rs
@@ -2,11 +2,12 @@ use std::error::Error;
 use std::fs::File;
 use std::io::prelude::*;
 use std::process::Command;
+use std::env;
 
 fn run_cmd(args: &[&str]) -> Result<String, Box<dyn Error>> {
     let cmd = Command::new(args[0]).args(&args[1..]).output()?;
     if cmd.status.success() {
-        Ok(String::from_utf8_lossy(&cmd.stdout).to_string())
+        Ok(String::from_utf8_lossy(&cmd.stdout).trim().to_string())
     } else {
         Err(From::from("failed"))
     }
@@ -16,21 +17,43 @@ fn read_file(filename: &str) -> Result<String, Box<dyn Error>> {
     let mut file = File::open(filename)?;
     let mut contents = String::new();
     file.read_to_string(&mut contents)?;
+    contents = contents.trim().to_string();
 
     Ok(contents)
 }
 
-fn main() -> Result<(), Box<dyn Error>> {
+fn print_version(include_sha: bool) -> Result<(), Box<dyn Error>> {
+    let mut version = read_file("../../../CURRENT_VERSION")?;
     let sha = run_cmd(&["git", "rev-parse", "HEAD"])?;
-    let with_changes = if run_cmd(&["git", "diff", "--quiet"]).is_err() {
-        "-local_changes"
-    } else {
-        ""
-    };
-    println!("cargo:rustc-env=GIT_VERSION={}{}", sha, with_changes);
 
-    let version = read_file("../../../CURRENT_VERSION")?;
+    if include_sha {
+        version.push('-');
+        version.push_str(&sha);
+
+        // if we're a non-release buil, check to see if git has
+        // unstaged changes
+        if run_cmd(&["git", "diff", "--quiet"]).is_err() {
+            version.push('.');
+            version.push_str("localchanges");
+        }
+    }
+
+    println!("cargo:rustc-env=GIT_VERSION={}", sha);    
     println!("cargo:rustc-env=ONEFUZZ_VERSION={}", version);
-
+ 
     Ok(())
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    // If we're built off of a tag, we accept CURRENT_VERSION as is.  Otherwise
+    // modify it to indicate local build
+    if let Ok(val) = env::var("GITHUB_REF") {
+        if val.starts_with("refs/tags/") { 
+            print_version(false)
+        } else {
+            print_version(true)
+        }
+    } else {
+        print_version(true)
+    }
 }

--- a/src/api-service/dev-deploy.sh
+++ b/src/api-service/dev-deploy.sh
@@ -14,12 +14,32 @@ fi
 set -ex
 
 TARGET=${1}
-cd ${APP_DIR}
-(cd ../pytypes && python setup.py sdist bdist_wheel && cp dist/*.whl ../api-service/__app__)
-cd __app__
+pushd ${APP_DIR}
+VERSION=$(../ci/get-version.sh)
+../ci/set-versions.sh
+
+# clean up any previously built onefuzztypes packages
+rm __app__/onefuzztypes*.whl
+
+# build a local copy of onefuzztypes
+rm -rf local-pytypes
+cp -r ../pytypes local-pytypes
+pushd local-pytypes
+rm -f dist/*
+python setup.py sdist bdist_wheel
+cp dist/*.whl ../__app__
+popd
+rm -r local-pytypes
+
+# deploy a the instance with the locally built onefuzztypes
+pushd __app__
 uuidgen > onefuzzlib/build.id
-sed -i s,onefuzztypes==0.0.0,./onefuzztypes-0.0.0-py3-none-any.whl, requirements.txt
+TYPELIB=$(ls onefuzztypes*.whl)
+sed -i s,.*onefuzztypes.*,./${TYPELIB}, requirements.txt
 func azure functionapp publish ${TARGET} --python
-sed -i s,./onefuzztypes-0.0.0-py3-none-any.whl,onefuzztypes==0.0.0, requirements.txt
-rm 'onefuzztypes-0.0.0-py3-none-any.whl'
-cat onefuzzlib/build.id
+sed -i s,./onefuzztypes.*,onefuzztypes==0.0.0, requirements.txt
+rm onefuzztypes*.whl
+popd
+
+../ci/unset-versions.sh
+cat __app__/onefuzzlib/build.id

--- a/src/ci/get-version.sh
+++ b/src/ci/get-version.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+set -e
+
+SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
+BASE_VERSION=$(cat ${SCRIPT_DIR}/../../CURRENT_VERSION)
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+GIT_HASH=$(git rev-parse HEAD)
+
+if [ '${CI}' == 'true' ]; then
+    TAG_VERSION=${GITHUB_REF#refs/tags/}
+    
+    # this isn't a tag
+    if [ ${TAG_VERSION} == ${GITHUB_REF} ]; then
+        echo ${BASE_VERSION}-${GIT_HASH}
+    else
+        echo ${BASE_VERSION}
+    fi    
+else
+    if $(git diff --quiet); then
+        echo ${BASE_VERSION}-${GIT_HASH}
+    else
+        echo ${BASE_VERSION}-${GIT_HASH}.localchanges
+    fi 
+fi

--- a/src/ci/get-version.sh
+++ b/src/ci/get-version.sh
@@ -10,7 +10,7 @@ BASE_VERSION=$(cat ${SCRIPT_DIR}/../../CURRENT_VERSION)
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
 GIT_HASH=$(git rev-parse HEAD)
 
-if [ '${CI}' == 'true' ]; then
+if [ "${GITHUB_REF}" != "" ]; then
     TAG_VERSION=${GITHUB_REF#refs/tags/}
     
     # this isn't a tag

--- a/src/ci/unset-versions.sh
+++ b/src/ci/unset-versions.sh
@@ -13,5 +13,5 @@ cd ${SCRIPT_DIR}/../../
 SET_VERSIONS="src/pytypes/onefuzztypes/__version__.py src/api-service/__app__/onefuzzlib/__version__.py src/cli/onefuzz/__version__.py"
 SET_REQS="src/cli/requirements.txt src/api-service/__app__/requirements.txt"
 
-sed -i "s/0.0.0/${VERSION}/" ${SET_VERSIONS}
-sed -i "s/onefuzztypes==0.0.0/onefuzztypes==${VERSION}/" ${SET_REQS}
+sed -i 's/__version__ = .*/__version__ = "0.0.0"/' ${SET_VERSIONS}
+sed -i "s/onefuzztypes==.*/onefuzztypes==0.0.0/" ${SET_REQS}

--- a/src/proxy-manager/build.rs
+++ b/src/proxy-manager/build.rs
@@ -1,8 +1,8 @@
+use std::env;
 use std::error::Error;
 use std::fs::File;
 use std::io::prelude::*;
 use std::process::Command;
-use std::env;
 
 fn run_cmd(args: &[&str]) -> Result<String, Box<dyn Error>> {
     let cmd = Command::new(args[0]).args(&args[1..]).output()?;
@@ -38,9 +38,9 @@ fn print_version(include_sha: bool) -> Result<(), Box<dyn Error>> {
         }
     }
 
-    println!("cargo:rustc-env=GIT_VERSION={}", sha);    
+    println!("cargo:rustc-env=GIT_VERSION={}", sha);
     println!("cargo:rustc-env=ONEFUZZ_VERSION={}", version);
- 
+
     Ok(())
 }
 
@@ -48,7 +48,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     // If we're built off of a tag, we accept CURRENT_VERSION as is.  Otherwise
     // modify it to indicate local build
     if let Ok(val) = env::var("GITHUB_REF") {
-        if val.starts_with("refs/tags/") { 
+        if val.starts_with("refs/tags/") {
             print_version(false)
         } else {
             print_version(true)

--- a/src/proxy-manager/build.rs
+++ b/src/proxy-manager/build.rs
@@ -30,7 +30,7 @@ fn print_version(include_sha: bool) -> Result<(), Box<dyn Error>> {
         version.push('-');
         version.push_str(&sha);
 
-        // if we're a non-release buil, check to see if git has
+        // if we're a non-release build, check to see if git has
         // unstaged changes
         if run_cmd(&["git", "diff", "--quiet"]).is_err() {
             version.push('.');
@@ -47,13 +47,10 @@ fn print_version(include_sha: bool) -> Result<(), Box<dyn Error>> {
 fn main() -> Result<(), Box<dyn Error>> {
     // If we're built off of a tag, we accept CURRENT_VERSION as is.  Otherwise
     // modify it to indicate local build
-    if let Ok(val) = env::var("GITHUB_REF") {
-        if val.starts_with("refs/tags/") {
-            print_version(false)
-        } else {
-            print_version(true)
-        }
+    let include_sha = if let Ok(val) = env::var("GITHUB_REF") {
+        !val.starts_with("refs/tags/")
     } else {
-        print_version(true)
-    }
+        true
+    };
+    print_version(include_sha)
 }

--- a/src/proxy-manager/build.rs
+++ b/src/proxy-manager/build.rs
@@ -2,11 +2,12 @@ use std::error::Error;
 use std::fs::File;
 use std::io::prelude::*;
 use std::process::Command;
+use std::env;
 
 fn run_cmd(args: &[&str]) -> Result<String, Box<dyn Error>> {
     let cmd = Command::new(args[0]).args(&args[1..]).output()?;
     if cmd.status.success() {
-        Ok(String::from_utf8_lossy(&cmd.stdout).to_string())
+        Ok(String::from_utf8_lossy(&cmd.stdout).trim().to_string())
     } else {
         Err(From::from("failed"))
     }
@@ -16,21 +17,43 @@ fn read_file(filename: &str) -> Result<String, Box<dyn Error>> {
     let mut file = File::open(filename)?;
     let mut contents = String::new();
     file.read_to_string(&mut contents)?;
+    contents = contents.trim().to_string();
 
     Ok(contents)
 }
 
-fn main() -> Result<(), Box<dyn Error>> {
+fn print_version(include_sha: bool) -> Result<(), Box<dyn Error>> {
+    let mut version = read_file("../../CURRENT_VERSION")?;
     let sha = run_cmd(&["git", "rev-parse", "HEAD"])?;
-    let with_changes = if run_cmd(&["git", "diff", "--quiet"]).is_err() {
-        "-local_changes"
-    } else {
-        ""
-    };
-    println!("cargo:rustc-env=GIT_VERSION={}{}", sha, with_changes);
 
-    let version = read_file("../../CURRENT_VERSION")?;
+    if include_sha {
+        version.push('-');
+        version.push_str(&sha);
+
+        // if we're a non-release buil, check to see if git has
+        // unstaged changes
+        if run_cmd(&["git", "diff", "--quiet"]).is_err() {
+            version.push('.');
+            version.push_str("localchanges");
+        }
+    }
+
+    println!("cargo:rustc-env=GIT_VERSION={}", sha);    
     println!("cargo:rustc-env=ONEFUZZ_VERSION={}", version);
-
+ 
     Ok(())
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    // If we're built off of a tag, we accept CURRENT_VERSION as is.  Otherwise
+    // modify it to indicate local build
+    if let Ok(val) = env::var("GITHUB_REF") {
+        if val.starts_with("refs/tags/") { 
+            print_version(false)
+        } else {
+            print_version(true)
+        }
+    } else {
+        print_version(true)
+    }
 }


### PR DESCRIPTION
## Summary of the Pull Request

Unless Onefuzz is built in Github from a 'refs/tags', append the SHA and potentially .localchanges to the version string.

This provides an easy marker for identifying if the system has local changes included or not.

## Info on Pull Request

* Updates the each of the `build.rs` to to check GITHUB_REF and `git diff --quiet` to identify local changes
* Adds a util to reset setting versions (reset-versions.sh)
* Adds a util to get the version string without setting it (get-version.sh)
* Updates the service API deploy-dev.sh to package onefuzztypes & the api with the stamped in build strings

## Validation Steps Performed

Manual inspection of built artifacts.  Locally built should be:
* 1.0.0-HASH or 1.0.0-HASH.localchanges in the case of modifying code locally without checking it in.
* CI builds should be 1.0.0-HASH
* Tag builds should be 1.0.0