### PR TITLE
Scaleset size update

### DIFF
--- a/src/api-service/__app__/agent_registration/__init__.py
+++ b/src/api-service/__app__/agent_registration/__init__.py
@@ -3,6 +3,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+import logging
 from uuid import UUID
 
 import azure.functions as func
@@ -14,7 +15,7 @@ from onefuzztypes.responses import AgentRegistration
 from ..onefuzzlib.agent_authorization import verify_token
 from ..onefuzzlib.azure.creds import get_fuzz_storage, get_instance_name
 from ..onefuzzlib.azure.queue import get_queue_sas
-from ..onefuzzlib.pools import Node, NodeMessage, Pool
+from ..onefuzzlib.pools import Node, NodeMessage, Pool, Scaleset
 from ..onefuzzlib.request import not_ok, ok, parse_uri
 
 
@@ -76,8 +77,10 @@ def get(req: func.HttpRequest) -> func.HttpResponse:
 
 def post(req: func.HttpRequest) -> func.HttpResponse:
     registration_request = parse_uri(AgentRegistrationPost, req)
+    logging.info(f"request: {registration_request}")
     if isinstance(registration_request, Error):
         return not_ok(registration_request, context="agent registration")
+
     agent_node = Node.get_by_machine_id(registration_request.machine_id)
 
     pool = Pool.get_by_name(registration_request.pool_name)
@@ -95,9 +98,16 @@ def post(req: func.HttpRequest) -> func.HttpResponse:
             pool_name=registration_request.pool_name,
             machine_id=registration_request.machine_id,
             scaleset_id=registration_request.scaleset_id,
-            version=registration_request.version
+            version=registration_request.version,
         )
         agent_node.save()
+        node_count = len(
+            Node.search_states(scaleset_id=registration_request.scaleset_id)
+        )
+        scaleset = Scaleset.get_by_id(registration_request.scaleset_id)
+        if node_count > scaleset.size:
+            scaleset.size += 1
+            scaleset.save()
     elif agent_node.version.lower != registration_request.version:
         NodeMessage.clear_messages(agent_node.machine_id)
         agent_node.version = registration_request.version

--- a/src/api-service/__app__/agent_registration/__init__.py
+++ b/src/api-service/__app__/agent_registration/__init__.py
@@ -101,10 +101,22 @@ def post(req: func.HttpRequest) -> func.HttpResponse:
             version=registration_request.version,
         )
         agent_node.save()
+
+        scaleset = Scaleset.get_by_id(scaleset_id=registration_request.scaleset_id)
+        if isinstance(scaleset, Error):
+            return not_ok(
+                Error(
+                    code=ErrorCode.INVALID_REQUEST,
+                    errors=[
+                        "unable to find scaleset '%s'"
+                        % registration_request.scaleset_id
+                    ],
+                ),
+                context="agent registration",
+            )
         node_count = len(
             Node.search_states(scaleset_id=registration_request.scaleset_id)
         )
-        scaleset = Scaleset.get_by_id(registration_request.scaleset_id)
         if node_count > scaleset.size:
             scaleset.size += 1
             scaleset.save()


### PR DESCRIPTION
## Summary of the Pull Request
Size is not increased for the scaleset when it is resized, thus leaving it in a hanging state of resize when scaling up.

_What is this about?_
The condition mentioned at https://github.com/microsoft/onefuzz/blob/3b3572d0b364df0bc9e354804b92f45672259e3e/src/api-service/__app__/onefuzzlib/pools.py#L684:L690

```
logging.info(
                    "resize is finished, waiting for nodes to check in: "
                    "%s (%d of %d nodes checked in)",
                    self.scaleset_id,
                    node_count,
                    self.size,
                )
```

is never fulfilled when I am trying out server side self-scaling especially when I have to scale up. I cannot see the scaleset size increasing when a new node is registered. This condition will add only if number of nodes get greater than scaleset size specified.

## PR Checklist
* [ ] Applies to work item: #xxx
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/onefuzz) and sign the CLI.
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_

## Validation Steps Performed
Also added logging steps, which were helpful in my debugging. let me know if it is not needed.

_How does someone test & validate?_
Tested manually with pool scaling work.