### PR TITLE
Always use logging.warning in python

### DIFF
--- a/src/api-service/__app__/onefuzzlib/tasks/main.py
+++ b/src/api-service/__app__/onefuzzlib/tasks/main.py
@@ -181,7 +181,7 @@ class Task(BASE_TASK, ORMMixin):
                 else:
                     return pool
 
-        logging.warn(
+        logging.warning(
             "unable to find a scaleset that matches the task prereqs: %s",
             self.task_id,
         )

--- a/src/cli/examples/integration-test.py
+++ b/src/cli/examples/integration-test.py
@@ -442,7 +442,7 @@ class TestOnefuzz:
         """ stop a specific template """
 
         if self.skip_cleanup:
-            self.logger.warn("not cleaning up target: %s", target)
+            self.logger.warning("not cleaning up target: %s", target)
         else:
             self.of.template.stop(
                 self.project,
@@ -456,7 +456,7 @@ class TestOnefuzz:
         """ cleanup all of the integration pools & jobs """
 
         if self.skip_cleanup:
-            self.logger.warn("not cleaning up")
+            self.logger.warning("not cleaning up")
             return True
 
         self.logger.info("cleaning up")
@@ -527,7 +527,7 @@ class Run(Command):
             tester.launch(samples)
             tester.check_jobs()
             if skip_repro:
-                self.logger.warn("not testing crash repro")
+                self.logger.warning("not testing crash repro")
             else:
                 tester.launch_repro()
                 tester.check_repro()

--- a/src/cli/onefuzz/api.py
+++ b/src/cli/onefuzz/api.py
@@ -201,7 +201,7 @@ class Versions(Endpoint):
                 and api.patch >= cli.patch
             )
             if cli_str == "0.0.0" and not result:
-                self.logger.warn(
+                self.logger.warning(
                     "ignoring compatibility check as the CLI was installed "
                     "from git.  api: %s cli: %s",
                     api_str,


### PR DESCRIPTION
Fixes `DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead`