### PR TITLE
Always use the get_*_account helper methods

### DIFF
--- a/src/api-service/__app__/onefuzzlib/proxy.py
+++ b/src/api-service/__app__/onefuzzlib/proxy.py
@@ -5,7 +5,6 @@
 
 import datetime
 import logging
-import os
 from typing import List, Optional, Tuple
 
 from azure.mgmt.compute.models import VirtualMachine
@@ -23,6 +22,7 @@ from pydantic import Field
 from .__version__ import __version__
 from .azure.auth import build_auth
 from .azure.containers import get_file_sas_url, save_blob
+from .azure.creds import get_func_storage
 from .azure.ip import get_public_ip
 from .azure.queue import get_queue_sas
 from .azure.vm import VM
@@ -191,12 +191,12 @@ class Proxy(ORMMixin):
             url=get_file_sas_url(
                 "proxy-configs",
                 "%s/config.json" % self.region,
-                account_id=os.environ["ONEFUZZ_FUNC_STORAGE"],
+                account_id=get_func_storage(),
                 read=True,
             ),
             notification=get_queue_sas(
                 "proxy",
-                account_id=os.environ["ONEFUZZ_FUNC_STORAGE"],
+                account_id=get_func_storage(),
                 add=True,
             ),
             forwards=forwards,
@@ -207,7 +207,7 @@ class Proxy(ORMMixin):
             "proxy-configs",
             "%s/config.json" % self.region,
             proxy_config.json(),
-            account_id=os.environ["ONEFUZZ_FUNC_STORAGE"],
+            account_id=get_func_storage(),
         )
 
     @classmethod

--- a/src/api-service/__app__/onefuzzlib/tasks/config.py
+++ b/src/api-service/__app__/onefuzzlib/tasks/config.py
@@ -12,7 +12,7 @@ from onefuzztypes.enums import Compare, ContainerPermission, ContainerType, Task
 from onefuzztypes.models import TaskConfig, TaskDefinition, TaskUnitConfig
 
 from ..azure.containers import blob_exists, container_exists, get_container_sas_url
-from ..azure.creds import get_fuzz_storage, get_instance_url
+from ..azure.creds import get_func_storage, get_fuzz_storage, get_instance_url
 from ..azure.queue import get_queue_sas
 from .defs import TASK_DEFINITIONS
 
@@ -183,7 +183,7 @@ def build_task_config(
         telemetry_key=os.environ.get("ONEFUZZ_TELEMETRY"),
         heartbeat_queue=get_queue_sas(
             "task-heartbeat",
-            account_id=os.environ["ONEFUZZ_FUNC_STORAGE"],
+            account_id=get_func_storage(),
             add=True,
         ),
         back_channel_address="https://%s/api/back_channel" % (get_instance_url()),

--- a/src/api-service/__app__/pool/__init__.py
+++ b/src/api-service/__app__/pool/__init__.py
@@ -12,7 +12,12 @@ from onefuzztypes.models import AgentConfig, Error
 from onefuzztypes.requests import PoolCreate, PoolSearch, PoolStop
 from onefuzztypes.responses import BoolResult
 
-from ..onefuzzlib.azure.creds import get_base_region, get_instance_url, get_regions
+from ..onefuzzlib.azure.creds import (
+    get_base_region,
+    get_func_storage,
+    get_instance_url,
+    get_regions,
+)
 from ..onefuzzlib.azure.queue import get_queue_sas
 from ..onefuzzlib.azure.vmss import list_available_skus
 from ..onefuzzlib.pools import Pool
@@ -27,7 +32,7 @@ def set_config(pool: Pool) -> Pool:
         telemetry_key=os.environ.get("ONEFUZZ_TELEMETRY"),
         heartbeat_queue=get_queue_sas(
             "node-heartbeat",
-            account_id=os.environ["ONEFUZZ_FUNC_STORAGE"],
+            account_id=get_func_storage(),
             add=True,
         ),
     )

--- a/src/api-service/__app__/queue_file_changes/__init__.py
+++ b/src/api-service/__app__/queue_file_changes/__init__.py
@@ -5,11 +5,11 @@
 
 import json
 import logging
-import os
 from typing import Dict
 
 import azure.functions as func
 
+from ..onefuzzlib.azure.creds import get_fuzz_storage
 from ..onefuzzlib.dashboard import get_event
 from ..onefuzzlib.notifications.main import new_files
 
@@ -25,7 +25,7 @@ def file_added(event: Dict) -> None:
 def main(msg: func.QueueMessage, dashboard: func.Out[str]) -> None:
     event = json.loads(msg.get_body())
 
-    if event["topic"] != os.environ["ONEFUZZ_DATA_STORAGE"]:
+    if event["topic"] != get_fuzz_storage():
         return
 
     if event["eventType"] != "Microsoft.Storage.BlobCreated":


### PR DESCRIPTION
## Summary of the Pull Request

This updates the rest of the python code not yet already touched to use the get_func_storage and get_fuzz_storage helper methods.

## Validation Steps Performed

Standard integration testing