### PR TITLE
Updated deploy-onefuzz-via-azure-devops

### DIFF
--- a/contrib/deploy-onefuzz-via-azure-devops/deploy-onefuzz.yml
+++ b/contrib/deploy-onefuzz-via-azure-devops/deploy-onefuzz.yml
@@ -9,20 +9,20 @@
 # to deploy OneFuzz on Azure.
 #
 # List of custom variables:
-# | Variable Name        | Comments                                                  |
-# |----------------------|-----------------------------------------------------------|
-# |AZURE_CLIENT_ID       | The appication ID created by you or the deployment script |
-# |AZURE_CLIENT_SECRET   | Secret created by App registration process                |
-# |AZURE_TENANT_ID       | Tenant ID of the Azure Subscription                       |
-# |CONTACT_EMAIL_ADDRESS | Email address for communication                           |
-# |ONEFUZZ_DEPLOY_LOC    | Deployment Folder location of this script location        |
-# |ONEFUZZ_INSTANCE_NAME | Instance name of Onefuzz Deployement                      |
-# |ONEFUZZ_SERVICE_URL   | OneFuzz service URL. Generally the url defined in App     |
-# |                      | Registration                                              |
-# |REGION                | OneFuzz Region (prefer westus2)                           |
-# |RESOURCE_GROUP_NAME   | Resource gorup name for OneFuzz deployment                |
-# |VERSION               | Specify OneFuzz version or do not set to get latest       |
-# |DEPLOY_ARGS           | Specify optional OneFuzz deploy.py arguments              |
+# | Variable Name        | Comments                                                  | Required/Optional |
+# |----------------------|-----------------------------------------------------------|-------------------|
+# |AZURE_CLIENT_ID       | The appication ID created by you or the deployment script | Required          |
+# |AZURE_CLIENT_SECRET   | Secret created by App registration process                | Required          |
+# |AZURE_TENANT_ID       | Tenant ID of the Azure Subscription                       | Required          |
+# |CONTACT_EMAIL_ADDRESS | Email address for communication                           | Required          |
+# |DEPLOY_ARGS           | Specify OneFuzz deploy.py arguments                       | Optional          |
+# |ONEFUZZ_DEPLOY_LOC    | Deployment Folder location of this script location        | Required          |
+# |ONEFUZZ_INSTANCE_NAME | Instance name of Onefuzz Deployement                      | Required          |
+# |ONEFUZZ_SERVICE_URL   | OneFuzz service URL. Generally the url defined in App     | Required          |
+# |                      | Registration                                              | Required          |
+# |REGION                | OneFuzz Region (prefer westus2)                           | Required          |
+# |RESOURCE_GROUP_NAME   | Resource group name for OneFuzz deployment                | Required          |
+# |VERSION               | Specify OneFuzz version, defaults to latest               | Optional          |
 #
 # Note: Make sure to provide the App owners permission to onefuzz resource group
 

--- a/contrib/deploy-onefuzz-via-azure-devops/deploy-onefuzz.yml
+++ b/contrib/deploy-onefuzz-via-azure-devops/deploy-onefuzz.yml
@@ -22,7 +22,7 @@
 # |                      | Registration                                              | Required          |
 # |REGION                | OneFuzz Region (prefer westus2)                           | Required          |
 # |RESOURCE_GROUP_NAME   | Resource group name for OneFuzz deployment                | Required          |
-# |VERSION               | Specify OneFuzz version, defaults to latest               | Optional          |
+# |VERSION               | Specify OneFuzz version. Default is latest.               | Optional          |
 #
 # Note: Make sure to provide the App owners permission to onefuzz resource group
 

--- a/contrib/deploy-onefuzz-via-azure-devops/deploy-onefuzz.yml
+++ b/contrib/deploy-onefuzz-via-azure-devops/deploy-onefuzz.yml
@@ -20,8 +20,9 @@
 # |ONEFUZZ_SERVICE_URL   | OneFuzz service URL. Generally the url defined in App     |
 # |                      | Registration                                              |
 # |REGION                | OneFuzz Region (prefer westus2)                           |
-# |RESOURCE_GROUP_NAME   | Resource group name for OneFuzz deployment                |
-# |VERSION               | Specify OneFuzz version or do not set to get latest       |                      
+# |RESOURCE_GROUP_NAME   | Resource gorup name for OneFuzz deployment                |
+# |VERSION               | Specify OneFuzz version or do not set to get latest       |
+# |DEPLOY_ARGS           | Specify optional OneFuzz deploy.py arguments              |
 #
 # Note: Make sure to provide the App owners permission to onefuzz resource group
 
@@ -81,7 +82,12 @@ stages:
             script: |
               set -ex
               az login --service-principal -u $(ONEFUZZ_SERVICE_URL) -p $(AZURE_CLIENT_SECRET) --tenant $(AZURE_TENANT_ID)
-              python deploy.py --client_id $(AZURE_CLIENT_ID) --client_secret $(AZURE_CLIENT_SECRET) $REGION $RESOURCE_GROUP_NAME $ONEFUZZ_INSTANCE_NAME $CONTACT_EMAIL_ADDRESS
+              if [ -z ${DEPLOY_ARGS+x} ]
+              then
+                python deploy.py --client_id $(AZURE_CLIENT_ID) --client_secret $(AZURE_CLIENT_SECRET) $REGION $RESOURCE_GROUP_NAME $ONEFUZZ_INSTANCE_NAME $CONTACT_EMAIL_ADDRESS
+              else
+                python deploy.py --client_id $(AZURE_CLIENT_ID) --client_secret $(AZURE_CLIENT_SECRET) $REGION $RESOURCE_GROUP_NAME $ONEFUZZ_INSTANCE_NAME $CONTACT_EMAIL_ADDRESS "${DEPLOY_ARGS)"
+              fi
               echo "Deployed Onefuzz $(onefuzz_release.version)"
 
         - task: CopyFiles@2

--- a/contrib/deploy-onefuzz-via-azure-devops/deploy-onefuzz.yml
+++ b/contrib/deploy-onefuzz-via-azure-devops/deploy-onefuzz.yml
@@ -86,7 +86,7 @@ stages:
               then
                 python deploy.py --client_id $(AZURE_CLIENT_ID) --client_secret $(AZURE_CLIENT_SECRET) $REGION $RESOURCE_GROUP_NAME $ONEFUZZ_INSTANCE_NAME $CONTACT_EMAIL_ADDRESS
               else
-                python deploy.py --client_id $(AZURE_CLIENT_ID) --client_secret $(AZURE_CLIENT_SECRET) $REGION $RESOURCE_GROUP_NAME $ONEFUZZ_INSTANCE_NAME $CONTACT_EMAIL_ADDRESS "$(DEPLOY_ARGS)"
+                python deploy.py --client_id $(AZURE_CLIENT_ID) --client_secret $(AZURE_CLIENT_SECRET) $REGION $RESOURCE_GROUP_NAME $ONEFUZZ_INSTANCE_NAME $CONTACT_EMAIL_ADDRESS $(DEPLOY_ARGS)
               fi
               echo "Deployed Onefuzz $(onefuzz_release.version)"
 
@@ -128,4 +128,3 @@ stages:
             ./onefuzz-cli-$(version).exe config --endpoint $(ONEFUZZ_SERVICE_URL) --client_id "$(AZURE_CLIENT_ID)" --client_secret "$(AZURE_CLIENT_SECRET)"
             ./onefuzz-cli-$(version).exe --version
             until ./onefuzz-cli-$(version).exe versions check --exact; do echo "waiting due to version mismatch"; sleep 1; done
-

--- a/contrib/deploy-onefuzz-via-azure-devops/deploy-onefuzz.yml
+++ b/contrib/deploy-onefuzz-via-azure-devops/deploy-onefuzz.yml
@@ -86,7 +86,7 @@ stages:
               then
                 python deploy.py --client_id $(AZURE_CLIENT_ID) --client_secret $(AZURE_CLIENT_SECRET) $REGION $RESOURCE_GROUP_NAME $ONEFUZZ_INSTANCE_NAME $CONTACT_EMAIL_ADDRESS
               else
-                python deploy.py --client_id $(AZURE_CLIENT_ID) --client_secret $(AZURE_CLIENT_SECRET) $REGION $RESOURCE_GROUP_NAME $ONEFUZZ_INSTANCE_NAME $CONTACT_EMAIL_ADDRESS "${DEPLOY_ARGS)"
+                python deploy.py --client_id $(AZURE_CLIENT_ID) --client_secret $(AZURE_CLIENT_SECRET) $REGION $RESOURCE_GROUP_NAME $ONEFUZZ_INSTANCE_NAME $CONTACT_EMAIL_ADDRESS "$(DEPLOY_ARGS)"
               fi
               echo "Deployed Onefuzz $(onefuzz_release.version)"
 
@@ -128,3 +128,4 @@ stages:
             ./onefuzz-cli-$(version).exe config --endpoint $(ONEFUZZ_SERVICE_URL) --client_id "$(AZURE_CLIENT_ID)" --client_secret "$(AZURE_CLIENT_SECRET)"
             ./onefuzz-cli-$(version).exe --version
             until ./onefuzz-cli-$(version).exe versions check --exact; do echo "waiting due to version mismatch"; sleep 1; done
+

--- a/contrib/deploy-onefuzz-via-azure-devops/deploy-onefuzz.yml
+++ b/contrib/deploy-onefuzz-via-azure-devops/deploy-onefuzz.yml
@@ -9,20 +9,20 @@
 # to deploy OneFuzz on Azure.
 #
 # List of custom variables:
-# | Variable Name        | Comments                                                  |
-# |----------------------|-----------------------------------------------------------|
-# |AZURE_CLIENT_ID       | The appication ID created by you or the deployment script |
-# |AZURE_CLIENT_SECRET   | Secret created by App registration process                |
-# |AZURE_TENANT_ID       | Tenant ID of the Azure Subscription                       |
-# |CONTACT_EMAIL_ADDRESS | Email address for communication                           |
-# |ONEFUZZ_DEPLOY_LOC    | Deployment Folder location of this script location        |
-# |ONEFUZZ_INSTANCE_NAME | Instance name of Onefuzz Deployement                      |
-# |ONEFUZZ_SERVICE_URL   | OneFuzz service URL. Generally the url defined in App     |
-# |                      | Registration                                              |
-# |REGION                | OneFuzz Region (prefer westus2)                           |
-# |RESOURCE_GROUP_NAME   | Resource group name for OneFuzz deployment                |
-# |VERSION               | Specify OneFuzz version or do not set to get latest       |
-# |DEPLOY_ARGS           | Specify optional OneFuzz deploy.py arguments              |
+# | Variable Name        | Comments                                                  | Required/Optional |
+# |----------------------|-----------------------------------------------------------|-------------------|
+# |AZURE_CLIENT_ID       | The appication ID created by you or the deployment script | Required          |
+# |AZURE_CLIENT_SECRET   | Secret created by App registration process                | Required          |
+# |AZURE_TENANT_ID       | Tenant ID of the Azure Subscription                       | Required          |
+# |CONTACT_EMAIL_ADDRESS | Email address for communication                           | Required          |
+# |DEPLOY_ARGS           | Specify OneFuzz deploy.py arguments                       | Optional          |
+# |ONEFUZZ_DEPLOY_LOC    | Deployment Folder location of this script location        | Required          |
+# |ONEFUZZ_INSTANCE_NAME | Instance name of Onefuzz Deployement                      | Required          |
+# |ONEFUZZ_SERVICE_URL   | OneFuzz service URL. Generally the url defined in App     | Required          |
+# |                      | Registration                                              | Required          |
+# |REGION                | OneFuzz Region (prefer westus2)                           | Required          |
+# |RESOURCE_GROUP_NAME   | Resource group name for OneFuzz deployment                | Required          |
+# |VERSION               | Specify OneFuzz version, defaults to latest               | Optional          |
 #
 # Note: Make sure to provide the App owners permission to onefuzz resource group
 

--- a/contrib/deploy-onefuzz-via-azure-devops/deploy-onefuzz.yml
+++ b/contrib/deploy-onefuzz-via-azure-devops/deploy-onefuzz.yml
@@ -20,7 +20,7 @@
 # |ONEFUZZ_SERVICE_URL   | OneFuzz service URL. Generally the url defined in App     |
 # |                      | Registration                                              |
 # |REGION                | OneFuzz Region (prefer westus2)                           |
-# |RESOURCE_GROUP_NAME   | Resource gorup name for OneFuzz deployment                |
+# |RESOURCE_GROUP_NAME   | Resource group name for OneFuzz deployment                |
 # |VERSION               | Specify OneFuzz version or do not set to get latest       |
 # |DEPLOY_ARGS           | Specify optional OneFuzz deploy.py arguments              |
 #

--- a/contrib/deploy-onefuzz-via-azure-devops/deploy-onefuzz.yml
+++ b/contrib/deploy-onefuzz-via-azure-devops/deploy-onefuzz.yml
@@ -20,7 +20,8 @@
 # |ONEFUZZ_SERVICE_URL   | OneFuzz service URL. Generally the url defined in App     |
 # |                      | Registration                                              |
 # |REGION                | OneFuzz Region (prefer westus2)                           |
-# |RESOURCE_GROUP_NAME   | Resource gorup name for OneFuzz deployment                |                        
+# |RESOURCE_GROUP_NAME   | Resource group name for OneFuzz deployment                |
+# |VERSION               | Specify OneFuzz version or do not set to get latest       |                      
 #
 # Note: Make sure to provide the App owners permission to onefuzz resource group
 
@@ -48,8 +49,14 @@ stages:
               python -m pip install pipenv tox
               pipenv install
               artifact="artifact"
-              pipenv run python get_latest_version.py -path $artifact
-              version="$(pipenv run python get_latest_version.py -version)"
+              if [ -z ${VERSION+x} ]
+              then
+                pipenv run python get_latest_version.py -path $artifact
+                version="$(pipenv run python get_latest_version.py -display_latest_version)"
+              else
+                pipenv run python get_latest_version.py -path $artifact -version $(VERSION)
+                version="$(VERSION)"
+              fi
               echo "Onefuzz version is $version"
               echo "##vso[task.setvariable variable=version;isOutput=true]$version"
               echo "##vso[task.setvariable variable=artifact]$artifact"

--- a/contrib/deploy-onefuzz-via-azure-devops/deploy-onefuzz.yml
+++ b/contrib/deploy-onefuzz-via-azure-devops/deploy-onefuzz.yml
@@ -9,20 +9,20 @@
 # to deploy OneFuzz on Azure.
 #
 # List of custom variables:
-# | Variable Name        | Comments                                                  | Required/Optional |
-# |----------------------|-----------------------------------------------------------|-------------------|
-# |AZURE_CLIENT_ID       | The appication ID created by you or the deployment script | Required          |
-# |AZURE_CLIENT_SECRET   | Secret created by App registration process                | Required          |
-# |AZURE_TENANT_ID       | Tenant ID of the Azure Subscription                       | Required          |
-# |CONTACT_EMAIL_ADDRESS | Email address for communication                           | Required          |
-# |DEPLOY_ARGS           | Specify OneFuzz deploy.py arguments                       | Optional          |
-# |ONEFUZZ_DEPLOY_LOC    | Deployment Folder location of this script location        | Required          |
-# |ONEFUZZ_INSTANCE_NAME | Instance name of Onefuzz Deployement                      | Required          |
-# |ONEFUZZ_SERVICE_URL   | OneFuzz service URL. Generally the url defined in App     | Required          |
-# |                      | Registration                                              | Required          |
-# |REGION                | OneFuzz Region (prefer westus2)                           | Required          |
-# |RESOURCE_GROUP_NAME   | Resource group name for OneFuzz deployment                | Required          |
-# |VERSION               | Specify OneFuzz version. Default is latest.               | Optional          |
+# | Variable Name        | Comments                                                  |
+# |----------------------|-----------------------------------------------------------|
+# |AZURE_CLIENT_ID       | The appication ID created by you or the deployment script |
+# |AZURE_CLIENT_SECRET   | Secret created by App registration process                |
+# |AZURE_TENANT_ID       | Tenant ID of the Azure Subscription                       |
+# |CONTACT_EMAIL_ADDRESS | Email address for communication                           |
+# |ONEFUZZ_DEPLOY_LOC    | Deployment Folder location of this script location        |
+# |ONEFUZZ_INSTANCE_NAME | Instance name of Onefuzz Deployement                      |
+# |ONEFUZZ_SERVICE_URL   | OneFuzz service URL. Generally the url defined in App     |
+# |                      | Registration                                              |
+# |REGION                | OneFuzz Region (prefer westus2)                           |
+# |RESOURCE_GROUP_NAME   | Resource gorup name for OneFuzz deployment                |
+# |VERSION               | Specify OneFuzz version or do not set to get latest       |
+# |DEPLOY_ARGS           | Specify optional OneFuzz deploy.py arguments              |
 #
 # Note: Make sure to provide the App owners permission to onefuzz resource group
 
@@ -50,7 +50,7 @@ stages:
               python -m pip install pipenv tox
               pipenv install
               artifact="artifact"
-              if [ -z ${VERSION+x} ]
+              if [ -z $(VERSION) ]
               then
                 pipenv run python get_latest_version.py -path $artifact
                 version="$(pipenv run python get_latest_version.py -display_latest_version)"
@@ -82,12 +82,7 @@ stages:
             script: |
               set -ex
               az login --service-principal -u $(ONEFUZZ_SERVICE_URL) -p $(AZURE_CLIENT_SECRET) --tenant $(AZURE_TENANT_ID)
-              if [ -z ${DEPLOY_ARGS+x} ]
-              then
-                python deploy.py --client_id $(AZURE_CLIENT_ID) --client_secret $(AZURE_CLIENT_SECRET) $REGION $RESOURCE_GROUP_NAME $ONEFUZZ_INSTANCE_NAME $CONTACT_EMAIL_ADDRESS
-              else
-                python deploy.py --client_id $(AZURE_CLIENT_ID) --client_secret $(AZURE_CLIENT_SECRET) $REGION $RESOURCE_GROUP_NAME $ONEFUZZ_INSTANCE_NAME $CONTACT_EMAIL_ADDRESS $(DEPLOY_ARGS)
-              fi
+              python deploy.py --client_id $(AZURE_CLIENT_ID) --client_secret $(AZURE_CLIENT_SECRET) $REGION $RESOURCE_GROUP_NAME $ONEFUZZ_INSTANCE_NAME $CONTACT_EMAIL_ADDRESS $DEPLOY_ARGS
               echo "Deployed Onefuzz $(onefuzz_release.version)"
 
         - task: CopyFiles@2

--- a/contrib/deploy-onefuzz-via-azure-devops/get_latest_version.py
+++ b/contrib/deploy-onefuzz-via-azure-devops/get_latest_version.py
@@ -42,10 +42,7 @@ class Onefuzz:
             self.download_artifact(path, artifact["id"], artifact["name"])
 
     def onefuzz_release_artifacts(self, path, version):
-        if version is not None:
-            release_id = self.get_release_id_by_name(version)
-        else:
-            release_id = self.get_release_id_by_name()
+        release_id = self.get_release_id_by_name(version)
         artifacts = self.list_assets(release_id)
         self.download_artifacts(path, artifacts)
 

--- a/contrib/deploy-onefuzz-via-azure-devops/get_latest_version.py
+++ b/contrib/deploy-onefuzz-via-azure-devops/get_latest_version.py
@@ -15,8 +15,11 @@ class Onefuzz:
         latest_release = requests.get(f"{BASE_URL}/releases/latest").json()
         return latest_release["name"]
 
-    def get_release_id_by_name(self, version_name):
-        release = requests.get(f"{BASE_URL}/releases/tags/{version_name}").json()
+    def get_release_id_by_name(self, version_name=None):
+        if version_name is None:
+            release = requests.get(f"{BASE_URL}/releases/releases/latest").json()
+        else:
+            release = requests.get(f"{BASE_URL}/releases/tags/{version_name}").json()
         return release["id"]
 
     def list_assets(self, release_id):
@@ -42,7 +45,7 @@ class Onefuzz:
         if version is not None:
             release_id = self.get_release_id_by_name(version)
         else:
-            release_id = self.get_release_id_by_name("latest")
+            release_id = self.get_release_id_by_name()
         artifacts = self.list_assets(release_id)
         self.download_artifacts(path, artifacts)
 

--- a/contrib/deploy-onefuzz-via-azure-devops/get_latest_version.py
+++ b/contrib/deploy-onefuzz-via-azure-devops/get_latest_version.py
@@ -11,9 +11,13 @@ BASE_URL = "https://api.github.com/repos/microsoft/onefuzz"
 
 
 class Onefuzz:
-    def get_latest_version(self):
-        latest_releasee = requests.get(f"{BASE_URL}/releases/latest").json()
-        return (latest_releasee["id"], latest_releasee["name"])
+    def get_latest_version_name(self):
+        latest_release = requests.get(f"{BASE_URL}/releases/latest").json()
+        return latest_release["name"]
+
+    def get_release_id_by_name(self, version_name):
+        release = requests.get(f"{BASE_URL}/releases/tags/{version_name}").json()
+        return release["id"]
 
     def list_assets(self, release_id):
         assets = requests.get(f"{BASE_URL}/releases/{release_id}/assets").json()
@@ -34,8 +38,11 @@ class Onefuzz:
         for artifact in artifacts:
             self.download_artifact(path, artifact["id"], artifact["name"])
 
-    def onefuzz_release_artifacts(self, path):
-        release_id, _ = self.get_latest_version()
+    def onefuzz_release_artifacts(self, path, version):
+        if version is not None:
+            release_id = self.get_release_id_by_name(version)
+        else:
+            release_id = self.get_release_id_by_name("latest")
         artifacts = self.list_assets(release_id)
         self.download_artifacts(path, artifacts)
 
@@ -55,16 +62,22 @@ def main():
     )
     parser.add_argument(
         "-version",
+        type=str,
+        default=None,
+        help="Get specific Onefuzz version",
+    )
+    parser.add_argument(
+        "-display_latest_version",
         action="store_true",
         help="Get Onefuzz latest version",
     )
 
     args = parser.parse_args()
     if args.path:
-        Onefuzz().onefuzz_release_artifacts(args.path)
+        Onefuzz().onefuzz_release_artifacts(args.path, args.version)
 
-    if args.version:
-        print(Onefuzz().get_latest_version()[1])
+    if args.display_latest_version:
+        print(Onefuzz().get_latest_version_name())
 
 
 if __name__ == "__main__":

--- a/contrib/deploy-onefuzz-via-azure-devops/get_latest_version.py
+++ b/contrib/deploy-onefuzz-via-azure-devops/get_latest_version.py
@@ -17,7 +17,7 @@ class Onefuzz:
 
     def get_release_id_by_name(self, version_name=None):
         if version_name is None:
-            release = requests.get(f"{BASE_URL}/releases/releases/latest").json()
+            release = requests.get(f"{BASE_URL}/releases/latest").json()
         else:
             release = requests.get(f"{BASE_URL}/releases/tags/{version_name}").json()
         return release["id"]


### PR DESCRIPTION
## Summary of the Pull Request

(1)
Updated 'contrib' submodule to allow user to optionally specify OneFuzz version to deploy. 

(2)
Updated 'contrib' submodule to allow user to optionally specify deploy.py arguments, e.g. --export_appinsights.

(3)
Fixed a minor typo in line 23 of deploy-onefuzz.yml for 'gorup' name. 

## PR Checklist
* [X] Applies to work item: #232 
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/onefuzz) and sign the CLI.
* [X] Tests added/passed
* [X] Requires documentation to be updated
* [ ] I've discussed this with core contributors already.

## Info on Pull Request

Updated deploy-onefuzz-via-azure-devops to allow user to specify version

## Validation Steps Performed

I verified the Pipeline works like it did before I made any changes plus if you specify 'VERSION' then it'll deploy that version of OneFuzz. As well as if DEPLOY_ARGS are provided or not. 
