### PR TITLE
Remove use of `batch` in NodeMessages

### DIFF
--- a/src/api-service/__app__/agent_commands/__init__.py
+++ b/src/api-service/__app__/agent_commands/__init__.py
@@ -35,7 +35,9 @@ def delete(req: func.HttpRequest) -> func.HttpResponse:
     if isinstance(request, Error):
         return not_ok(request, context="NodeCommandDelete")
 
-    NodeMessage.delete_messages(request.machine_id, [request.message_id])
+    message = NodeMessage.get(request.machine_id, request.message_id)
+    if message:
+        message.delete()
     return ok(BoolResult(result=True))
 
 

--- a/src/api-service/__app__/onefuzzlib/pools.py
+++ b/src/api-service/__app__/onefuzzlib/pools.py
@@ -40,7 +40,6 @@ from .azure.creds import get_fuzz_storage
 from .azure.image import get_os
 from .azure.network import Network
 from .azure.queue import create_queue, delete_queue, peek_queue, queue_object
-from .azure.table import get_client
 from .azure.vmss import (
     UnableToUpdate,
     create_vmss,
@@ -232,17 +231,10 @@ class NodeMessage(ORMMixin):
         return entries
 
     @classmethod
-    def delete_messages(cls, agent_id: UUID, message_ids: List[str]) -> None:
-        client = get_client(table=cls.table_name())
-        with client.batch(table_name=cls.table_name()) as batch:
-            for message_id in message_ids:
-                batch.delete_entity(agent_id, message_id)
-
-    @classmethod
     def clear_messages(cls, agent_id: UUID) -> None:
         messages = cls.get_messages(agent_id)
-        message_ids = [m.message_id for m in messages]
-        cls.delete_messages(agent_id, message_ids)
+        for message in messages:
+            message.delete()
 
 
 class Pool(BASE_POOL, ORMMixin):

--- a/src/api-service/__app__/onefuzzlib/pools.py
+++ b/src/api-service/__app__/onefuzzlib/pools.py
@@ -234,12 +234,9 @@ class NodeMessage(ORMMixin):
     @classmethod
     def delete_messages(cls, agent_id: UUID, message_ids: List[str]) -> None:
         client = get_client(table=cls.table_name())
-        batch = client.batch(table_name=cls.table_name())
-
-        for message_id in message_ids:
-            batch.delete_entity(agent_id, message_id)
-
-        client.commit_batch(cls.table_name(), batch)
+        with client.batch(table_name=cls.table_name()) as batch:
+            for message_id in message_ids:
+                batch.delete_entity(agent_id, message_id)
 
     @classmethod
     def clear_messages(cls, agent_id: UUID) -> None:

--- a/src/api-service/dev-deploy.sh
+++ b/src/api-service/dev-deploy.sh
@@ -19,7 +19,7 @@ VERSION=$(../ci/get-version.sh)
 ../ci/set-versions.sh
 
 # clean up any previously built onefuzztypes packages
-rm __app__/onefuzztypes*.whl
+rm -f __app__/onefuzztypes*.whl
 
 # build a local copy of onefuzztypes
 rm -rf local-pytypes
@@ -38,7 +38,7 @@ TYPELIB=$(ls onefuzztypes*.whl)
 sed -i s,.*onefuzztypes.*,./${TYPELIB}, requirements.txt
 func azure functionapp publish ${TARGET} --python
 sed -i s,./onefuzztypes.*,onefuzztypes==0.0.0, requirements.txt
-rm onefuzztypes*.whl
+rm -f onefuzztypes*.whl
 popd
 
 ../ci/unset-versions.sh


### PR DESCRIPTION
## Summary of the Pull Request

Fixes `NodeMessage.delete_messages` incorrectly using `batch`.

## Info on Pull Request

Updates the call to batch to use it like a context manager, per [TableService docs](https://docs.microsoft.com/en-us/python/api/azure-cosmosdb-table/azure.cosmosdb.table.tableservice.TableService?view=azure-python#batch-table-name--timeout-none-)

In addition, the ORM layer auto-maps contextual types, like UUIDs to strs for primary & row keys.  Until we add 'batch' to ORM.py, we should just iterate over the items directly.

## Validation Steps Performed

In the post 1.0.0 builds, nodes should no longer generate the following exception as they connect in:

`Exception: AttributeError: '_GeneratorContextManager' object has no attribute 'delete_entity'`