### PR TITLE
include examples in SDK

### DIFF
--- a/src/cli/MANIFEST.in
+++ b/src/cli/MANIFEST.in
@@ -1,3 +1,4 @@
-LICENSE
+include LICENSE
 include *.txt
 include *.md
+graft examples


### PR DESCRIPTION
Adding the examples is needed to work towards making the CICD resources entirely self-contained in the build artifacts