### PR TITLE
Don't use HTTP 404 on agent refresh error

### DIFF
--- a/src/api-service/__app__/agent_registration/__init__.py
+++ b/src/api-service/__app__/agent_registration/__init__.py
@@ -57,7 +57,6 @@ def get(req: func.HttpRequest) -> func.HttpResponse:
                 ],
             ),
             context="agent registration",
-            status_code=404,
         )
     else:
         pool = Pool.get_by_name(agent_node.pool_name)


### PR DESCRIPTION
As discussed in #241, we should not use 404 status code on agent registration failure.

This change will cause agent registration failure to use the default status code for `not_ok`, which is 400.