### PR TITLE
use installed azcopy if the packaged azcopy versions are not compatable

### DIFF
--- a/src/deployment/data_migration.py
+++ b/src/deployment/data_migration.py
@@ -1,8 +1,13 @@
-from azure.cosmosdb.table.tableservice import TableService
-from azure.cosmosdb.table.models import Entity
-from azure.cosmosdb.table.tablebatch import TableBatch
+#!/usr/bin/env python
+#
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 import json
-from typing import Optional, Callable, Dict, List
+from typing import Callable, Dict, List
+
+from azure.cosmosdb.table.tablebatch import TableBatch
+from azure.cosmosdb.table.tableservice import TableService
 
 
 def migrate_task_os(table_service: TableService) -> None:

--- a/src/deployment/register_pool_application.py
+++ b/src/deployment/register_pool_application.py
@@ -8,7 +8,7 @@ import json
 import logging
 import os
 from datetime import datetime, timedelta
-from typing import Dict, List, Tuple, NamedTuple, Optional
+from typing import Dict, List, NamedTuple, Optional, Tuple
 from uuid import UUID, uuid4
 
 from azure.cli.core import get_default_cli  # type: ignore
@@ -22,7 +22,6 @@ from azure.graphrbac.models import (
 )
 from functional import seq
 from msrest.serialization import TZ_UTC
-
 
 logger = logging.getLogger("deploy")
 
@@ -120,7 +119,8 @@ def create_application_registration(
         required_resource_access=(
             [
                 RequiredResourceAccess(
-                    resource_access=resource_access, resource_app_id=app.app_id,
+                    resource_access=resource_access,
+                    resource_app_id=app.app_id,
                 )
             ]
             if len(resource_access) > 0
@@ -268,7 +268,10 @@ def main():
     formatter = argparse.ArgumentDefaultsHelpFormatter
     parser = argparse.ArgumentParser(
         formatter_class=formatter,
-        description="Create an application registration and/or generate a password for the pool agent",
+        description=(
+            "Create an application registration and/or "
+            "generate a password for the pool agent"
+        ),
     )
     parser.add_argument("application_name")
     parser.add_argument("-v", "--verbose", action="store_true")


### PR DESCRIPTION
## Summary of the Pull Request

This checks if the azcopy we provide are compatible with the host used for deployment and otherwise makes use of the user-installed azcopy.

This enables deployment on non-x86_64 Linux/Windows platforms (such as OSX)

## PR Checklist
* [X] Applies to work item: #120 
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/onefuzz) and sign the CLI.
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

1. The deployment scripts still prefer the built-in azcopy, but will use the system provided azcopy if our built-in versions are incompatible.
2. Addresses lint issues in the deploy code
3. Adds missing copyright to code written by MSFT

## Validation Steps Performed

Run deployment from a linux/x86_64 platform and an OSX platform.  Both should succeed.