### PR TITLE
Add Onefuzz.container.reset to the SDK

### DIFF
--- a/src/cli/onefuzz/api.py
+++ b/src/cli/onefuzz/api.py
@@ -277,11 +277,12 @@ class Containers(Endpoint):
     def reset(
         self, container_types: Optional[List[enums.ContainerType]] = None
     ) -> None:
-        """Reset all Conatiners unless specified.
+        """Reset containers unless specified.
         [Caution]: It can lead to unexpected results.
+        The default conatiners are listed ContainerType.reset_defaults
         """
         if not container_types:
-            container_types = enums.ContainerType.__dict__["_member_map_"].values()
+            container_types = enums.ContainerType.reset_defaults()
 
         if not container_types:
             raise Exception("Container type is None")

--- a/src/cli/onefuzz/api.py
+++ b/src/cli/onefuzz/api.py
@@ -275,56 +275,23 @@ class Containers(Endpoint):
         return self._req_model_list("GET", responses.ContainerInfoBase)
 
     def reset(
-        self,
-        analysis: bool = False,
-        coverage: bool = False,
-        crashes: bool = False,
-        inputs: bool = False,
-        no_repro: bool = False,
-        readonly_inputs: bool = False,
-        reports: bool = False,
-        setup: bool = False,
-        unique_reports: bool = False,
+        self, container_types: Optional[List[enums.ContainerType]] = None
     ) -> None:
         """Reset all Conatiners unless specified.
         [Caution]: It can lead to unexpected results.
-
-        :param bool analysis: Delete only analysis containers.
-        :param bool coverage: Delete only coverage containers.
-        :param bool crashes: Delete only crashes containers.
-        :param bool inputs: Delete only inputs containers.
-        :param bool no_repro: Delete only no_repro containers.
-        :param bool readonly_inputs: Delete only readonly_inputs containers.
-        :param bool reports: Delete only reports containers.
-        :param bool setup: Delete only setup containers.
-        :param bool unique_reports: Delete only unique_reports containers.
         """
-        container_types = {
-            "analysis": False,
-            "coverage": False,
-            "crashes": False,
-            "inputs": False,
-            "no_repro": False,
-            "readonly_inputs": False,
-            "reports": False,
-            "setup": False,
-            "unique_reports": False,
-        }
-        for k, v in locals().items():
-            if k in container_types and v:
-                container_types[k] = v
-        if not any(list(container_types.values())):
-            for k, _ in container_types.items():
-                container_types[k] = True
+        if not container_types:
+            container_types = enums.ContainerType.__dict__["_member_map_"].values()
 
-        container_types = dict(filter(lambda x: x[1], container_types.items()))
-        delete_container_types = container_types.keys()
+        if not container_types:
+            raise Exception("Container type is None")
 
         for container in self.list():
             if (
                 container.metadata
                 and "container_type" in container.metadata
-                and container.metadata["container_type"] in delete_container_types
+                and enums.ContainerType(container.metadata["container_type"])
+                in container_types
             ):
                 self.logger.info("removing container: %s", container.name)
                 self.delete(container.name)

--- a/src/cli/onefuzz/api.py
+++ b/src/cli/onefuzz/api.py
@@ -314,17 +314,17 @@ class Containers(Endpoint):
             if k in container_types and v:
                 container_types[k] = v
         if not any(list(container_types.values())):
-            for k, v in container_types.items():
+            for k, _ in container_types.items():
                 container_types[k] = True
 
         container_types = dict(filter(lambda x: x[1], container_types.items()))
-        container_types = container_types.keys()
+        delete_container_types = container_types.keys()
 
         for container in self.list():
             if (
                 container.metadata
                 and "container_type" in container.metadata
-                and container.metadata["container_type"] in container_types
+                and container.metadata["container_type"] in delete_container_types
             ):
                 self.logger.info("removing container: %s", container.name)
                 self.delete(container.name)

--- a/src/cli/onefuzz/api.py
+++ b/src/cli/onefuzz/api.py
@@ -299,19 +299,6 @@ class Containers(Endpoint):
         :param bool setup: Delete only setup containers.
         :param bool unique_reports: Delete only unique_reports containers.
         """
-        """
-        arguments = [
-            analysis,
-            coverage,
-            crashes,
-            inputs,
-            no_repro,
-            readonly_inputs,
-            reports,
-            setup,
-            unique_reports,
-        ]
-        """
         container_types = {
             "analysis": False,
             "coverage": False,

--- a/src/pytypes/onefuzztypes/enums.py
+++ b/src/pytypes/onefuzztypes/enums.py
@@ -189,17 +189,31 @@ class Compare(Enum):
 
 
 class ContainerType(Enum):
-    setup = "setup"
+    analysis = "analysis"
+    coverage = "coverage"
     crashes = "crashes"
     inputs = "inputs"
-    readonly_inputs = "readonly_inputs"
-    unique_inputs = "unique_inputs"
-    coverage = "coverage"
-    reports = "reports"
-    unique_reports = "unique_reports"
     no_repro = "no_repro"
+    readonly_inputs = "readonly_inputs"
+    reports = "reports"
+    setup = "setup"
     tools = "tools"
-    analysis = "analysis"
+    unique_inputs = "unique_inputs"
+    unique_reports = "unique_reports"
+
+    @classmethod
+    def reset_defaults(cls) -> List["ContainerType"]:
+        return [
+            cls.analysis,
+            cls.coverage,
+            cls.crashes,
+            cls.inputs,
+            cls.no_repro,
+            cls.readonly_inputs,
+            cls.reports,
+            cls.setup,
+            cls.unique_reports,
+        ]
 
 
 class StatsFormat(Enum):


### PR DESCRIPTION
## Summary of the Pull Request

To reduce overload for scaling and for testing I need to delete particular set of container. Adding `container reset` cli argument.

## PR Checklist
* [ ] Applies to work item: #xxx
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/onefuzz) and sign the CLI.
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

Also, 
- changing `reset --containers` to call `containers reset`
- sorting types in `ContainerType`

## Validation Steps Performed

Manually tested.
