### PR TITLE
Expand coverage and debugger APIs

### DIFF
--- a/src/agent/coverage/src/lib.rs
+++ b/src/agent/coverage/src/lib.rs
@@ -77,10 +77,6 @@ impl ModuleCoverageBlocks {
         Path::new(&self.module)
     }
 
-    pub fn module_name(&self) -> &Path {
-        Path::new(&self.module)
-    }
-
     pub fn blocks(&self) -> &[Block] {
         &self.blocks
     }

--- a/src/agent/coverage/src/lib.rs
+++ b/src/agent/coverage/src/lib.rs
@@ -6,14 +6,17 @@
 #![allow(clippy::new_without_default)]
 
 mod intel;
-mod pe;
+pub mod pe;
 
-use std::{ffi::OsString, fs::File, path::PathBuf};
+use std::{
+    ffi::OsString,
+    fs::File,
+    path::{Path, PathBuf},
+};
 
 use anyhow::Result;
 use fixedbitset::FixedBitSet;
 use serde::{Deserialize, Serialize};
-use std::path::Path;
 
 pub const COVERAGE_MAP: &str = "coverage-map";
 
@@ -41,23 +44,37 @@ impl Block {
     }
 }
 
-#[derive(Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct ModuleCoverageBlocks {
     module: OsString,
+    path: PathBuf,
     blocks: Vec<Block>,
 }
 
 impl ModuleCoverageBlocks {
-    pub fn new<S: Into<OsString>>(module: S, rvas_bitset: FixedBitSet) -> Self {
+    pub fn new(
+        path: impl Into<PathBuf>,
+        module: impl Into<OsString>,
+        rvas_bitset: FixedBitSet,
+    ) -> Self {
         let blocks: Vec<_> = rvas_bitset
             .ones()
             .map(|rva| Block::new(rva as u32, false))
             .collect();
 
         ModuleCoverageBlocks {
+            path: path.into(),
             module: module.into(),
             blocks,
         }
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub fn name(&self) -> &Path {
+        Path::new(&self.module)
     }
 
     pub fn module_name(&self) -> &Path {
@@ -77,7 +94,7 @@ impl ModuleCoverageBlocks {
     }
 }
 
-#[derive(Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct AppCoverageBlocks {
     modules: Vec<ModuleCoverageBlocks>,
 }
@@ -92,8 +109,10 @@ impl AppCoverageBlocks {
         &self.modules
     }
 
-    pub fn add_module(&mut self, module: ModuleCoverageBlocks) {
+    pub fn add_module(&mut self, module: ModuleCoverageBlocks) -> usize {
+        let idx = self.modules.len();
         self.modules.push(module);
+        idx
     }
 
     pub fn report_block_hit(&mut self, module_index: usize, block_index: usize) {
@@ -120,7 +139,7 @@ pub fn run_init(output_dir: PathBuf, modules: Vec<PathBuf>, function: bool) -> R
             let rvas_bitset = pe::process_image(&module, function)?;
 
             let module_name = module.file_stem().unwrap(); // Unwrap guaranteed by `is_file` test above.
-            let module_rvas = ModuleCoverageBlocks::new(&module_name, rvas_bitset);
+            let module_rvas = ModuleCoverageBlocks::new(module.clone(), &module_name, rvas_bitset);
             result.add_module(module_rvas);
         } else {
             anyhow::bail!("Cannot find file `{}`", module.as_path().display());

--- a/src/agent/debugger/src/debugger.rs
+++ b/src/agent/debugger/src/debugger.rs
@@ -40,7 +40,7 @@ use winapi::{
 
 use crate::target::Target;
 use crate::{
-    dbghelp::{self, SymInfo},
+    dbghelp::{self, ModuleInfo, SymInfo, SymLineInfo},
     debug_event::{DebugEvent, DebugEventInfo},
     stack,
 };
@@ -287,6 +287,10 @@ impl Debugger {
         } else {
             anyhow::bail!("Unexpected event: {}", de)
         }
+    }
+
+    pub fn target(&mut self) -> &mut Target {
+        &mut self.target
     }
 
     fn next_breakpoint_id(&mut self) -> BreakpointId {
@@ -638,9 +642,19 @@ impl Debugger {
         );
     }
 
+    pub fn get_module_info(&self, pc: u64) -> Result<ModuleInfo> {
+        let dbghelp = dbghelp::lock()?;
+        dbghelp.sym_get_module_info(self.target.process_handle(), pc)
+    }
+
     pub fn get_symbol(&self, pc: u64) -> Result<SymInfo> {
         let dbghelp = dbghelp::lock()?;
         dbghelp.sym_from_inline_context(self.target.process_handle(), pc, 0)
+    }
+
+    pub fn get_symbol_line_info(&self, pc: u64) -> Result<SymLineInfo> {
+        let dbghelp = dbghelp::lock()?;
+        dbghelp.sym_get_file_and_line(self.target.process_handle(), pc, 0)
     }
 
     pub fn get_current_thread_id(&self) -> u64 {

--- a/src/agent/input-tester/src/crash_detector.rs
+++ b/src/agent/input-tester/src/crash_detector.rs
@@ -177,7 +177,7 @@ fn prepare_coverage_breakpoints(
     if let Some(coverage_map) = coverage_map {
         let mut id_to_block = fnv::FnvHashMap::default();
         for (m, module) in coverage_map.modules().iter().enumerate() {
-            let name = module.module_name();
+            let name = module.name();
             for (i, block) in module.blocks().iter().enumerate() {
                 // For better performance, we can skip registering breakpoints that have
                 // been hit as we only care about new coverage.


### PR DESCRIPTION
- Enable tracking module paths when collecting coverage
- Expose `Target`, more `dbghelp` functions from `Debugger`