### PR TITLE
save the DynamicConfig for reload upon reboot

### DIFF
--- a/src/agent/onefuzz-supervisor/src/config.rs
+++ b/src/agent/onefuzz-supervisor/src/config.rs
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+use anyhow::Result;
 use reqwest::StatusCode;
 use std::{
-    path::Path,
+    path::{Path, PathBuf},
     time::{Duration, Instant},
 };
-
-use anyhow::Result;
+use tokio::fs;
 use url::Url;
 use uuid::Uuid;
 
@@ -80,7 +80,7 @@ impl StaticConfig {
     }
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct DynamicConfig {
     /// Queried to get pending commands for the machine.
     pub commands_url: Url,
@@ -90,6 +90,30 @@ pub struct DynamicConfig {
 
     /// Work queue to poll, as an Azure Storage Queue SAS URL.
     pub work_queue: Url,
+}
+
+impl DynamicConfig {
+    pub async fn save(&self) -> Result<()> {
+        let path = Self::save_path()?;
+        let data = serde_json::to_vec(&self)?;
+        fs::write(&path, &data).await?;
+        info!("saved dynamic-config: {}", path.display());
+        Ok(())
+    }
+
+    pub async fn load() -> Result<Self> {
+        let path = Self::save_path()?;
+        let data = fs::read(&path).await?;
+        let ctx: Self = serde_json::from_slice(&data)?;
+        info!("loaded dynamic-config: {}", path.display());
+        Ok(ctx)
+    }
+
+    fn save_path() -> Result<PathBuf> {
+        Ok(onefuzz::fs::onefuzz_root()?
+            .join("etc")
+            .join("dynamic-config.json"))
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -135,7 +159,8 @@ impl Registration {
 
             match response {
                 Ok(response) => {
-                    let dynamic_config = response.json().await?;
+                    let dynamic_config: DynamicConfig = response.json().await?;
+                    dynamic_config.save().await?;
                     return Ok(Self {
                         config,
                         dynamic_config,
@@ -155,6 +180,18 @@ impl Registration {
         }
 
         anyhow::bail!("Unable to register agent")
+    }
+
+    pub async fn load_existing(config: StaticConfig) -> Result<Self> {
+        let dynamic_config = DynamicConfig::load().await?;
+        let machine_id = onefuzz::machine_id::get_machine_id().await?;
+        let mut registration = Self {
+            config,
+            dynamic_config,
+            machine_id,
+        };
+        registration.renew().await?;
+        Ok(registration)
     }
 
     pub async fn create_managed(config: StaticConfig) -> Result<Self> {
@@ -181,6 +218,7 @@ impl Registration {
             .error_for_status()?;
 
         self.dynamic_config = response.json().await?;
+        self.dynamic_config.save().await?;
 
         Ok(())
     }

--- a/src/agent/onefuzz-supervisor/src/main.rs
+++ b/src/agent/onefuzz-supervisor/src/main.rs
@@ -124,8 +124,11 @@ async fn run_agent(config: StaticConfig) -> Result<()> {
         telemetry::set_property(EventData::ScalesetId(scaleset));
     }
 
-    let registration = config::Registration::create_managed(config.clone()).await?;
-    verbose!("created managed registration: {:?}", registration);
+    let registration = match config::Registration::load_existing(config.clone()).await {
+        Ok(registration) => registration,
+        Err(_) => config::Registration::create_managed(config.clone()).await?,
+    };
+    verbose!("current registration: {:?}", registration);
 
     let coordinator = coordinator::Coordinator::new(registration.clone()).await?;
     verbose!("initialized coordinator");


### PR DESCRIPTION
## Summary of the Pull Request

This saves DynamicConfig to disk such that it can be reloaded upon reboot.

This moves the agent to a mode such that 'registration' only happens upon first connection.

## PR Checklist
* [ ] Applies to work item: #xxx
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/onefuzz) and sign the CLI.
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_

## Validation Steps Performed

_How does someone test & validate?_
