### PR TITLE
include deleting unique_inputs on containers.reset

### DIFF
--- a/src/pytypes/onefuzztypes/enums.py
+++ b/src/pytypes/onefuzztypes/enums.py
@@ -214,6 +214,7 @@ class ContainerType(Enum):
             cls.reports,
             cls.setup,
             cls.unique_reports,
+            cls.unique_inputs,
         ]
 
 


### PR DESCRIPTION
For `onefuzz containers reset`, we filter which containers to delete and only delete based on context.    This specifically allows us to not delete tools containers while removing all of the fuzzing metadata.

This PR adds unique_inputs as a containertype that gets reset, along with all of the other fuzzing metadata containers.