### PR TITLE
Add target_workers to TaskUnitConfig

### DIFF
--- a/src/api-service/__app__/onefuzzlib/tasks/config.py
+++ b/src/api-service/__app__/onefuzzlib/tasks/config.py
@@ -267,6 +267,9 @@ def build_task_config(
     if TaskFeature.target_options_merge in definition.features:
         config.target_options_merge = task_config.task.target_options_merge or False
 
+    if TaskFeature.target_workers in definition.features:
+        config.target_workers = task_config.task.target_workers
+
     if TaskFeature.rename_output in definition.features:
         config.rename_output = task_config.task.rename_output or False
 

--- a/src/pytypes/onefuzztypes/models.py
+++ b/src/pytypes/onefuzztypes/models.py
@@ -297,6 +297,7 @@ class TaskUnitConfig(BaseModel):
     target_options: Optional[List[str]]
     target_timeout: Optional[int]
     target_options_merge: Optional[bool]
+    target_workers: Optional[int]
     check_asan_log: Optional[bool]
     check_debugger: Optional[bool]
     check_retry_count: Optional[int]


### PR DESCRIPTION
## Summary of the Pull Request

`libfuzzer_fuzz` task uses `target_workers` configuration.

https://github.com/microsoft/onefuzz/blob/87085bc48a7eb24fad3d30d6b935b7ca7de14315/src/agent/onefuzz-agent/src/tasks/fuzz/libfuzzer_fuzz.rs#L64-L67

But, that was not included in the `TaskUnitConfig`, so agents never know the configured value.

## PR Checklist
* [ ] Applies to work item: #xxx
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/onefuzz) and sign the CLI.
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

Add `target_workers` member to `TaskUnitConfig`.

## Validation Steps Performed

tested by deploying the fix to my server, and checked number of fuzzer processes in the vms and whether `config.json` is created well in the vms.
