### PR TITLE
prevent users from enabling public access to containers

### DIFF
--- a/src/deployment/azuredeploy.json
+++ b/src/deployment/azuredeploy.json
@@ -526,7 +526,8 @@
             },
             "properties": {
                 "supportsHttpsTrafficOnly": true,
-                "accessTier": "Hot"
+                "accessTier": "Hot",
+                "allowBlobPublicAccess": false
             },
             "tags": {
                 "OWNER": "[parameters('owner')]"
@@ -544,7 +545,8 @@
             },
             "properties": {
                 "supportsHttpsTrafficOnly": true,
-                "accessTier": "Hot"
+                "accessTier": "Hot",
+                "allowBlobPublicAccess": false
             },
             "tags": {
                 "OWNER": "[parameters('owner')]"


### PR DESCRIPTION
## Summary of the Pull Request

Though it needs some configuration and extra steps to access the data. Ideally it will be better to not allow public access at all.

Ref: https://docs.microsoft.com/en-us/azure/storage/blobs/anonymous-read-access-configure?tabs=portal#about-anonymous-public-read-access

## PR Checklist
* [ ] Applies to work item: #xxx
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/onefuzz) and sign the CLI.
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

At configuration page of storage account
Before:
![image](https://user-images.githubusercontent.com/13012539/98879268-f78ed180-2439-11eb-9be6-2f2b2630cee7.png)

After:
![image](https://user-images.githubusercontent.com/13012539/98879289-08d7de00-243a-11eb-891b-e64c5def7a9a.png)

tested on redeployment. Gave a test run with a fuzzer as well.