### PR TITLE
report coverage total after batch processing

### DIFF
--- a/src/agent/onefuzz-agent/src/tasks/coverage/libfuzzer_coverage.rs
+++ b/src/agent/onefuzz-agent/src/tasks/coverage/libfuzzer_coverage.rs
@@ -105,6 +105,7 @@ impl CoverageTask {
             self.record_corpus_coverage(&mut processor, dir).await?;
             fs::remove_dir_all(&dir.path).await?;
         }
+        processor.report_total().await?;
         self.config.coverage.sync_push().await?;
 
         info!(


### PR DESCRIPTION
## Summary of the Pull Request

If a coverage task is started with a large number of inputs but no new coverage ever hits the task's input queue, the total coverage is never reported.

## Validation Steps Performed

Run a coverage task with a large number of inputs without a fuzzing task.  Notice that the total coverage is logged to app-insights.