### PR TITLE
address help issues in the expanded reset command

### DIFF
--- a/src/cli/onefuzz/api.py
+++ b/src/cli/onefuzz/api.py
@@ -1290,10 +1290,10 @@ class Onefuzz:
 
         return data
 
-    def _user_confirmation(self, message: List[str]) -> bool:
+    def _user_confirmation(self, message: str) -> bool:
         answer: Optional[str] = None
         while answer not in ["y", "n"]:
-            answer = input(" ".join(message)).strip()
+            answer = input(message).strip()
 
         if answer == "n":
             self.logger.info("not stopping")
@@ -1389,19 +1389,6 @@ class Onefuzz:
         :param bool tasks: Stop all tasks.
         :param bool yes: Ignoring to specify "y" in prompt.
         """
-        delete_options = [
-            containers,
-            jobs,
-            pools,
-            notifications,
-            repros,
-            scalesets,
-            tasks,
-        ]
-        arguments = [everything]
-        arguments.extend(delete_options)
-        if not any(arguments):
-            jobs, notifications, repros, tasks = True, True, True, True
 
         if everything:
             containers, jobs, pools, notifications, repros, scalesets, tasks = (
@@ -1413,10 +1400,13 @@ class Onefuzz:
                 True,
                 True,
             )
+        elif not any(
+            [containers, jobs, pools, notifications, repros, scalesets, tasks]
+        ):
+            jobs, notifications, repros, tasks = True, True, True, True
 
         if containers and not (tasks or jobs):
-            print("Use --jobs or --tasks with containers")
-            return
+            raise Exception("Resetting containers requires resetting jobs or tasks")
 
         to_delete = []
         argument_str = {
@@ -1431,8 +1421,9 @@ class Onefuzz:
         for k, v in locals().items():
             if k in argument_str and v:
                 to_delete.append(k)
-        message = ["Confirm stopping %s " % (", ".join(to_delete))]
-        message += ["(specify y or n): "]
+        message = "Confirm stopping %s (specify y or n): " % (
+            ", ".join(sorted(to_delete))
+        )
         if not yes and not self._user_confirmation(message):
             return
 

--- a/src/cli/onefuzz/cli.py
+++ b/src/cli/onefuzz/cli.py
@@ -335,6 +335,8 @@ class Builder:
             class_result = self.parse_annotation_class(name, annotation, default)
             if class_result is not None:
                 result.update(class_result)
+                if help_doc and result["help"] != help_doc:
+                    result["help"] = "%s %s" % (help_doc, result["help"])
                 return result
 
         # isinstance type signatures doesn't support TypeVar


### PR DESCRIPTION
The expanded `reset` command now includes help documentation for each of the arguments.  

With this PR, the help looks like this:
```
$ onefuzz reset --help
usage: onefuzz reset [-h] [-v] [--format {json,raw}] [--query QUERY] [--containers] [--everything] [--jobs] [--notifications] [--pools]
                     [--repros] [--scalesets] [--tasks] [--yes]

optional arguments:
  -h, --help           show this help message and exit
  -v, --verbose        increase output verbosity
  --format {json,raw}  output format
  --query QUERY        JMESPath query string. See http://jmespath.org/ for more information and examples.
  --containers         Delete all the containers. (Default: False. Sets value to True)
  --everything         Delete all containers, pools and managed scalesets. (Default: False. Sets value to True)
  --jobs               Stop all jobs. (Default: False. Sets value to True)
  --notifications      Stop all notifications. (Default: False. Sets value to True)
  --pools              Delete all pools. (Default: False. Sets value to True)
  --repros             Delete all repro vms. (Default: False. Sets value to True)
  --scalesets          Delete all managed scalesets. (Default: False. Sets value to True)
  --tasks              Stop all tasks. (Default: False. Sets value to True)
  --yes                Ignoring to specify "y" in prompt. (Default: False. Sets value to True)
$
```