### PR TITLE
Allow unmaintained memmap

### DIFF
--- a/src/ci/agent.sh
+++ b/src/ci/agent.sh
@@ -18,7 +18,7 @@ cargo fmt -- --check
 # RUSTSEC-2019-0031: a dependency spin (pulled in from ring) is not actively maintained
 # RUSTSEC-2020-0016: a dependency net2 (pulled in from tokio) is deprecated
 # RUSTSEC-2020-0036: a dependency failure (pulled from proc-maps) is deprecated
-cargo audit --deny warnings --deny unmaintained --deny unsound --deny yanked --ignore RUSTSEC-2019-0031 --ignore RUSTSEC-2020-0016 --ignore RUSTSEC-2020-0036
+cargo audit --deny warnings --deny unmaintained --deny unsound --deny yanked --ignore RUSTSEC-2019-0031 --ignore RUSTSEC-2020-0016 --ignore RUSTSEC-2020-0036 --ignore RUSTSEC-2020-0077
 cargo-license -j > data/licenses.json
 cargo build --release --locked
 # export RUST_LOG=trace


### PR DESCRIPTION
This PR temporarily allows the existing `memmap` dependency as identified in #363 and should be removed once an alternative has been updated.