### PR TITLE
reduce calls to containers.list()

### DIFF
--- a/src/cli/onefuzz/template.py
+++ b/src/cli/onefuzz/template.py
@@ -51,7 +51,6 @@ class Template(Command):
             msg.append("build:%s" % build)
         self.logger.info("stopping %s" % " ".join(msg))
 
-        containers = [x.name for x in self.onefuzz.containers.list()]
         jobs = self.onefuzz.jobs.list()
         for job in jobs:
             if job.config.project != project:
@@ -81,10 +80,8 @@ class Template(Command):
                             continue
                         to_remove.append(container.name)
                     for container_name in to_remove:
-                        if container_name in containers:
-                            self.logger.info("removing container: %s", container_name)
-                            self.onefuzz.containers.delete(container_name)
-                            containers.remove(container_name)
+                        if self.onefuzz.containers.delete(container_name).result:
+                            self.logger.info("removed container: %s", container_name)
 
                 if stop_notifications:
                     notifications = self.onefuzz.notifications.list()

--- a/src/cli/onefuzz/templates/__init__.py
+++ b/src/cli/onefuzz/templates/__init__.py
@@ -99,15 +99,11 @@ class JobHelper:
             )
 
     def create_containers(self) -> None:
-        all_containers = [x.name for x in self.onefuzz.containers.list()]
         for (container_type, container_name) in self.containers.items():
-            if container_name in all_containers:
-                self.logger.info("using container: %s", container_name)
-            else:
-                self.logger.info("creating container: %s", container_name)
-                self.onefuzz.containers.create(
-                    container_name, metadata={"container_type": container_type.name}
-                )
+            self.logger.info("using container: %s", container_name)
+            self.onefuzz.containers.create(
+                container_name, metadata={"container_type": container_type.name}
+            )
 
     def setup_notifications(self, config: Optional[NotificationConfig]) -> None:
         if not config:


### PR DESCRIPTION
Once an instance has massively large numbers of jobs, `containers.list()` becomes unacceptably slow.  

This removes `container.list()` in two places.

1. Template helper.  As creating containers is effectively idempotent, it's more efficient to always create the container, rather than check if the container exists and create it otherwise.
2. Template deletion.  As `container.delete()` returns a `BoolResult` of "true if deleted, false if it didn't exist", we can still indicate if the deletion occurred, without the overhead of checking if the container exists prior to deletion.