### PR TITLE
fix format strings in logging for onefuzzlib.azure.vm.get_vm

### DIFF
--- a/src/api-service/__app__/onefuzzlib/azure/vm.py
+++ b/src/api-service/__app__/onefuzzlib/azure/vm.py
@@ -25,7 +25,7 @@ from .ip import create_public_nic, delete_ip, delete_nic, get_ip, get_public_nic
 def get_vm(name: str) -> Optional[VirtualMachine]:
     resource_group = get_base_resource_group()
 
-    logging.debug("getting vm: %s %s - %s", resource_group, name)
+    logging.debug("getting vm: %s", name)
     compute_client = mgmt_client_factory(ComputeManagementClient)
     try:
         return cast(


### PR DESCRIPTION
## Summary of the Pull Request

Fixes an exception due to mismatched formatting arguments

## PR Checklist
* [x] Applies to work item: #188 
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx