### PR TITLE
allow specifying endpoint for test script

### DIFF
--- a/src/cli/examples/integration-test.py
+++ b/src/cli/examples/integration-test.py
@@ -509,6 +509,7 @@ class Run(Command):
         self,
         samples: Directory,
         *,
+        endpoint: Optional[str] = None,
         user_pools: Optional[Dict[str, str]] = None,
         pool_size: int = 10,
         region: Optional[str] = None,
@@ -517,6 +518,7 @@ class Run(Command):
         skip_repro: bool = False,
         skip_cleanup: bool = False,
     ) -> None:
+        self.onefuzz.__setup__(endpoint=endpoint)
         tester = TestOnefuzz(
             self.onefuzz,
             self.logger,


### PR DESCRIPTION
## Summary of the Pull Request

Allows specifying the endpoint to run the e2e integration tests

## PR Checklist
* [ ] Applies to work item: #xxx
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/onefuzz) and sign the CLI.
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

Adds --endpoint to integration-test.py

## Validation Steps Performed

Run the e2e deployment scripts