### PR TITLE
Use second-chance break on av on libfuzzer coverage extraction

### DIFF
--- a/src/agent/script/win64/libfuzzer-coverage/DumpCounters.js
+++ b/src/agent/script/win64/libfuzzer-coverage/DumpCounters.js
@@ -88,7 +88,7 @@ function dumpCounters(results_dir, sample_name) {
     execute(".restart");
 
     // Disable FCE from sanitizers.
-    execute("sxi av");
+    execute("sxd av");
 
     // Run to exit break in `ntdll!NtTerminateProcess`.
     execute("g");


### PR DESCRIPTION
This PR moves from ignoring AVs to handling them as second chance exceptions.  This allows letting the libfuzzer runtime based exceptions to continue, but still stopping during AVs not handled by libfuzzer.

See [sx, sxd, sxe, sxi, sxn, sxr, sx- (Set Exceptions)](https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/sx--sxd--sxe--sxi--sxn--sxr--sx---set-exceptions-#remarks) for more on exception handling.