### PR TITLE
add '--endpoint' to 'repro_cmd' for integrations

### DIFF
--- a/src/api-service/__app__/agent_registration/__init__.py
+++ b/src/api-service/__app__/agent_registration/__init__.py
@@ -12,14 +12,14 @@ from onefuzztypes.requests import AgentRegistrationGet, AgentRegistrationPost
 from onefuzztypes.responses import AgentRegistration
 
 from ..onefuzzlib.agent_authorization import verify_token
-from ..onefuzzlib.azure.creds import get_fuzz_storage, get_instance_name
+from ..onefuzzlib.azure.creds import get_fuzz_storage, get_instance_url
 from ..onefuzzlib.azure.queue import get_queue_sas
 from ..onefuzzlib.pools import Node, NodeMessage, Pool
 from ..onefuzzlib.request import not_ok, ok, parse_uri
 
 
 def create_registration_response(machine_id: UUID, pool: Pool) -> func.HttpResponse:
-    base_address = "https://%s.azurewebsites.net" % get_instance_name()
+    base_address = get_instance_url()
     events_url = "%s/api/agents/events" % base_address
     commands_url = "%s/api/agents/commands" % base_address
     work_queue = get_queue_sas(

--- a/src/api-service/__app__/onefuzzlib/azure/creds.py
+++ b/src/api-service/__app__/onefuzzlib/azure/creds.py
@@ -96,6 +96,11 @@ def get_instance_name() -> str:
     return os.environ["ONEFUZZ_INSTANCE_NAME"]
 
 
+@cached
+def get_instance_url() -> str:
+    return "https://%s.azurewebsites.net" % get_instance_name()
+
+
 @cached(ttl=60)
 def get_regions() -> List[str]:
     client = mgmt_client_factory(SubscriptionClient)

--- a/src/api-service/__app__/onefuzzlib/extension.py
+++ b/src/api-service/__app__/onefuzzlib/extension.py
@@ -12,7 +12,7 @@ from onefuzztypes.models import AgentConfig, ReproConfig
 from onefuzztypes.primitives import Extension, Region
 
 from .azure.containers import get_container_sas_url, get_file_sas_url, save_blob
-from .azure.creds import get_func_storage, get_instance_name
+from .azure.creds import get_func_storage, get_instance_url
 from .azure.monitor import get_monitor_settings
 from .reports import get_report
 
@@ -91,7 +91,7 @@ def dependency_extension(region: Region, os: OS) -> Optional[Extension]:
 def build_pool_config(pool_name: str) -> str:
     agent_config = AgentConfig(
         pool_name=pool_name,
-        onefuzz_url="https://%s.azurewebsites.net" % get_instance_name(),
+        onefuzz_url=get_instance_url(),
         instrumentation_key=os.environ.get("APPINSIGHTS_INSTRUMENTATIONKEY"),
         telemetry_key=os.environ.get("ONEFUZZ_TELEMETRY"),
     )

--- a/src/api-service/__app__/onefuzzlib/notifications/common.py
+++ b/src/api-service/__app__/onefuzzlib/notifications/common.py
@@ -8,8 +8,8 @@ from typing import Optional
 from jinja2.sandbox import SandboxedEnvironment
 from onefuzztypes.models import Report
 
-from ..azure.creds import get_instance_url
 from ..azure.containers import auth_download_url
+from ..azure.creds import get_instance_url
 from ..jobs import Job
 from ..tasks.config import get_setup_container
 from ..tasks.main import Task

--- a/src/api-service/__app__/onefuzzlib/notifications/common.py
+++ b/src/api-service/__app__/onefuzzlib/notifications/common.py
@@ -8,6 +8,7 @@ from typing import Optional
 from jinja2.sandbox import SandboxedEnvironment
 from onefuzztypes.models import Report
 
+from ..azure.creds import get_instance_url
 from ..azure.containers import auth_download_url
 from ..jobs import Job
 from ..tasks.config import get_setup_container
@@ -55,7 +56,7 @@ class Render:
                 "target_url": self.target_url,
                 "report_container": self.container,
                 "report_filename": self.filename,
-                "repro_cmd": "onefuzz repro create_and_connect %s %s"
-                % (self.container, self.filename),
+                "repro_cmd": "onefuzz --endpoint %s repro create_and_connect %s %s"
+                % (get_instance_url(), self.container, self.filename),
             }
         )

--- a/src/api-service/__app__/onefuzzlib/tasks/config.py
+++ b/src/api-service/__app__/onefuzzlib/tasks/config.py
@@ -12,7 +12,7 @@ from onefuzztypes.enums import Compare, ContainerPermission, ContainerType, Task
 from onefuzztypes.models import TaskConfig, TaskDefinition, TaskUnitConfig
 
 from ..azure.containers import blob_exists, get_container_sas_url, get_containers
-from ..azure.creds import get_fuzz_storage, get_instance_name
+from ..azure.creds import get_fuzz_storage, get_instance_url
 from ..azure.queue import get_queue_sas
 from .defs import TASK_DEFINITIONS
 
@@ -184,8 +184,7 @@ def build_task_config(
             account_id=os.environ["ONEFUZZ_FUNC_STORAGE"],
             add=True,
         ),
-        back_channel_address="https://%s.azurewebsites.net/api/back_channel"
-        % (get_instance_name()),
+        back_channel_address="https://%s/api/back_channel" % (get_instance_url()),
     )
 
     if definition.monitor_queue:

--- a/src/api-service/__app__/pool/__init__.py
+++ b/src/api-service/__app__/pool/__init__.py
@@ -10,7 +10,7 @@ from onefuzztypes.enums import ErrorCode, PoolState
 from onefuzztypes.models import AgentConfig, Error
 from onefuzztypes.requests import PoolCreate, PoolSearch, PoolStop
 
-from ..onefuzzlib.azure.creds import get_instance_name
+from ..onefuzzlib.azure.creds import get_instance_url
 from ..onefuzzlib.pools import Pool
 from ..onefuzzlib.request import not_ok, ok, parse_request
 
@@ -18,7 +18,7 @@ from ..onefuzzlib.request import not_ok, ok, parse_request
 def set_config(pool: Pool) -> Pool:
     pool.config = AgentConfig(
         pool_name=pool.name,
-        onefuzz_url="https://%s.azurewebsites.net" % get_instance_name(),
+        onefuzz_url=get_instance_url(),
         instrumentation_key=os.environ.get("APPINSIGHTS_INSTRUMENTATIONKEY"),
         telemetry_key=os.environ.get("ONEFUZZ_TELEMETRY"),
     )


### PR DESCRIPTION
## Summary of the Pull Request

Updates crash report notifications `repro_cmd` to go from:

`onefuzz repro create_and_connect container file`

to:
`onefuzz --endpoint https://INSTANCE.azurewebsites.net repro create_and_connect container file`

This is extremely valuable to help users that support multiple OneFuzz instances.

## PR Checklist
* [ ] Applies to work item
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/onefuzz) and sign the CLI.
* [X] Tests added/passed
* [ ] Requires documentation to be updated
* [X] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

In addition to the aforementioned change to notifications, updates everywhere that was building the URL to the instance to use the new helper method
 
## Validation Steps Performed

1. Create a crash reporting task
2. Create a notification that uses `{{ repro_cmd }}`
3. Create a crash report for said task.
4. Note the repro_cmd is updated to include --endpoint for the instance.