### PR TITLE
fix reading instance_id on follow-on deploy

### DIFF
--- a/src/deployment/deploy.py
+++ b/src/deployment/deploy.py
@@ -480,7 +480,7 @@ class Client:
         blob_client = client.get_blob_client(container_name, blob_name)
         if blob_client.exists():
             logger.debug("instance_id already exists")
-            instance_id = uuid.UUID(blob_client.download_blob().readall())
+            instance_id = uuid.UUID(blob_client.download_blob().readall().decode())
         else:
             logger.debug("creating new instance_id")
             instance_id = uuid.uuid4()


### PR DESCRIPTION
Fixes the following exception introduced in #245

```
INFO:deploy:checking if RBAC already exists
INFO:deploy:deploying arm template: azuredeploy.json
INFO:deploy:assigning the user managed identity role
INFO:deploy:creating eventgrid destination queue
INFO:deploy:creating eventgrid subscription
INFO:deploy:uploading tools from tools
INFO:deploy:setting instance_id log export
Traceback (most recent call last):
  File "deploy.py", line 842, in <module>
    main()
  File "deploy.py", line 836, in main
    state[1](client)
  File "deploy.py", line 483, in add_instance_id
    instance_id = uuid.UUID(blob_client.download_blob().readall())
  File "/usr/lib/python3.8/uuid.py", line 166, in __init__
    hex = hex.replace('urn:', '').replace('uuid:', '')
TypeError: a bytes-like object is required, not 'str'
```