### PR TITLE
Render envelope.event as json

### DIFF
--- a/src/api-service/__app__/agent_events/__init__.py
+++ b/src/api-service/__app__/agent_events/__init__.py
@@ -215,7 +215,7 @@ def post(req: func.HttpRequest) -> func.HttpResponse:
     logging.info(
         "node event: machine_id: %s event: %s",
         envelope.machine_id,
-        envelope.event,
+        envelope.event.json(exclude_none=True),
     )
 
     if isinstance(envelope.event, NodeEvent):


### PR DESCRIPTION
This PR updates the agent event logging to use a json representation, rather than repr, of the event.

By using pydantic's json renderer, we can specify exclude_none, which removes 'error=None' from showing up in the logs.