### PR TITLE
mark task as failued if ADO notification fails

### DIFF
--- a/src/pytypes/onefuzztypes/enums.py
+++ b/src/pytypes/onefuzztypes/enums.py
@@ -227,6 +227,7 @@ class ErrorCode(Enum):
     UNABLE_TO_FIND = 467
     TASK_FAILED = 468
     INVALID_NODE = 469
+    NOTIFICATION_FAILURE = 470
 
 
 class HeartbeatType(Enum):


### PR DESCRIPTION
## Summary of the Pull Request

When notifications related to a report fail, the task that generated the report should be marked as failed

## PR Checklist
* [x] Applies to work item: #75 

## Info on Pull Request

This traps on the python Exceptions related to configuration errors in ADO notifications and marks the task that generated the report as failed.

## Validation Steps Performed

Use an invalid ADO notification config (such as invalid username for assign to), generate a report (such as via `onefuzz debug notification job`) and observe that the crash reporting job is marked as failed.