### PR TITLE
reduce how often list_containers is called

### DIFF
--- a/src/api-service/__app__/download/__init__.py
+++ b/src/api-service/__app__/download/__init__.py
@@ -7,7 +7,11 @@ import azure.functions as func
 from onefuzztypes.enums import ErrorCode
 from onefuzztypes.models import Error, FileEntry
 
-from ..onefuzzlib.azure.containers import blob_exists, get_containers, get_file_sas_url
+from ..onefuzzlib.azure.containers import (
+    blob_exists,
+    container_exists,
+    get_file_sas_url,
+)
 from ..onefuzzlib.request import not_ok, parse_uri, redirect
 
 
@@ -16,7 +20,7 @@ def get(req: func.HttpRequest) -> func.HttpResponse:
     if isinstance(request, Error):
         return not_ok(request, context="download")
 
-    if request.container not in get_containers():
+    if not container_exists(request.container):
         return not_ok(
             Error(code=ErrorCode.INVALID_REQUEST, errors=["invalid container"]),
             context=request.container,

--- a/src/api-service/__app__/notifications/__init__.py
+++ b/src/api-service/__app__/notifications/__init__.py
@@ -10,7 +10,7 @@ from onefuzztypes.enums import ErrorCode
 from onefuzztypes.models import Error
 from onefuzztypes.requests import NotificationCreate, NotificationGet
 
-from ..onefuzzlib.azure.containers import get_containers
+from ..onefuzzlib.azure.containers import container_exists
 from ..onefuzzlib.notifications.main import Notification
 from ..onefuzzlib.request import not_ok, ok, parse_request
 
@@ -29,8 +29,7 @@ def post(req: func.HttpRequest) -> func.HttpResponse:
     if isinstance(request, Error):
         return not_ok(request, context="notification create")
 
-    containers = get_containers()
-    if request.container not in containers:
+    if not container_exists(request.container):
         return not_ok(
             Error(code=ErrorCode.INVALID_REQUEST, errors=["invalid container"]),
             context=request.container,

--- a/src/api-service/__app__/onefuzzlib/azure/containers.py
+++ b/src/api-service/__app__/onefuzzlib/azure/containers.py
@@ -10,8 +10,18 @@ from typing import Any, Dict, Optional, Union, cast
 
 from azure.common import AzureHttpError, AzureMissingResourceHttpError
 from azure.storage.blob import BlobPermissions, ContainerPermissions
+from memoization import cached
 
 from .creds import get_blob_service
+
+
+@cached(ttl=5)
+def container_exists(name: str, account_id: Optional[str] = None) -> bool:
+    try:
+        get_blob_service(account_id).get_container_properties(name)
+        return True
+    except AzureHttpError:
+        return False
 
 
 def get_containers(account_id: Optional[str] = None) -> Dict[str, Dict[str, str]]:

--- a/src/api-service/__app__/onefuzzlib/azure/containers.py
+++ b/src/api-service/__app__/onefuzzlib/azure/containers.py
@@ -37,8 +37,7 @@ def get_container_metadata(
 ) -> Optional[Dict[str, str]]:
     try:
         result = get_blob_service(account_id).get_container_metadata(name)
-        if result:
-            return cast(Dict[str, str], result)
+        return cast(Dict[str, str], result)
     except AzureHttpError:
         pass
     return None


### PR DESCRIPTION
Reduce performance issues relating to `container in list_containers()` as a method of checking of a container exists.

This becomes noticeable once extremely large numbers of containers are created.