### PR TITLE
Save the managed identity as soon as it's available

### DIFF
--- a/src/api-service/__app__/onefuzzlib/pools.py
+++ b/src/api-service/__app__/onefuzzlib/pools.py
@@ -664,6 +664,8 @@ class Scaleset(BASE_SCALESET, ORMMixin):
                 logging.info("creating scaleset: %s", self.scaleset_id)
         elif vmss.provisioning_state == "Creating":
             logging.info("Waiting on scaleset creation: %s", self.scaleset_id)
+            if vmss.identity and vmss.identity.principal_id:
+                self.client_object_id = vmss.identity.principal_id
         else:
             logging.info("scaleset running: %s", self.scaleset_id)
             self.state = ScalesetState.running


### PR DESCRIPTION
When creating a large scaleset, individual VMs will often be "ready" long before the scaleset as a whole is done. 
 Supervisors trying to register before the full scaleset is up will be rejected as the managed identity is only saved once the scaleset is fully setup.

This saves the identity as soon as it's available when polling the scaleset state