### PR TITLE
Adding -DD parameter to unzip command. Forces file replacement irrespective of timestamp.

### DIFF
--- a/contrib/deploy-onefuzz-via-azure-devops/deploy-onefuzz.yml
+++ b/contrib/deploy-onefuzz-via-azure-devops/deploy-onefuzz.yml
@@ -69,7 +69,7 @@ stages:
             workingDirectory: "$(ONEFUZZ_DEPLOY_LOC)/$(artifact)"
             script: |
               set -ex
-              unzip -DD onefuzz-deployment-$(onefuzz_release.version).zip
+              unzip onefuzz-deployment-$(onefuzz_release.version).zip
               pip install -r requirements.txt
               wget -q https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb
               sudo dpkg -i packages-microsoft-prod.deb

--- a/contrib/deploy-onefuzz-via-azure-devops/deploy-onefuzz.yml
+++ b/contrib/deploy-onefuzz-via-azure-devops/deploy-onefuzz.yml
@@ -121,6 +121,6 @@ stages:
           targetType: 'inline'
           script: |
             set -ex
-            ./onefuzz-cli-$(version).exe config --endpoint $(ONEFUZZ_SERVICE_URL) --client_id "$(AZURE_CLIENT_ID)" --client_secret "$(AZURE_CLIENT_SECRET)"
+            ./onefuzz-cli-$(version).exe config --endpoint $(ONEFUZZ_SERVICE_URL) --client_id "$(AZURE_CLIENT_ID)" --client_secret "$(AZURE_CLIENT_SECRET)" --authority "https://login.microsoftonline.com/$(AZURE_TENANT_ID)"
             ./onefuzz-cli-$(version).exe --version
             until ./onefuzz-cli-$(version).exe versions check --exact; do echo "waiting due to version mismatch"; sleep 1; done

--- a/contrib/deploy-onefuzz-via-azure-devops/deploy-onefuzz.yml
+++ b/contrib/deploy-onefuzz-via-azure-devops/deploy-onefuzz.yml
@@ -69,7 +69,7 @@ stages:
             workingDirectory: "$(ONEFUZZ_DEPLOY_LOC)/$(artifact)"
             script: |
               set -ex
-              unzip onefuzz-deployment-$(onefuzz_release.version).zip
+              unzip -DD onefuzz-deployment-$(onefuzz_release.version).zip
               pip install -r requirements.txt
               wget -q https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb
               sudo dpkg -i packages-microsoft-prod.deb


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_
When running automated deployments, Andrew and I found that 'tools' were not being properly replaced with the updated versions if the deployment was created _prior_ to the original instance deployment. 
To explain the scenario, I've provided our own experience as an example. 

Let's look at the following scenario:
- MSR released version 1.9.0 at 2:55pm on 11/20/2020. 
- A 1.7.0 instance of OneFuzz was manually deployed by a user at 2:55pm on 11/23/2020. 
- The user then creates an Azure pipeline to automatically update the instance and triggers an update at 2:55pm on 11/24/2020

What ends up happening is that when the automated deployment occurs, it unzips the 1.9.0 deployment zip and compares the timestamps within that zip (2:55pm on 11/20/2020) to the timestamps currently in the 'tools' container within the function app (2:55pm on 11/23/2020). Because the container timestamps are more recent than the zip timestamps, the files **are not** replaced. We are then stuck in a situation where some of the tools, like the onefuzz-agent, are version 1.7.0 while the rest of the api have been properly updated to 1.9.0. 

To mitigate this issue, we've added the -DD parameter to the unzip command. 
The duplicated option -DD forces suppression of timestamp restoration for all extracted entries (files and directories). This option results in setting the timestamps for all extracted entries to the current time.

## Info on Pull Request

_What does this include?_
Changes to the .yml deployment file. Specifically, we've added the -DD param to the unzip command. 

## Validation Steps Performed
We've tested this change in our deployment pipeline. 

_How does someone test & validate?_
One can test by following a similar pattern of events as the ones detailed above. Without the param, the files are not updated. With the param, the files are properly updated. 