### PR TITLE
fix bug stopping templates

### DIFF
--- a/src/cli/onefuzz/template.py
+++ b/src/cli/onefuzz/template.py
@@ -54,6 +54,9 @@ class Template(Command):
         containers = [x.name for x in self.onefuzz.containers.list()]
         jobs = self.onefuzz.jobs.list()
         for job in jobs:
+            if job.config.project != project:
+                continue
+
             if job.config.name != name:
                 continue
 


### PR DESCRIPTION
In 'onefuzz template stop', the project was ignored, causing jobs that had the same 'name', and build if provided, to stop.