### PR TITLE
Expose coverage/exec_sec for libfuzzer targets via CLI

### DIFF
--- a/src/cli/onefuzz/debug.py
+++ b/src/cli/onefuzz/debug.py
@@ -423,12 +423,19 @@ class DebugLog(Command):
     def _query_libfuzzer_coverage(
         self, query: str, timespan: str, limit: Optional[int] = None
     ):
+        project_fields = [
+            "rate=customDimensions.rate",
+            "covered=customDimensions.covered",
+            "features=customDimensions.features",
+            "timestamp",
+        ]
+
         query_parts = [
             "customEvents",
             "where name == 'coverage_data'",
             query,
             "order by timestamp desc",
-            "project rate=customDimensions.rate, timestamp",
+            f"project {','.join(project_fields)}",
         ]
 
         if limit:
@@ -448,7 +455,7 @@ class DebugLog(Command):
         project_fields = [
             "machine_id=customDimensions.machine_id",
             "worker_id=customDimensions.worker_id",
-            "rate=customDimensions.execs_sec",
+            "execs_sec=customDimensions.execs_sec",
             "timestamp",
         ]
 

--- a/src/cli/onefuzz/debug.py
+++ b/src/cli/onefuzz/debug.py
@@ -383,7 +383,9 @@ class DebugLog(Command):
             return raw_data
         return self._convert(raw_data)
 
-    def _query_parts(self, parts: List[str], timespan=str, *, raw: bool = False) -> Any:
+    def _query_parts(
+        self, parts: List[str], timespan: str, *, raw: bool = False
+    ) -> Any:
         log_query = " | ".join(parts)
         return self.query(log_query, timespan=timespan, raw=raw)
 
@@ -422,7 +424,7 @@ class DebugLog(Command):
 
     def _query_libfuzzer_coverage(
         self, query: str, timespan: str, limit: Optional[int] = None
-    ):
+    ) -> Any:
         project_fields = [
             "rate=customDimensions.rate",
             "covered=customDimensions.covered",

--- a/src/cli/onefuzz/debug.py
+++ b/src/cli/onefuzz/debug.py
@@ -220,6 +220,13 @@ class DebugTask(Command):
         timespan: str = DAY_TIMESPAN,
         limit: Optional[int] = None,
     ) -> Any:
+        """
+        Get the coverage for the specified task
+
+        :param task_id value: Task ID
+        :param str timespan: ISO 8601 duration format
+        :param int limit: Limit the number of records returned
+        """
         task = self.onefuzz.tasks.get(task_id)
         query = f"where customDimensions.task_id == '{task.task_id}'"
         return self.onefuzz.debug.logs._query_libfuzzer_coverage(query, timespan, limit)
@@ -230,6 +237,13 @@ class DebugTask(Command):
         timespan: str = DAY_TIMESPAN,
         limit: Optional[int] = None,
     ) -> Any:
+        """
+        Get the executions per second for the specified task
+
+        :param task_id value: Task ID
+        :param str timespan: ISO 8601 duration format
+        :param int limit: Limit the number of records returned
+        """
         task = self.onefuzz.tasks.get(task_id)
         query = f"where customDimensions.task_id == '{task.task_id}'"
         return self.onefuzz.debug.logs._query_libfuzzer_execs_sec(
@@ -287,6 +301,13 @@ class DebugJob(Command):
         timespan: str = DAY_TIMESPAN,
         limit: Optional[int] = None,
     ) -> Any:
+        """
+        Get the coverage for the specified job
+
+        :param job_id value: Job ID
+        :param str timespan: ISO 8601 duration format
+        :param int limit: Limit the number of records returned
+        """
         job = self.onefuzz.jobs.get(job_id)
         query = f"where customDimensions.job_id == '{job.job_id}'"
         return self.onefuzz.debug.logs._query_libfuzzer_coverage(query, timespan, limit)
@@ -297,6 +318,13 @@ class DebugJob(Command):
         timespan: str = DAY_TIMESPAN,
         limit: Optional[int] = None,
     ) -> Any:
+        """
+        Get the executions per second for the specified job
+
+        :param job_id value: Job ID
+        :param str timespan: ISO 8601 duration format
+        :param int limit: Limit the number of records returned
+        """
         job = self.onefuzz.jobs.get(job_id)
         query = f"where customDimensions.job_id == '{job.job_id}'"
         return self.onefuzz.debug.logs._query_libfuzzer_execs_sec(

--- a/src/cli/onefuzz/debug.py
+++ b/src/cli/onefuzz/debug.py
@@ -446,7 +446,6 @@ class DebugLog(Command):
         limit: Optional[int] = None,
     ) -> Any:
         project_fields = [
-            "task_id=customDimensions.task_id",
             "machine_id=customDimensions.machine_id",
             "worker_id=customDimensions.worker_id",
             "rate=customDimensions.execs_sec",


### PR DESCRIPTION
Adds debug subcommands to the SDK/CLI that simplify querying Application Insights for libfuzzer telemetry.  

Querying for the latest execs_sec for a job, by job_id fragment.
```
$ onefuzz debug job libfuzzer_execs_sec 88 --limit 1
[
    {
        "execs_sec": "191035",
        "machine_id": "b2dbe720-4fd8-4342-957a-6cb0979d2187",
        "timestamp": "2020-11-18T00:08:53.98Z",
        "worker_id": "0"
    }
]
```

Querying for the latest coverage for a job, by job_id fragment.
```
$ onefuzz debug job libfuzzer_coverage 88 --limit 1
[
    {
        "covered": "10",
        "features": "21",
        "rate": "0.47619047619047616",
        "timestamp": "2020-11-18T00:09:40.793Z"
    }
]
```

