### PR TITLE
default TTL for queued messages to infinite

### DIFF
--- a/src/api-service/__app__/onefuzzlib/azure/queue.py
+++ b/src/api-service/__app__/onefuzzlib/azure/queue.py
@@ -102,11 +102,17 @@ def send_message(
     message: bytes,
     *,
     account_id: str,
+    visibility_timeout: Optional[int] = None,
+    time_to_live: int = -1,
 ) -> None:
     queue = get_queue(name, account_id=account_id)
     if queue:
         try:
-            queue.send_message(base64.b64encode(message).decode())
+            queue.send_message(
+                base64.b64encode(message).decode(),
+                visibility_timeout=visibility_timeout,
+                time_to_live=time_to_live,
+            )
         except ResourceNotFoundError:
             pass
 
@@ -163,6 +169,7 @@ def queue_object(
     *,
     account_id: str,
     visibility_timeout: Optional[int] = None,
+    time_to_live: int = -1,
 ) -> bool:
     queue = get_queue(name, account_id=account_id)
     if not queue:
@@ -170,7 +177,9 @@ def queue_object(
 
     encoded = base64.b64encode(message.json(exclude_none=True).encode()).decode()
     try:
-        queue.send_message(encoded, visibility_timeout=visibility_timeout)
+        queue.send_message(
+            encoded, visibility_timeout=visibility_timeout, time_to_live=time_to_live
+        )
         return True
     except ResourceNotFoundError:
         return False

--- a/src/api-service/__app__/onefuzzlib/azure/queue.py
+++ b/src/api-service/__app__/onefuzzlib/azure/queue.py
@@ -23,6 +23,8 @@ from .creds import get_storage_account_name_key
 
 QueueNameType = Union[str, UUID]
 
+DEFAULT_TTL = -1
+
 
 @cached(ttl=60)
 def get_queue_client(account_id: str) -> QueueServiceClient:
@@ -103,7 +105,7 @@ def send_message(
     *,
     account_id: str,
     visibility_timeout: Optional[int] = None,
-    time_to_live: int = -1,
+    time_to_live: int = DEFAULT_TTL,
 ) -> None:
     queue = get_queue(name, account_id=account_id)
     if queue:
@@ -169,7 +171,7 @@ def queue_object(
     *,
     account_id: str,
     visibility_timeout: Optional[int] = None,
-    time_to_live: int = -1,
+    time_to_live: int = DEFAULT_TTL,
 ) -> bool:
     queue = get_queue(name, account_id=account_id)
     if not queue:


### PR DESCRIPTION
## Summary of the Pull Request

Sets the default TTL for queue message to infinite (rather than 7 days). 

Currently, storage queues are used for managing scheduled tasks.  If a task is not scheduled for 7 days, the entry for the task expires from the queue leaving the task as Scheduled forever.

## Info on Pull Request

This PR also aligns the API to between send_message and queue_object.

## Validation Steps Performed

Standard integration tests