### PR TITLE
Make supervisor heartbeat only fire on main loop progress

### DIFF
--- a/src/agent/onefuzz-agent/src/tasks/heartbeat.rs
+++ b/src/agent/onefuzz-agent/src/tasks/heartbeat.rs
@@ -68,7 +68,7 @@ pub trait HeartbeatSender {
 
     fn alive(&self) {
         if let Err(error) = self.send(HeartbeatData::TaskAlive) {
-            error!("{}", error);
+            error!("failed to send heartbeat: {}", error);
         }
     }
 }

--- a/src/agent/onefuzz-agent/src/tasks/heartbeat.rs
+++ b/src/agent/onefuzz-agent/src/tasks/heartbeat.rs
@@ -48,8 +48,7 @@ pub async fn init_task_heartbeat(queue_url: Url, task_id: Uuid) -> Result<TaskHe
             let machine_id = context.state.machine_id;
             let machine_name = context.state.machine_name.clone();
 
-            let data =
-                HeartbeatClient::<TaskContext, _>::drain_current_messages(context.clone());
+            let data = HeartbeatClient::<TaskContext, _>::drain_current_messages(context.clone());
             let _ = context
                 .queue_client
                 .enqueue(Heartbeat {

--- a/src/agent/onefuzz-agent/src/tasks/heartbeat.rs
+++ b/src/agent/onefuzz-agent/src/tasks/heartbeat.rs
@@ -64,26 +64,24 @@ pub async fn init_task_heartbeat(queue_url: Url, task_id: Uuid) -> Result<TaskHe
 }
 
 pub trait HeartbeatSender {
-    fn send(&self, data: HeartbeatData) -> Result<()>;
+    fn send(&self, data: HeartbeatData);
 
     fn alive(&self) {
-        self.send(HeartbeatData::TaskAlive).unwrap()
+        self.send(HeartbeatData::TaskAlive)
     }
 }
 
 impl HeartbeatSender for TaskHeartbeatClient {
-    fn send(&self, data: HeartbeatData) -> Result<()> {
+    fn send(&self, data: HeartbeatData) {
         let mut messages_lock = self.context.pending_messages.lock().unwrap();
         messages_lock.insert(data);
-        Ok(())
     }
 }
 
 impl HeartbeatSender for Option<TaskHeartbeatClient> {
-    fn send(&self, data: HeartbeatData) -> Result<()> {
-        match self {
-            Some(client) => client.send(data),
-            None => Ok(()),
+    fn send(&self, data: HeartbeatData) {
+        if let Some(client) = self {
+            client.send(data)
         }
     }
 }

--- a/src/agent/onefuzz-agent/src/tasks/heartbeat.rs
+++ b/src/agent/onefuzz-agent/src/tasks/heartbeat.rs
@@ -48,9 +48,8 @@ pub async fn init_task_heartbeat(queue_url: Url, task_id: Uuid) -> Result<TaskHe
             let machine_id = context.state.machine_id;
             let machine_name = context.state.machine_name.clone();
 
-            let mut data =
+            let data =
                 HeartbeatClient::<TaskContext, _>::drain_current_messages(context.clone());
-            data.push(HeartbeatData::MachineAlive);
             let _ = context
                 .queue_client
                 .enqueue(Heartbeat {

--- a/src/agent/onefuzz-agent/src/tasks/heartbeat.rs
+++ b/src/agent/onefuzz-agent/src/tasks/heartbeat.rs
@@ -6,6 +6,7 @@ use crate::onefuzz::machine_id::{get_machine_id, get_machine_name};
 use anyhow::Result;
 use reqwest::Url;
 use serde::{self, Deserialize, Serialize};
+use std::io::{Error, ErrorKind};
 use uuid::Uuid;
 
 #[derive(Debug, Deserialize, Serialize, Hash, Eq, PartialEq, Clone)]
@@ -64,24 +65,30 @@ pub async fn init_task_heartbeat(queue_url: Url, task_id: Uuid) -> Result<TaskHe
 }
 
 pub trait HeartbeatSender {
-    fn send(&self, data: HeartbeatData);
+    fn send(&self, data: HeartbeatData) -> Result<()>;
 
     fn alive(&self) {
-        self.send(HeartbeatData::TaskAlive)
+        self.send(HeartbeatData::TaskAlive).unwrap()
     }
 }
 
 impl HeartbeatSender for TaskHeartbeatClient {
-    fn send(&self, data: HeartbeatData) {
-        let mut messages_lock = self.context.pending_messages.lock().unwrap();
+    fn send(&self, data: HeartbeatData) -> Result<()> {
+        let mut messages_lock = self
+            .context
+            .pending_messages
+            .lock()
+            .map_err(|_| Error::new(ErrorKind::Other, "Unable to acquire the lock"))?;
         messages_lock.insert(data);
+        Ok(())
     }
 }
 
 impl HeartbeatSender for Option<TaskHeartbeatClient> {
-    fn send(&self, data: HeartbeatData) {
-        if let Some(client) = self {
-            client.send(data)
+    fn send(&self, data: HeartbeatData) -> Result<()> {
+        match self {
+            Some(client) => client.send(data),
+            None => Ok(()),
         }
     }
 }

--- a/src/agent/onefuzz-supervisor/src/agent.rs
+++ b/src/agent/onefuzz-supervisor/src/agent.rs
@@ -44,7 +44,7 @@ impl Agent {
             setup_runner,
             work_queue,
             worker_runner,
-            heartbeat: heartbeat,
+            heartbeat,
             previous_state,
         }
     }

--- a/src/agent/onefuzz-supervisor/src/agent.rs
+++ b/src/agent/onefuzz-supervisor/src/agent.rs
@@ -6,7 +6,7 @@ use tokio::time;
 
 use crate::coordinator::*;
 use crate::done::set_done_lock;
-use crate::heartbeat::AgentHeartbeatClient;
+use crate::heartbeat::{AgentHeartbeatClient, HeartbeatSender};
 use crate::reboot::*;
 use crate::scheduler::*;
 use crate::setup::*;
@@ -20,7 +20,7 @@ pub struct Agent {
     setup_runner: Box<dyn ISetupRunner>,
     work_queue: Box<dyn IWorkQueue>,
     worker_runner: Box<dyn IWorkerRunner>,
-    _heartbeat: Option<AgentHeartbeatClient>,
+    heartbeat: Option<AgentHeartbeatClient>,
     previous_state: NodeState,
 }
 
@@ -44,7 +44,7 @@ impl Agent {
             setup_runner,
             work_queue,
             worker_runner,
-            _heartbeat: heartbeat,
+            heartbeat: heartbeat,
             previous_state,
         }
     }
@@ -67,6 +67,7 @@ impl Agent {
         }
 
         loop {
+            self.heartbeat.alive();
             if delay.is_elapsed() {
                 self.execute_pending_commands().await?;
                 delay = command_delay();

--- a/src/agent/onefuzz-supervisor/src/heartbeat.rs
+++ b/src/agent/onefuzz-supervisor/src/heartbeat.rs
@@ -54,7 +54,6 @@ pub async fn init_agent_heartbeat(queue_url: Url) -> Result<AgentHeartbeatClient
     Ok(hb)
 }
 
-
 pub trait HeartbeatSender {
     fn send(&self, data: HeartbeatData) -> Result<()>;
 

--- a/src/agent/onefuzz-supervisor/src/heartbeat.rs
+++ b/src/agent/onefuzz-supervisor/src/heartbeat.rs
@@ -59,7 +59,7 @@ pub trait HeartbeatSender {
 
     fn alive(&self) {
         if let Err(error) = self.send(HeartbeatData::MachineAlive) {
-            error!("{}", error);
+            error!("failed to send heartbeat: {}", error);
         }
     }
 }

--- a/src/agent/onefuzz-supervisor/src/heartbeat.rs
+++ b/src/agent/onefuzz-supervisor/src/heartbeat.rs
@@ -55,26 +55,24 @@ pub async fn init_agent_heartbeat(queue_url: Url) -> Result<AgentHeartbeatClient
 }
 
 pub trait HeartbeatSender {
-    fn send(&self, data: HeartbeatData) -> Result<()>;
+    fn send(&self, data: HeartbeatData);
 
     fn alive(&self) {
-        self.send(HeartbeatData::MachineAlive).unwrap()
+        self.send(HeartbeatData::MachineAlive)
     }
 }
 
 impl HeartbeatSender for AgentHeartbeatClient {
-    fn send(&self, data: HeartbeatData) -> Result<()> {
+    fn send(&self, data: HeartbeatData) {
         let mut messages_lock = self.context.pending_messages.lock().unwrap();
         messages_lock.insert(data);
-        Ok(())
     }
 }
 
 impl HeartbeatSender for Option<AgentHeartbeatClient> {
-    fn send(&self, data: HeartbeatData) -> Result<()> {
-        match self {
-            Some(client) => client.send(data),
-            None => Ok(()),
+    fn send(&self, data: HeartbeatData) {
+        if let Some(client) = self {
+            client.send(data)
         }
     }
 }


### PR DESCRIPTION
## Summary of the Pull Request

sends the supervisor heartbeat in the main loop
removed the default machine alien heartbeat from the tasks

## PR Checklist
* [x] Applies to work item: closes #277
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/onefuzz) and sign the CLI.
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_

## Validation Steps Performed

_How does someone test & validate?_
