### PR TITLE
Fail the task if parsing asan_log files fail

### DIFF
--- a/src/agent/onefuzz/src/asan.rs
+++ b/src/agent/onefuzz/src/asan.rs
@@ -7,6 +7,8 @@ use regex::Regex;
 use std::{collections::HashMap, hash::BuildHasher, path::Path};
 use tokio::{fs, stream::StreamExt};
 
+const ASAN_LOG_TRUNCATE_SIZE: usize = 4096;
+
 #[derive(Clone, Debug)]
 pub struct AsanLog {
     text: String,
@@ -136,8 +138,8 @@ pub async fn check_asan_string(mut data: String) -> Result<Option<AsanLog>> {
     if asan.is_some() {
         return Ok(asan);
     } else {
-        if data.len() > 4096 {
-            data.truncate(4096);
+        if data.len() > ASAN_LOG_TRUNCATE_SIZE {
+            data.truncate(ASAN_LOG_TRUNCATE_SIZE);
             data.push_str("...<truncated>");
         }
         warn!("unable to parse asan log from string: {:?}", data);
@@ -154,8 +156,8 @@ pub async fn check_asan_path(asan_dir: &Path) -> Result<Option<AsanLog>> {
         if asan.is_some() {
             return Ok(asan);
         } else {
-            if asan_text.len() > 4096 {
-                asan_text.truncate(4096);
+            if asan_text.len() > ASAN_LOG_TRUNCATE_SIZE {
+                asan_text.truncate(ASAN_LOG_TRUNCATE_SIZE);
                 asan_text.push_str("...<truncated>");
             }
             bail!(

--- a/src/agent/onefuzz/src/asan.rs
+++ b/src/agent/onefuzz/src/asan.rs
@@ -136,8 +136,8 @@ pub async fn check_asan_string(mut data: String) -> Result<Option<AsanLog>> {
     if asan.is_some() {
         return Ok(asan);
     } else {
-        if data.len() > 1024 {
-            data.truncate(1024);
+        if data.len() > 4096 {
+            data.truncate(4096);
             data.push_str("...<truncated>");
         }
         warn!("unable to parse asan log from string: {:?}", data);
@@ -154,11 +154,11 @@ pub async fn check_asan_path(asan_dir: &Path) -> Result<Option<AsanLog>> {
         if asan.is_some() {
             return Ok(asan);
         } else {
-            if asan_text.len() > 1024 {
-                asan_text.truncate(1024);
+            if asan_text.len() > 4096 {
+                asan_text.truncate(4096);
                 asan_text.push_str("...<truncated>");
             }
-            warn!(
+            bail!(
                 "unable to parse asan log {}: {:?}",
                 file.path().display(),
                 asan_text


### PR DESCRIPTION
This differentiates parsing ASAN log parse failures from ASAN logs not existing, fixing the first part of #343.