### PR TITLE
limit size of error log saved as a Task Error

### DIFF
--- a/src/api-service/__app__/agent_events/__init__.py
+++ b/src/api-service/__app__/agent_events/__init__.py
@@ -168,8 +168,8 @@ def on_worker_event(machine_id: UUID, event: WorkerEvent) -> None:
                     code=ErrorCode.TASK_FAILED,
                     errors=[
                         "task failed. exit_status:%s" % exit_status,
-                        event.done.stdout,
-                        event.done.stderr,
+                        event.done.stdout[-4096:],
+                        event.done.stderr[-4096:],
                     ],
                 )
             )


### PR DESCRIPTION
## Summary of the Pull Request

Limits stdout/stderr logged as part of the Task.error upon task failure to the last 4k of each.