### PR TITLE
use rust-lld on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         path: |
           sccache
           src/agent/target
-        key: agent-${{ runner.os }}-${{ hashFiles('src/agent/Cargo.lock') }}
+        key: agent-${{ runner.os }}-${{ hashFiles('src/agent/Cargo.lock') }}-2020-11-18
         restore-keys: |
            agent-${{ runner.os }}
     - name: Linux Prereqs

--- a/src/agent/.cargo/config
+++ b/src/agent/.cargo/config
@@ -1,2 +1,3 @@
 [target.x86_64-pc-windows-msvc]
 rustflags = ["-C", "target-feature=+crt-static"]
+linker = "rust-lld"


### PR DESCRIPTION
This PR is an attempt to improve windows compile times by using LLVM's linker.

For more information, see https://nnethercote.github.io/perf-book/compile-times.html#linking