### PR TITLE
app-insights export was missed from the 1.3.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## 1.3.0
 ### Added
 * Agent: Crash reports for LibFuzzer now attempts to parse STDERR in addition to `ASAN_OPTIONS=log_path`.  This enables crash reporting of go-fuzz based binaries.  [#127](https://github.com/microsoft/onefuzz/pull/127)
+* Deployment: During deployment, App Insights logs can be configured to automatically export logs to the `app-insights` container in instance specific `func` storage account.  [#102](https://github.com/microsoft/onefuzz/pull/102)
 
 ### Changed
 * Agent: Reduced logs sent from the agent [#125](https://github.com/microsoft/onefuzz/pull/125)


### PR DESCRIPTION
The work from #102 was missed from the changelog.  This PR adds it to the changelog.