### PR TITLE
fixing input marker expansion in the supervisor task

### DIFF
--- a/src/agent/onefuzz-agent/src/tasks/analysis/generic.rs
+++ b/src/agent/onefuzz-agent/src/tasks/analysis/generic.rs
@@ -120,7 +120,7 @@ pub async fn run_tool(input: impl AsRef<Path>, config: &Config) -> Result<()> {
     let mut tool_args = Expand::new();
 
     tool_args
-        .input(&input)
+        .input_path(&input)
         .target_exe(&config.target_exe)
         .target_options(&config.target_options)
         .analyzer_exe(&config.analyzer_exe)

--- a/src/agent/onefuzz-agent/src/tasks/fuzz/supervisor.rs
+++ b/src/agent/onefuzz-agent/src/tasks/fuzz/supervisor.rs
@@ -192,7 +192,7 @@ async fn start_supervisor(
         .input_corpus(inputs_dir);
 
     if let Some(input_marker) = supervisor_input_marker {
-        expand.input(input_marker);
+        expand.input_marker(input_marker);
     }
 
     let args = expand.evaluate(supervisor_options)?;

--- a/src/agent/onefuzz-agent/src/tasks/merge/generic.rs
+++ b/src/agent/onefuzz-agent/src/tasks/merge/generic.rs
@@ -132,7 +132,7 @@ async fn merge(config: &Config, output_dir: impl AsRef<Path>) -> Result<()> {
     let mut supervisor_args = Expand::new();
 
     supervisor_args
-        .input(&config.supervisor_input_marker)
+        .input_marker(&config.supervisor_input_marker)
         .input_corpus(&config.unique_inputs.path)
         .target_options(&config.target_options)
         .supervisor_exe(&config.supervisor_exe)

--- a/src/agent/onefuzz/src/expand.rs
+++ b/src/agent/onefuzz/src/expand.rs
@@ -316,7 +316,7 @@ mod tests {
             .input_corpus(Path::new(input_corpus_dir))
             .generated_inputs(Path::new(generated_inputs_dir))
             .target_options(&my_options)
-            .input(input_path)
+            .input_path(input_path)
             .evaluate(&my_args)?;
 
         let input_corpus_path = dunce::canonicalize(input_corpus_dir)?;

--- a/src/agent/onefuzz/src/expand.rs
+++ b/src/agent/onefuzz/src/expand.rs
@@ -127,10 +127,15 @@ impl<'a> Expand<'a> {
         self
     }
 
-    pub fn input(&mut self, arg: impl AsRef<Path>) -> &mut Self {
+    pub fn input_path(&mut self, arg: impl AsRef<Path>) -> &mut Self {
         let arg = arg.as_ref();
         let path = String::from(arg.to_string_lossy());
         self.set_value(PlaceHolder::Input, ExpandedValue::Path(path));
+        self
+    }
+
+    pub fn input_marker(&mut self, arg: &str) -> &mut Self {
+        self.set_value(PlaceHolder::Input, ExpandedValue::Scalar(String::from(arg)));
         self
     }
 

--- a/src/agent/onefuzz/src/input_tester.rs
+++ b/src/agent/onefuzz/src/input_tester.rs
@@ -186,7 +186,7 @@ impl<'a> Tester<'a> {
         let (argv, env) = {
             let mut expand = Expand::new();
             expand
-                .input(input_file)
+                .input_path(input_file)
                 .target_exe(&self.exe_path)
                 .target_options(&self.arguments);
 


### PR DESCRIPTION
input marker was set as a path instead of a string value

## Summary of the Pull Request

_What is this about?_

## PR Checklist
* [x] Tests added/passed
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_

## Validation Steps Performed

_How does someone test & validate?_
