### PR TITLE
uninstall onefuzztypes and reinstall

### DIFF
--- a/src/ci/build_cli.ps1
+++ b/src/ci/build_cli.ps1
@@ -8,6 +8,8 @@ param (
 try { 
     Push-Location
 
+    pip uninstall onefuzztypes -y
+
     # Get Version and Replace versions
     if ($version -eq "$null") {
         $version = bash .\get-version.sh


### PR DESCRIPTION
## Summary of the Pull Request

I am observed while using `build_cli` if onefuzztypes is updated, installing of `onefuzztypes` is ignored. Therefore uninstalling to avoid spending related to it. 

## PR Checklist
* [ ] Applies to work item: #xxx
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/onefuzz) and sign the CLI.
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

Observed in PR #198 .

## Validation Steps Performed

manually tested.
