### PR TITLE
fail louder when uploads fail

### DIFF
--- a/src/agent/onefuzz-agent/src/tasks/fuzz/generator.rs
+++ b/src/agent/onefuzz-agent/src/tasks/fuzz/generator.rs
@@ -8,7 +8,9 @@ use crate::tasks::{
 };
 use anyhow::{Error, Result};
 use futures::stream::StreamExt;
-use onefuzz::{expand::Expand, fs::set_executable, input_tester::Tester, sha256};
+use onefuzz::{
+    expand::Expand, fs::set_executable, input_tester::Tester, sha256, telemetry::Event::new_result,
+};
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::{
@@ -63,7 +65,7 @@ pub async fn spawn(config: Arc<GeneratorConfig>) -> Result<(), Error> {
         config.readonly_inputs.clone(),
         std::time::Duration::from_secs(10),
     );
-    let crash_dir_monitor = utils::monitor_result_dir(config.crashes.clone());
+    let crash_dir_monitor = utils::monitor_result_dir(config.crashes.clone(), new_result);
     let tester = Tester::new(
         &config.target_exe,
         &config.target_options,

--- a/src/agent/onefuzz-agent/src/tasks/fuzz/libfuzzer_fuzz.rs
+++ b/src/agent/onefuzz-agent/src/tasks/fuzz/libfuzzer_fuzz.rs
@@ -11,14 +11,12 @@ use futures::{future::try_join_all, stream::StreamExt};
 use onefuzz::{
     fs::list_files,
     libfuzzer::{LibFuzzer, LibFuzzerLine},
-    monitor::DirectoryMonitor,
     process::ExitStatus,
     system,
     telemetry::{
         Event::{new_coverage, new_result, process_stats, runtime_stats},
         EventData,
     },
-    uploader::BlobUploader,
 };
 use serde::Deserialize;
 use std::{collections::HashMap, path::PathBuf};
@@ -79,8 +77,8 @@ impl LibFuzzerFuzzTask {
 
         // To be scheduled.
         let resync = self.resync_all_corpuses();
-        let new_corpus = self.monitor_new_corpus();
-        let faults = self.monitor_faults();
+        let new_inputs = utils::monitor_result_dir(self.config.inputs.clone(), new_coverage);
+        let new_crashes = utils::monitor_result_dir(self.config.crashes.clone(), new_result);
 
         let (stats_sender, stats_receiver) = mpsc::unbounded_channel();
         let report_stats = report_runtime_stats(workers as usize, stats_receiver, hb_client);
@@ -91,7 +89,7 @@ impl LibFuzzerFuzzTask {
 
         let fuzzers = try_join_all(fuzzers);
 
-        futures::try_join!(resync, new_corpus, faults, fuzzers, report_stats)?;
+        futures::try_join!(resync, new_inputs, new_crashes, fuzzers, report_stats)?;
 
         Ok(())
     }
@@ -208,56 +206,6 @@ impl LibFuzzerFuzzTask {
 
             self.sync_all_corpuses().await?;
         }
-    }
-
-    async fn monitor_new_corpus(&self) -> Result<()> {
-        let url = self.config.inputs.url.url();
-        let mut monitor = DirectoryMonitor::new(&self.config.inputs.path);
-        monitor.start()?;
-
-        monitor
-            .for_each(move |item| {
-                let url = url.clone();
-
-                async move {
-                    event!(new_coverage; EventData::Path = item.display().to_string());
-
-                    let mut uploader = BlobUploader::new(url);
-
-                    if let Err(err) = uploader.upload(item.clone()).await {
-                        error!("Couldn't upload coverage: {}", err);
-                    }
-                }
-            })
-            .await;
-
-        Ok(())
-    }
-
-    async fn monitor_faults(&self) -> Result<()> {
-        let url = self.config.crashes.url.url();
-        let dir = self.config.crashes.path.clone();
-
-        let mut monitor = DirectoryMonitor::new(dir);
-        monitor.start()?;
-
-        monitor
-            .for_each(move |item| {
-                let url = url.clone();
-
-                async move {
-                    event!(new_result; EventData::Path = item.display().to_string());
-
-                    let mut uploader = BlobUploader::new(url);
-
-                    if let Err(err) = uploader.upload(item.clone()).await {
-                        error!("Couldn't upload fault: {}", err);
-                    }
-                }
-            })
-            .await;
-
-        Ok(())
     }
 }
 

--- a/src/agent/onefuzz-agent/src/tasks/fuzz/supervisor.rs
+++ b/src/agent/onefuzz-agent/src/tasks/fuzz/supervisor.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-
 #![allow(clippy::too_many_arguments)]
 use crate::tasks::{
     config::{CommonConfig, ContainerType, SyncedDir},
@@ -13,6 +12,7 @@ use anyhow::{Error, Result};
 use onefuzz::{
     expand::Expand,
     fs::{has_files, set_executable, OwnedDir},
+    telemetry::Event::new_result,
 };
 use serde::Deserialize;
 use std::{
@@ -64,7 +64,7 @@ pub async fn spawn(config: SupervisorConfig) -> Result<(), Error> {
     };
 
     utils::init_dir(&crashes.path).await?;
-    let monitor_crashes = utils::monitor_result_dir(crashes.clone());
+    let monitor_crashes = utils::monitor_result_dir(crashes.clone(), new_result);
 
     let inputs = SyncedDir {
         path: runtime_dir.path().join("inputs"),

--- a/src/agent/onefuzz/src/az_copy.rs
+++ b/src/agent/onefuzz/src/az_copy.rs
@@ -54,7 +54,7 @@ pub async fn copy(src: impl AsRef<OsStr>, dst: impl AsRef<OsStr>, recursive: boo
         let stdout = String::from_utf8_lossy(&output.stdout);
         let stderr = String::from_utf8_lossy(&output.stderr);
         anyhow::bail!(
-            "sync failed src:{:?} dst:{:?} stdout:{:?} stderr:{:?}",
+            "copy failed src:{:?} dst:{:?} stdout:{:?} stderr:{:?}",
             src.as_ref(),
             dst.as_ref(),
             stdout,

--- a/src/agent/onefuzz/src/az_copy.rs
+++ b/src/agent/onefuzz/src/az_copy.rs
@@ -19,11 +19,13 @@ pub async fn sync(src: impl AsRef<OsStr>, dst: impl AsRef<OsStr>) -> Result<()> 
 
     let output = cmd.spawn()?.wait_with_output().await?;
     if !output.status.success() {
+        let stdout = String::from_utf8_lossy(&output.stdout);
         let stderr = String::from_utf8_lossy(&output.stderr);
         anyhow::bail!(
-            "sync failed '{:?}' ==> '{:?}' : {}",
+            "sync failed src:{:?} dst:{:?} stdout:{:?} stderr:{:?}",
             src.as_ref(),
             dst.as_ref(),
+            stdout,
             stderr
         );
     }
@@ -49,11 +51,13 @@ pub async fn copy(src: impl AsRef<OsStr>, dst: impl AsRef<OsStr>, recursive: boo
 
     let output = cmd.spawn()?.wait_with_output().await?;
     if !output.status.success() {
+        let stdout = String::from_utf8_lossy(&output.stdout);
         let stderr = String::from_utf8_lossy(&output.stderr);
         anyhow::bail!(
-            "copy failed '{:?}' ==> '{:?}' : {}",
+            "sync failed src:{:?} dst:{:?} stdout:{:?} stderr:{:?}",
             src.as_ref(),
             dst.as_ref(),
+            stdout,
             stderr
         );
     }


### PR DESCRIPTION
## Summary of the Pull Request

Makes upload failures more verbose and fail fast.

## PR Checklist
* [x] Applies to work item: #153 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/onefuzz) and sign the CLI.
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

1. Standardizes on a single SyncDir based director monitor.
2. Update said uploader to use `while ... monitor.next()` rather than `monitor.for_each` such that failures can be reported
3. Update azcopy wrapper to include stdout & stderr on failure, as some (but not all) errors in azcopy are printed to stdout.

## Validation Steps Performed

Run standard integration tests