### PR TITLE
Adding version as a param to dev-deploy script

### DIFF
--- a/src/api-service/dev-deploy.ps1
+++ b/src/api-service/dev-deploy.ps1
@@ -7,10 +7,10 @@ param (
     # Specifying version for function
     [Parameter(Mandatory = $false)]
     [string]
-    $version
+    $version = "0.0.0"
 )
 
-try { 
+try {
     Push-Location
     Set-Location "$app_dir/../pytypes"
     python setup.py sdist bdist_wheel 
@@ -19,13 +19,9 @@ try {
     Set-Location __app__
     (New-Guid).Guid | Out-File onefuzzlib/build.id -Encoding ascii
     (Get-Content -path "requirements.txt") -replace 'onefuzztypes==0.0.0', './onefuzztypes-0.0.0-py3-none-any.whl' | Out-File "requirements.txt"
-    if ($version -ne "$null") {
-        (Get-Content -path "onefuzzlib/__version__.py") -replace '__version__ = "0.0.0"', "__version__ = ""$version""" | Out-File "onefuzzlib/__version__.py" -Encoding utf8
-    }
+    (Get-Content -path "onefuzzlib/__version__.py") -replace '__version__ = "0.0.0"', "__version__ = ""$version""" | Out-File "onefuzzlib/__version__.py" -Encoding utf8
     func azure functionapp publish $target --python
-    if ($version -ne "$null") {
-        (Get-Content -path "onefuzzlib/__version__.py") -replace "__version__ = ""$version""", '__version__ = "0.0.0"' | Out-File "onefuzzlib/__version__.py" -Encoding utf8
-    }
+    (Get-Content -path "onefuzzlib/__version__.py") -replace "__version__ = ""$version""", '__version__ = "0.0.0"' | Out-File "onefuzzlib/__version__.py" -Encoding utf8
     (Get-Content -path "requirements.txt") -replace './onefuzztypes-0.0.0-py3-none-any.whl', 'onefuzztypes==0.0.0' | Out-File "requirements.txt"
     Remove-Item 'onefuzztypes-*-py3-none-any.whl'
     Get-Content 'onefuzzlib/build.id'


### PR DESCRIPTION
## Summary of the Pull Request

Adding version as a param to dev-deploy script

## PR Checklist
* [ ] Applies to work item: #xxx
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/onefuzz) and sign the CLI.
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

I have to modify `__version__.py` many times and sometimes goes into commit. Adding version in script will give more flexibility for dev working on windows and function app.

Also, I have to delete bunch of `onefuzztypes-*-py3-none-any.whl`. Therefore, using regex now to delete them.

## Validation Steps Performed

manually tested.
