### PR TITLE
Small fix in set_current_thread in Windows debugger

### DIFF
--- a/src/agent/debugger/src/target.rs
+++ b/src/agent/debugger/src/target.rs
@@ -225,6 +225,7 @@ impl Target {
     }
 
     pub fn set_current_thread(&mut self, thread_id: DWORD) {
+        self.current_thread_id = thread_id;
         self.current_thread_handle = self.thread_info.get(&thread_id).unwrap().handle;
     }
 


### PR DESCRIPTION
Trivial fix to address an issue with the `current_thread_id` only returning the initial thread id.