### PR TITLE
disable sympath in libfuzzer_coverage extraction unless it's set via target_env

### DIFF
--- a/src/agent/onefuzz-agent/src/tasks/coverage/recorder.rs
+++ b/src/agent/onefuzz-agent/src/tasks/coverage/recorder.rs
@@ -128,10 +128,13 @@ impl CoverageRecorder {
             .join("libfuzzer-coverage")
             .join("DumpCounters.js");
 
+        let should_disable_sympath = !self.config.target_env.contains_key("_NT_SYMBOL_PATH");
+
         let cdb_cmd = format!(
-            ".scriptload {}; !dumpcounters {:?}; q",
+            ".scriptload {}; !dumpcounters {:?}, {}; q",
             script_path.to_string_lossy(),
-            output.to_string_lossy()
+            output.to_string_lossy(),
+            should_disable_sympath,
         );
 
         let mut cmd = Command::new("cdb.exe");

--- a/src/agent/script/win64/libfuzzer-coverage/DumpCounters.js
+++ b/src/agent/script/win64/libfuzzer-coverage/DumpCounters.js
@@ -83,7 +83,14 @@ function processModule(module, results_dir) {
     return true;
 }
 
-function dumpCounters(results_dir, sample_name) {
+function dumpCounters(results_dir, should_disable_sympath) {
+    if (should_disable_sympath == true) {
+        logln(`disabling sympath`);
+        execute('.sympath ""');
+    } else {
+        logln(`not disabling sympath`);
+    }
+
     // Reset to initial break in `ntdll!LdrpDoDebuggerBreak`.
     execute(".restart");
 
@@ -95,7 +102,7 @@ function dumpCounters(results_dir, sample_name) {
 
     let found = false;
     host.currentProcess.Modules.All(function (module) {
-        let result = processModule(module, results_dir, sample_name);
+        let result = processModule(module, results_dir);
         if (result) {
             found = true;
         }


### PR DESCRIPTION
## Summary of the Pull Request

Disables sympath used in cdb unless it's explicitly set via target_env.  This significantly improves the runtime performance of sancov extraction.

## Validation Steps Performed

Ran with `onefuzz-agent.exe debug libfuzzer-coverage`, once with `--target_env _NT_SYMBOL_PATH=c:\symbols` and once without.  Note that without is significantly faster.

## Follow on work
* Issue #220 tracks updating `libfuzzer_coverage` to support variable expansion appropriate.
* Issue #221 tracks updating variable expansion to support `{setup_dir}` such that the setup dir can be explicitly set.