### PR TITLE
fix create_vmss log message

### DIFF
--- a/src/api-service/__app__/onefuzzlib/azure/vmss.py
+++ b/src/api-service/__app__/onefuzzlib/azure/vmss.py
@@ -205,7 +205,7 @@ def create_vmss(
         return None
 
     logging.info(
-        "creating VM count"
+        "creating VM "
         "name: %s vm_sku: %s vm_count: %d "
         "image: %s subnet: %s spot_instances: %s",
         name,


### PR DESCRIPTION
This fixes a log message we currently generate.

From: 
`creating VM countname: 73d20a86-36e0-40bb-907b-f887f4df6ad9 vm_sku: Standard_D2s_v3 vm_count: 5` (...) 
To: 
`creating VM name: 73d20a86-36e0-40bb-907b-f887f4df6ad9 vm_sku: Standard_D2s_v3 vm_count: 5` (...)
