### PR TITLE
Support pre-release instance specific setup script paths

### DIFF
--- a/src/runtime-tools/linux/setup.sh
+++ b/src/runtime-tools/linux/setup.sh
@@ -6,7 +6,8 @@
 find .
 set -x
 
-INSTANCE_SETUP="/onefuzz/instance-specific-setup/linux/setup.sh"
+INSTANCE_OS_SETUP="/onefuzz/instance-specific-setup/linux/setup.sh"
+INSTANCE_SETUP="/onefuzz/instance-specific-setup/setup.sh"
 USER_SETUP="/onefuzz/setup/setup.sh"
 TASK_SETUP="/onefuzz/bin/task-setup.sh"
 MANAGED_SETUP="/onefuzz/bin/managed.sh"
@@ -58,6 +59,11 @@ if [ -f ${INSTANCE_SETUP} ]; then
     logger "onefuzz: instance setup script start"
     chmod +x ${INSTANCE_SETUP}
     ${INSTANCE_SETUP} 2>&1 | logger -s -i -t 'onefuzz-instance-setup'
+    logger "onefuzz: instance setup script stop"
+elif [ -f ${INSTANCE_OS_SETUP} ]; then
+    logger "onefuzz: instance setup script (linux) start"
+    chmod +x ${INSTANCE_OS_SETUP}
+    ${INSTANCE_OS_SETUP} 2>&1 | logger -s -i -t 'onefuzz-instance-setup'
     logger "onefuzz: instance setup script stop"
 else
     logger "onefuzz: no instance setup script"

--- a/src/runtime-tools/win64/setup.ps1
+++ b/src/runtime-tools/win64/setup.ps1
@@ -45,10 +45,15 @@ function Install-OnefuzzSetup {
     log "onefuzz: executing task-setup"
     ./task-setup.ps1
   }
+
   if (Test-Path -Path instance-specific-setup/setup.ps1) {
     log "onefuzz: executing user-setup"
     ./instance-specific-setup/setup.ps1
+  } elseif (Test-Path -Path instance-specific-setup/windows/setup.ps1) {
+    log "onefuzz: executing user-setup (windows)"
+    ./instance-specific-setup/windows/setup.ps1
   }
+
   if (Test-Path -Path setup/setup.ps1) {
     log "onefuzz: executing user-setup"
     ./setup/setup.ps1


### PR DESCRIPTION
Support `instance-specific-setup/<OS>/setup` and `instance-specific-setup/setup` scripts.

Fixes #328 