### PR TITLE
handle nested exceptions during cleanup on function deploy failures

### DIFF
--- a/src/deployment/deploy.py
+++ b/src/deployment/deploy.py
@@ -590,7 +590,6 @@ class Client:
         with tempfile.TemporaryDirectory() as tmpdirname:
             with zipfile.ZipFile(self.app_zip, "r") as zip_ref:
                 zip_ref.extractall(tmpdirname)
-                os.chdir(tmpdirname)
                 subprocess.check_output(
                     [
                         shutil.which("func"),
@@ -600,11 +599,10 @@ class Client:
                         self.application_name,
                         "--python",
                         "--no-build",
+                        cwd=tmpdirname,
                     ],
                     env=dict(os.environ, CLI_DEBUG="1"),
                 )
-
-            os.chdir(current_dir)
 
     def update_registration(self):
         if not self.create_registration:

--- a/src/deployment/deploy.py
+++ b/src/deployment/deploy.py
@@ -586,7 +586,6 @@ class Client:
 
     def deploy_app(self):
         logger.info("deploying function app %s", self.app_zip)
-        current_dir = os.getcwd()
         with tempfile.TemporaryDirectory() as tmpdirname:
             with zipfile.ZipFile(self.app_zip, "r") as zip_ref:
                 zip_ref.extractall(tmpdirname)

--- a/src/deployment/deploy.py
+++ b/src/deployment/deploy.py
@@ -598,9 +598,9 @@ class Client:
                         self.application_name,
                         "--python",
                         "--no-build",
-                        cwd=tmpdirname,
                     ],
                     env=dict(os.environ, CLI_DEBUG="1"),
+                    cwd=tmpdirname,
                 )
 
     def update_registration(self):


### PR DESCRIPTION
## Summary of the Pull Request

If subprocess.check_output() raises an exception, the handler for TemporaryDirectory() attempts to delete tmpdirname. This causes a permissions error since the terminal's cwd has been changed to tmpdirname. I'm not sure if this happens on Linux but on Windows, another exception is throw along with the error returned by check_output().

## PR Checklist
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/onefuzz) and sign the CLI.
* [X] Tests added/passed

## Info on Pull Request

This fix removes the need to use os.chdir(). 

## Validation Steps Performed

I tested this fix using Windows but not Linux. 
