### PR TITLE
only emit events on a change of state

### DIFF
--- a/src/agent/onefuzz-supervisor/src/agent.rs
+++ b/src/agent/onefuzz-supervisor/src/agent.rs
@@ -107,10 +107,10 @@ impl Agent {
         match (&event, self.previous_state) {
             (StateUpdateEvent::Free, NodeState::Free)
             | (StateUpdateEvent::Busy, NodeState::Busy)
-            | (StateUpdateEvent::SettingUp{..}, NodeState::SettingUp)
+            | (StateUpdateEvent::SettingUp { .. }, NodeState::SettingUp)
             | (StateUpdateEvent::Rebooting, NodeState::Rebooting)
             | (StateUpdateEvent::Ready, NodeState::Ready)
-            | (StateUpdateEvent::Done{..}, NodeState::Done) => {}
+            | (StateUpdateEvent::Done { .. }, NodeState::Done) => {}
             _ => {
                 self.coordinator.emit_event(event.into()).await?;
             }

--- a/src/agent/onefuzz-supervisor/src/scheduler.rs
+++ b/src/agent/onefuzz-supervisor/src/scheduler.rs
@@ -6,7 +6,7 @@ use std::fmt;
 use anyhow::Result;
 use onefuzz::process::Output;
 
-use crate::coordinator::NodeCommand;
+use crate::coordinator::{NodeCommand, NodeState};
 use crate::reboot::RebootContext;
 use crate::setup::ISetupRunner;
 use crate::work::*;
@@ -21,6 +21,19 @@ pub enum Scheduler {
     Done(State<Done>),
 }
 
+impl From<&Scheduler> for NodeState {
+    fn from(value: &Scheduler) -> Self {
+        match value {
+            Scheduler::Free(_) => Self::Free,
+            Scheduler::SettingUp(_) => Self::SettingUp,
+            Scheduler::PendingReboot(_) => Self::Rebooting,
+            Scheduler::Ready(_) => Self::Ready,
+            Scheduler::Busy(_) => Self::Busy,
+            Scheduler::Done(_) => Self::Done,
+        }
+    }
+}
+
 impl fmt::Display for Scheduler {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let s = match self {
@@ -32,28 +45,6 @@ impl fmt::Display for Scheduler {
             Self::Done(..) => "Scheduler::Done",
         };
         write!(f, "{}", s)
-    }
-}
-
-pub enum StateValue {
-    Free,
-    SettingUp,
-    PendingReboot,
-    Ready,
-    Busy,
-    Done,
-}
-
-impl From<&Scheduler> for StateValue {
-    fn from(value: &Scheduler) -> Self {
-        match value {
-            Scheduler::Free(_) => Self::Free,
-            Scheduler::SettingUp(_) => Self::SettingUp,
-            Scheduler::PendingReboot(_) => Self::PendingReboot,
-            Scheduler::Ready(_) => Self::Ready,
-            Scheduler::Busy(_) => Self::Busy,
-            Scheduler::Done(_) => Self::Done,
-        }
     }
 }
 

--- a/src/agent/onefuzz-supervisor/src/scheduler.rs
+++ b/src/agent/onefuzz-supervisor/src/scheduler.rs
@@ -35,6 +35,28 @@ impl fmt::Display for Scheduler {
     }
 }
 
+pub enum StateValue {
+    Free,
+    SettingUp,
+    PendingReboot,
+    Ready,
+    Busy,
+    Done,
+}
+
+impl From<&Scheduler> for StateValue {
+    fn from(value: &Scheduler) -> Self {
+        match value {
+            Scheduler::Free(_) => Self::Free,
+            Scheduler::SettingUp(_) => Self::SettingUp,
+            Scheduler::PendingReboot(_) => Self::PendingReboot,
+            Scheduler::Ready(_) => Self::Ready,
+            Scheduler::Busy(_) => Self::Busy,
+            Scheduler::Done(_) => Self::Done,
+        }
+    }
+}
+
 impl Scheduler {
     pub fn new() -> Self {
         Self::default()


### PR DESCRIPTION
## Summary of the Pull Request

This PR updates the supervisor to only emit events when there is a change in state.

## Validation Steps Performed

1. Standard integration tests will verify it doesn't break the state machine
2. Check app-insights to verify we don't see sequential "Free" or "Busy" events from a given node