### PR TITLE
fix job_templates deletion

### DIFF
--- a/src/api-service/__app__/job_templates_manage/__init__.py
+++ b/src/api-service/__app__/job_templates_manage/__init__.py
@@ -58,6 +58,9 @@ def delete(req: func.HttpRequest) -> func.HttpResponse:
         return not_ok(request, context="JobTemplateDelete")
 
     entry = JobTemplateIndex.get(request.name)
+    if entry is not None:
+        entry.delete()
+
     return ok(BoolResult(result=entry is not None))
 
 


### PR DESCRIPTION
The `delete` endpoint did not actually delete job templates.