### PR TITLE
ignore nodes already scheduled for re-imaging in outdated check

### DIFF
--- a/src/api-service/__app__/onefuzzlib/orm.py
+++ b/src/api-service/__app__/onefuzzlib/orm.py
@@ -46,6 +46,7 @@ from .updates import queue_update
 A = TypeVar("A", bound="ORMMixin")
 
 QUERY_VALUE_TYPES = Union[
+    List[bool],
     List[int],
     List[str],
     List[UUID],
@@ -135,6 +136,12 @@ def build_filters(
             field_name = field
 
         parts: Optional[List[str]] = None
+        if isinstance(values[0], bool):
+            parts = []
+            for x in values:
+                if not isinstance(x, bool):
+                    raise TypeError("unexpected type")
+                parts.append("%s eq %s" % (field_name, str(x).lower))
         if isinstance(values[0], int):
             parts = []
             for x in values:

--- a/src/api-service/__app__/onefuzzlib/pools.py
+++ b/src/api-service/__app__/onefuzzlib/pools.py
@@ -118,6 +118,10 @@ class Node(BASE_NODE, ORMMixin):
     def mark_outdated_nodes(cls) -> None:
         outdated = cls.search_outdated()
         for node in outdated:
+            if node.reimage_requested or node.delete_requested:
+                # this node is already marked for reimaging/deletion
+                continue
+
             logging.info(
                 "node is outdated: %s - node_version:%s api_version:%s",
                 node.machine_id,


### PR DESCRIPTION
If a node is already scheduled to be reimaged/deleted, we should not bother checking if it's outdated.