### PR TITLE
Set log levels in Azure Functions by hand for 3rd party libraries

### DIFF
--- a/src/api-service/__app__/onefuzzlib/azure/creds.py
+++ b/src/api-service/__app__/onefuzzlib/azure/creds.py
@@ -19,7 +19,7 @@ from memoization import cached
 from msrestazure.azure_active_directory import MSIAuthentication
 from msrestazure.tools import parse_resource_id
 
-from .monkeypatch import allow_more_workers
+from .monkeypatch import allow_more_workers, reduce_logging
 
 
 @cached(ttl=60)
@@ -30,6 +30,7 @@ def get_msi() -> MSIAuthentication:
 @cached(ttl=60)
 def mgmt_client_factory(client_class: Any) -> Any:
     allow_more_workers()
+    reduce_logging()
     try:
         return get_client_from_cli_profile(client_class)
     except CLIError:

--- a/src/api-service/__app__/onefuzzlib/azure/monkeypatch.py
+++ b/src/api-service/__app__/onefuzzlib/azure/monkeypatch.py
@@ -52,3 +52,5 @@ def reduce_logging() -> None:
         for prefix in to_quiet:
             if logger.name.startswith(prefix):
                 logger.level = logging.WARN
+
+    REDUCE_LOGGING = True


### PR DESCRIPTION
## Summary of the Pull Request

Reduces the log levels to `WARN` for multiple third-party libraries early in processing.

## Info on Pull Request

There doesn't appear to be a supported mechanism to reset logging levels on a per logger method for Azure Functions.  As such, this makes sets the log level for the most verbose of the 3rd party libraries we use.

Hopefully, the python Azure Functions runtime will provide a better mechanism to reduce these log levels in the future.

https://github.com/Azure/azure-functions-python-worker/issues/743

## Validation Steps Performed

Install, note we don't see all of the INFO logging from APIs like msrest in app insights.