### PR TITLE
Don't reset webhooks by default

### DIFF
--- a/src/cli/onefuzz/api.py
+++ b/src/cli/onefuzz/api.py
@@ -1575,7 +1575,7 @@ class Onefuzz:
         repros: bool = False,
         scalesets: bool = False,
         tasks: bool = False,
-        webhooks: bool = True,
+        webhooks: bool = False,
         yes: bool = False,
     ) -> None:
         """


### PR DESCRIPTION
When resetting webhooks was added to `onefuzz reset`, it should not have been setup to reset by default.