### PR TITLE
on shutdown of scalesets & pools, only return boolresponse

### DIFF
--- a/src/api-service/__app__/pool/__init__.py
+++ b/src/api-service/__app__/pool/__init__.py
@@ -10,6 +10,7 @@ import azure.functions as func
 from onefuzztypes.enums import ErrorCode, PoolState
 from onefuzztypes.models import AgentConfig, Error
 from onefuzztypes.requests import PoolCreate, PoolSearch, PoolStop
+from onefuzztypes.responses import BoolResult
 
 from ..onefuzzlib.azure.creds import get_base_region, get_instance_url, get_regions
 from ..onefuzzlib.azure.queue import get_queue_sas
@@ -124,7 +125,7 @@ def delete(req: func.HttpRequest) -> func.HttpResponse:
     else:
         pool.state = PoolState.shutdown
     pool.save()
-    return ok(set_config(pool))
+    return ok(BoolResult(result=True))
 
 
 def main(req: func.HttpRequest) -> func.HttpResponse:

--- a/src/api-service/__app__/scaleset/__init__.py
+++ b/src/api-service/__app__/scaleset/__init__.py
@@ -12,6 +12,7 @@ from onefuzztypes.requests import (
     ScalesetStop,
     ScalesetUpdate,
 )
+from onefuzztypes.responses import BoolResult
 
 from ..onefuzzlib.azure.creds import get_base_region, get_regions
 from ..onefuzzlib.azure.vmss import list_available_skus
@@ -112,7 +113,7 @@ def delete(req: func.HttpRequest) -> func.HttpResponse:
 
     scaleset.save()
     scaleset.auth = None
-    return ok(scaleset)
+    return ok(BoolResult(result=True))
 
 
 def patch(req: func.HttpRequest) -> func.HttpResponse:

--- a/src/cli/onefuzz/api.py
+++ b/src/cli/onefuzz/api.py
@@ -849,7 +849,7 @@ class Pool(Endpoint):
 
         return config
 
-    def shutdown(self, name: str, *, now: bool = False) -> models.Pool:
+    def shutdown(self, name: str, *, now: bool = False) -> responses.BoolResult:
         expanded_name = self._disambiguate(
             "name", name, lambda x: False, lambda: [x.name for x in self.list()]
         )
@@ -857,7 +857,7 @@ class Pool(Endpoint):
         self.logger.debug("shutdown worker pool: %s (now: %s)", expanded_name, now)
         return self._req_model(
             "DELETE",
-            models.Pool,
+            responses.BoolResult,
             json_data={"name": expanded_name, "now": now},
         )
 
@@ -1019,7 +1019,7 @@ class Scaleset(Endpoint):
 
     def shutdown(
         self, scaleset_id: UUID_EXPANSION, *, now: bool = False
-    ) -> models.Scaleset:
+    ) -> responses.BoolResult:
         scaleset_id_expanded = self._disambiguate_uuid(
             "scaleset_id",
             scaleset_id,
@@ -1029,7 +1029,7 @@ class Scaleset(Endpoint):
         self.logger.debug("shutdown scaleset: %s (now: %s)", scaleset_id_expanded, now)
         return self._req_model(
             "DELETE",
-            models.Scaleset,
+            responses.BoolResult,
             json_data={"scaleset_id": scaleset_id_expanded, "now": now},
         )
 


### PR DESCRIPTION
As is, we return the full pool or scaleset model, which isn't needed on delete