### PR TITLE
add missing telemetry relating to reports & tools

### DIFF
--- a/src/agent/onefuzz-agent/src/tasks/config.rs
+++ b/src/agent/onefuzz-agent/src/tasks/config.rs
@@ -109,7 +109,17 @@ impl Config {
             Config::GenericGenerator(_) => "generic_generator",
         };
 
-        event!(task_start; EventData::Type = event_type);
+        match self {
+            Config::GenericGenerator(c) => {
+                event!(task_start; EventData::Type = event_type, EventData::ToolName = c.generator_exe.clone());
+            }
+            Config::GenericAnalysis(c) => {
+                event!(task_start; EventData::Type = event_type, EventData::ToolName = c.analyzer_exe.clone());
+            }
+            _ => {
+                event!(task_start; EventData::Type = event_type);
+            }
+        }
     }
 
     pub async fn run(self) -> Result<()> {

--- a/src/agent/onefuzz-agent/src/tasks/report/crash_report.rs
+++ b/src/agent/onefuzz-agent/src/tasks/report/crash_report.rs
@@ -6,7 +6,9 @@ use onefuzz::{
     asan::AsanLog,
     blob::{BlobClient, BlobContainerUrl, BlobUrl},
     syncdir::SyncedDir,
+    telemetry::Event::{new_report, new_unable_to_reproduce, new_unique_report},
 };
+use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use uuid::Uuid;
@@ -58,16 +60,21 @@ async fn upload_deduped(report: &CrashReport, container: &BlobContainerUrl) -> R
     let blob = BlobClient::new();
     let deduped_name = report.unique_blob_name();
     let deduped_url = container.blob(deduped_name).url();
-    blob.put(deduped_url)
+    let result = blob
+        .put(deduped_url)
         .json(report)
         // Conditional PUT, only if-not-exists.
         .header("If-None-Match", "*")
         .send()
         .await?;
+    if result.status() != StatusCode::NOT_MODIFIED {
+        event!(new_unique_report;);
+    }
     Ok(())
 }
 
 async fn upload_report(report: &CrashReport, container: &BlobContainerUrl) -> Result<()> {
+    event!(new_report;);
     let blob = BlobClient::new();
     let url = container.blob(report.blob_name()).url();
     blob.put(url).json(report).send().await?;
@@ -75,8 +82,8 @@ async fn upload_report(report: &CrashReport, container: &BlobContainerUrl) -> Re
 }
 
 async fn upload_no_repro(report: &NoCrash, container: &BlobContainerUrl) -> Result<()> {
+    event!(new_unable_to_reproduce;);
     let blob = BlobClient::new();
-
     let url = container.blob(report.blob_name()).url();
     blob.put(url).json(report).send().await?;
     Ok(())

--- a/src/agent/onefuzz/src/telemetry.rs
+++ b/src/agent/onefuzz/src/telemetry.rs
@@ -19,6 +19,9 @@ pub enum Event {
     new_coverage,
     runtime_stats,
     process_stats,
+    new_report,
+    new_unique_report,
+    new_unable_to_reproduce,
 }
 
 impl Event {
@@ -30,6 +33,9 @@ impl Event {
             Self::new_result => "new_result",
             Self::runtime_stats => "runtime_stats",
             Self::process_stats => "process_stats",
+            Self::new_report => "new_report",
+            Self::new_unique_report => "new_unique_report",
+            Self::new_unable_to_reproduce => "new_unable_to_reproduce",
         }
     }
 }
@@ -64,6 +70,7 @@ pub enum EventData {
     CoveragePathsFound(u64),
     CoveragePathsImported(u64),
     CoverageMaxDepth(u64),
+    ToolName(String),
 }
 
 impl EventData {
@@ -97,6 +104,7 @@ impl EventData {
             Self::CoveragePathsImported(x) => ("coverage_paths_imported", x.to_string()),
             Self::CoverageMaxDepth(x) => ("coverage_paths_depth", x.to_string()),
             Self::Coverage(x) => ("coverage", x.to_string()),
+            Self::ToolName(x) => ("tool_name", x.to_owned()),
         }
     }
 
@@ -132,6 +140,7 @@ impl EventData {
             Self::CoveragePathsImported(_) => true,
             Self::CoverageMaxDepth(_) => true,
             Self::Coverage(_) => true,
+            Self::ToolName(_) => true,
         }
     }
 }


### PR DESCRIPTION
Adds the crash report & tool name telemetry already approved by CELA and documented in our telemetry guidance here:

https://github.com/microsoft/onefuzz/blob/main/docs/telemetry.md#data-recorded-by-agents