### PR TITLE
render the event model as json

### DIFF
--- a/src/api-service/__app__/agent_events/__init__.py
+++ b/src/api-service/__app__/agent_events/__init__.py
@@ -25,7 +25,7 @@ def process(envelope: NodeEventEnvelope) -> Result[None]:
     logging.info(
         "node event: machine_id: %s event: %s",
         envelope.machine_id,
-        envelope.event,
+        envelope.event.json(exclude_none=True),
     )
 
     if isinstance(envelope.event, NodeStateUpdate):


### PR DESCRIPTION
This removes `error=None` from showing up in the logs.