### PR TITLE
add the instrumentation key to Info

### DIFF
--- a/src/api-service/__app__/info/__init__.py
+++ b/src/api-service/__app__/info/__init__.py
@@ -10,6 +10,7 @@ from ..onefuzzlib.azure.creds import (
     get_base_region,
     get_base_resource_group,
     get_insights_appid,
+    get_insights_instrumentation_key,
     get_instance_id,
     get_subscription,
 )
@@ -26,5 +27,6 @@ def main(req: func.HttpRequest) -> func.HttpResponse:
             versions=versions(),
             instance_id=get_instance_id(),
             insights_appid=get_insights_appid(),
+            insights_instrumentation_key=get_insights_instrumentation_key(),
         )
     )

--- a/src/api-service/__app__/onefuzzlib/azure/creds.py
+++ b/src/api-service/__app__/onefuzzlib/azure/creds.py
@@ -83,6 +83,11 @@ def get_subscription() -> Any:  # should be str
 
 
 @cached
+def get_insights_instrumentation_key() -> Any:  # should be str
+    return os.environ["ONEFUZZ_TELEMETRY"]
+
+
+@cached
 def get_insights_appid() -> str:
     return os.environ["APPINSIGHTS_APPID"]
 

--- a/src/pytypes/onefuzztypes/responses.py
+++ b/src/pytypes/onefuzztypes/responses.py
@@ -38,6 +38,7 @@ class Info(BaseResponse):
     versions: Dict[str, Version]
     instance_id: Optional[UUID]
     insights_appid: Optional[str]
+    insights_instrumentation_key: Optional[str]
 
 
 class ContainerInfoBase(BaseResponse):


### PR DESCRIPTION
This provides the instance instrumentation key to Info.

This will enable logging to the instance app insights from the SDK.