### PR TITLE
Address typing issues hidden by memoization.caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,7 +213,7 @@ jobs:
         # set a minimum confidence to ignore known false positives
         vulture --min-confidence 61 __app__ 
 
-        ../ci/disable-py-cache.py
+        ../ci/disable-py-cache.sh
         mypy __app__ ./tests
   afl:
     runs-on: ubuntu-18.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,6 +212,9 @@ jobs:
 
         # set a minimum confidence to ignore known false positives
         vulture --min-confidence 61 __app__ 
+
+        ../ci/disable-py-cache.py
+        mypy __app__ ./tests
   afl:
     runs-on: ubuntu-18.04
     steps:

--- a/src/api-service/__app__/onefuzzlib/azure/vm.py
+++ b/src/api-service/__app__/onefuzzlib/azure/vm.py
@@ -41,7 +41,7 @@ def get_vm(name: str) -> Optional[VirtualMachine]:
 
 def create_vm(
     name: str,
-    location: str,
+    location: Region,
     vm_sku: str,
     image: str,
     password: str,

--- a/src/api-service/__app__/onefuzzlib/tasks/main.py
+++ b/src/api-service/__app__/onefuzzlib/tasks/main.py
@@ -47,6 +47,8 @@ class Task(BASE_TASK, ORMMixin):
     ) -> Union["Task", Error]:
         if config.vm:
             os = get_os(config.vm.region, config.vm.image)
+            if isinstance(os, Error):
+                return os
         elif config.pool:
             pool = Pool.get_by_name(config.pool.pool_name)
             if isinstance(pool, Error):

--- a/src/ci/disable-py-cache.sh
+++ b/src/ci/disable-py-cache.sh
@@ -3,6 +3,13 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
+
+# Temporary work-around to improve the efficacy of static analysis of functions
+# decorated with memoization.cached.
+#
+# For more information:
+# https://github.com/lonelyenvoy/python-memoization/issues/16
+
 set -ex
 
 SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})

--- a/src/ci/disable-py-cache.sh
+++ b/src/ci/disable-py-cache.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+set -ex
+
+SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
+
+sed -i "s/^from memoization import cached/##### from memoization import cached/" $(find . -name '*.py' -not -path .python_packages)
+sed -i "s/^@cached/##### @cached/" $(find . -name '*.py' -not -path .python_packages)

--- a/src/ci/enable-py-cache.sh
+++ b/src/ci/enable-py-cache.sh
@@ -3,6 +3,12 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
+# Temporary work-around to improve the efficacy of static analysis of functions
+# decorated with memoization.cached.
+#
+# For more information:
+# https://github.com/lonelyenvoy/python-memoization/issues/16
+
 set -ex
 
 SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})

--- a/src/ci/enable-py-cache.sh
+++ b/src/ci/enable-py-cache.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+set -ex
+
+SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
+
+sed -i "s/^##### from memoization import cached/from memoization import cached/" $(find . -name '*.py' -not -path .python_packages)
+sed -i "s/^##### @cached/@cached/" $(find . -name '*.py' -not -path .python_packages)


### PR DESCRIPTION
The caching library used by OneFuzz does not preserve type signatures.  

This PR includes the following changes:
* Scripts to enable & disable the use of the `memoization` library
* Uses the disable script to enable type checking without the `cached` function wrappers.
* Fixes two issues exposed once the type signatures were exposed.

See https://github.com/lonelyenvoy/python-memoization/issues/16 for more information.