### PR TITLE
Filter agent app-insights logs based on log::max_level

### DIFF
--- a/src/agent/onefuzz-agent/src/tasks/fuzz/supervisor.rs
+++ b/src/agent/onefuzz-agent/src/tasks/fuzz/supervisor.rs
@@ -9,7 +9,6 @@ use crate::tasks::{
     utils::{self, CheckNotify},
 };
 use anyhow::{Error, Result};
-use appinsights::telemetry::SeverityLevel;
 use onefuzz::{
     expand::Expand,
     fs::{has_files, set_executable, OwnedDir},

--- a/src/agent/onefuzz/src/telemetry.rs
+++ b/src/agent/onefuzz/src/telemetry.rs
@@ -341,25 +341,26 @@ macro_rules! event {
 #[macro_export]
 macro_rules! log {
     ($level: expr, $msg: expr) => {{
-        use appinsights::telemetry::SeverityLevel;
-        use SeverityLevel::*;
+        use appinsights::telemetry::SeverityLevel::{
+            Critical, Error, Information, Verbose, Warning,
+        };
 
-        {
-            let log_level = match $level {
-                SeverityLevel::Verbose => log::Level::Debug,
-                SeverityLevel::Information => log::Level::Info,
-                SeverityLevel::Warning => log::Level::Warn,
-                SeverityLevel::Error => log::Level::Error,
-                SeverityLevel::Critical => log::Level::Error,
-            };
+        let log_level = match $level {
+            Verbose => log::Level::Debug,
+            Information => log::Level::Info,
+            Warning => log::Level::Warn,
+            Error => log::Level::Error,
+            Critical => log::Level::Error,
+        };
 
-            let log_msg = $msg.to_string();
+        let log_msg = $msg.to_string();
 
-            log::log!(log_level, "{}", log_msg)
-        }
-
-        if let Some(client) = $crate::telemetry::client($crate::telemetry::ClientType::Instance) {
-            client.track_trace($msg, $level);
+        log::log!(log_level, "{}", log_msg);
+        if log_level <= log::max_level() {
+            if let Some(client) = $crate::telemetry::client($crate::telemetry::ClientType::Instance)
+            {
+                client.track_trace($msg, $level);
+            }
         }
     }};
 }

--- a/src/agent/onefuzz/src/telemetry.rs
+++ b/src/agent/onefuzz/src/telemetry.rs
@@ -353,10 +353,10 @@ macro_rules! log {
             Critical => log::Level::Error,
         };
 
-        let log_msg = $msg.to_string();
-
-        log::log!(log_level, "{}", log_msg);
+        // while log::log will filter based on log level, the telemetry
+        // client does *not*.
         if log_level <= log::max_level() {
+            log::log!(log_level, "{}", $msg.to_string());
             if let Some(client) = $crate::telemetry::client($crate::telemetry::ClientType::Instance)
             {
                 client.track_trace($msg, $level);

--- a/src/runtime-tools/win64/onefuzz.ps1
+++ b/src/runtime-tools/win64/onefuzz.ps1
@@ -5,6 +5,7 @@ $env:Path += ";C:\Program Files (x86)\Windows Kits\10\Debuggers\x64\;C:\onefuzz\
 $env:ONEFUZZ_ROOT = "C:\onefuzz"
 $env:ONEFUZZ_TOOLS = "C:\onefuzz\tools"
 $env:ASAN_SYMBOLIZER_PATH = "llvm-symbolizer"
+$env:RUST_LOG = "info"
 
 $logFile = "C:\onefuzz.log"
 function log ($message) {


### PR DESCRIPTION
## Summary of the Pull Request

As is, we send all levels of logging from the agent to app-insights, which is too verbose.  This aligns app-insights with log levels. 

On linux, this was previously set to 'info' and not set on windows.  This PR includes setting RUST_LOG to 'info' on windows.