### PR TITLE
Demonstrate a more complex template management

### DIFF
--- a/docs/managing-templates.md
+++ b/docs/managing-templates.md
@@ -26,7 +26,7 @@ notifications](notifications/teams.md) for new unique crash reports to an existi
     ```
     onefuzz job_templates manage get libfuzzer_linux > libfuzzer_linux.json
     ```
-4. With your preferred text editor, add the following to the notifications list (look for `"notifications": []`):
+3. With your preferred text editor, add the following to the `notifications` list:
     ```json 
     {
         "container_type": "unique_reports", 
@@ -134,3 +134,154 @@ Now let's make use of our new template.
         }
     ]
     ```
+
+## Adding a required field
+
+In may cases, we want users of the template to provide more detail, such as
+data that can be used to tailor the notifications based on the target at
+hand. This is accomplished via a [form fields](declarative-templates.md#example-form-fields).
+
+Let's make a new template that enables notifications via [Azure Devops Work
+Items](notifications/ado.md), where we require the user to specify the Area
+Path that the work items OneFuzz will create.
+
+This example will demonstrate setting the following:
+* `Project` via the project name specified during job creation.
+* `Area Path` via the new required field.
+* `Iteration Path` via a new optional field, with a default value in the template.
+
+1. Enable support for declarative templates.
+    ```
+    onefuzz config --enable_feature job_templates
+    ```
+2. Save a copy of the template locally.
+    ```
+    onefuzz job_templates manage get libfuzzer_linux > libfuzzer_linux_ado_areapath.json
+    ```
+3. With your preferred text editor, add the following to the `notifications` list:
+    ```json 
+    {
+      "config": {
+        "base_url": "https://dev.azure.com/org_name",
+        "auth_token": "ADO_AUTH_TOKEN",
+        "type": "Bug",
+        "project": "{{ job.project }}",
+        "ado_fields": {
+          "System.AreaPath": "{{ task.tags['area_path'] }}",
+          "Microsoft.VSTS.Scheduling.StoryPoints": "1",
+          "System.IterationPath": "{{ task.tags['iteration_path'] }}",
+          "System.Title": "{{ report.crash_site }} - {{ report.executable }}",
+          "Microsoft.VSTS.TCM.ReproSteps": "This is my call stack: <ul> {% for item in report.call_stack %} <li> {{ item }} </li> {% endfor %} </ul>"
+        },
+        "comment": "This is my comment. {{ report.input_sha256 }} {{ input_url }} <br> <pre>{{ repro_cmd }}</pre>",
+        "unique_fields": ["System.Title", "System.AreaPath"],
+        "on_duplicate": {
+          "comment": "Another <a href='{{ input_url }}'>POC</a> was found in <a href='{{ target_url }}'>target</a>. <br> <pre>{{ repro_cmd }}</pre>",
+          "set_state": { "Resolved": "Active" },
+          "ado_fields": {
+            "System.IterationPath": "{{ task.tags['iteration_path'] }}"
+          },
+          "increment": ["Microsoft.VSTS.Scheduling.StoryPoints"]
+        }
+      }
+    }
+    ```
+4. With your preferred text editor, add the following to user fields to the end of the `user_fields` list.
+    1. A required field that specifies the tag name `area_path`.
+        ```json
+        {
+            "help": "Area path for reported crashes",
+            "locations": [
+                {
+                    "op": "add",
+                    "path": "/tasks/1/tags/area_path"
+                }
+            ],
+            "name": "area_path",
+            "required": true,
+            "type": "Str"
+        }
+        ```
+    2. An optional field that specifies the `iteration_path`
+        ```json
+        {
+            "default": "Iteration\\Path\\Default\\Here",
+            "help": "Iteration path for reported crashes",
+            "locations": [
+                {
+                    "op": "add",
+                    "path": "/tasks/1/tags/iteration_path"
+                }
+            ],
+            "name": "iteration_path",
+            "required": false,
+            "type": "Str"
+        }
+        ```
+    > NOTE: Each of these fields use the `jsonpatch` path to add a tag to the second task (by array index), which is the `crash_report` task.  Check out [form fields](declarative-templates.md#example-form-fields) for more information.
+5. Upload the template.
+    ```
+    onefuzz job_templates manage upload libfuzzer_linux_ado_areapath @./libfuzzer_linux_ado_areapath.json
+    ```
+6. Refresh the template cache
+    ```
+    onefuzz job_templates refresh
+    ```
+
+Using `--help`, we can see the new optional and required arguments.  
+```
+$ onefuzz job_templates submit libfuzzer_linux_ado_areapath --help
+usage: onefuzz job_templates submit libfuzzer_linux_ado_areapath [-h] [-v] [--format {json,raw}] [--query QUERY]
+    [--target_exe TARGET_EXE] [--duration DURATION]
+    [--target_workers TARGET_WORKERS] [--vm_count VM_COUNT]
+    [--target_options [TARGET_OPTIONS [TARGET_OPTIONS ...]]]
+    [--target_env str=str [str=str ...]] [--reboot_after_setup]
+    [--check_retry_count CHECK_RETRY_COUNT]
+    [--target_timeout TARGET_TIMEOUT] [--mytags str=str [str=str ...]]
+    [--iteration_path ITERATION_PATH] [--setup_dir SETUP_DIR]
+    [--inputs_dir INPUTS_DIR] [--readonly_inputs_dir READONLY_INPUTS_DIR]
+    [--container_names ContainerType=str [ContainerType=str ...]]
+    [--parameters JobTemplateRequestParameters]
+    project name build pool_name area_path
+```
+
+The new field, `area_path` is now a required argument and `iteration_path` is
+an optional argument.
+
+Let's create a job using this template and verify the tags are as we expect.
+Since the parameters we added only modify the `libfuzzer_crash_report` task,
+we'll search just for the that task.
+```
+$ onefuzz job_templates submit libfuzzer_linux_ado_areapath myproject myname build1 linux My\\Iteration\\Path
+WARNING:onefuzz:job_templates are a preview-feature and may change in an upcoming release
+INFO:onefuzz:creating container: oft-setup-cf346c84f2df551381d9991a5efbd030
+INFO:onefuzz:uploading fuzz.exe to oft-setup-cf346c84f2df551381d9991a5efbd030
+INFO:onefuzz:creating container: oft-unique-reports-71bdf0b1ce175a2796954f8d62f5d3d0
+INFO:onefuzz:creating container: oft-reports-71bdf0b1ce175a2796954f8d62f5d3d0
+INFO:onefuzz:creating container: oft-coverage-71bdf0b1ce175a2796954f8d62f5d3d0
+INFO:onefuzz:creating container: oft-no-repro-71bdf0b1ce175a2796954f8d62f5d3d0
+INFO:onefuzz:creating container: oft-inputs-71bdf0b1ce175a2796954f8d62f5d3d0
+INFO:onefuzz:creating container: oft-crashes-71bdf0b1ce175a2796954f8d62f5d3d0
+INFO:onefuzz:creating container: oft-readonly-inputs-71bdf0b1ce175a2796954f8d62f5d3d0
+{
+    "config": {
+        "build": "build1",
+        "duration": 24,
+        "name": "myname",
+        "project": "myproject"
+    },
+    "job_id": "1eaa9a23-fcdb-400a-a26c-3ebe712fde53",
+    "state": "init"
+}
+$ onefuzz jobs tasks list 1eaa9a23-fcdb-400a-a26c-3ebe712fde53 --query "[?config.task.type == 'libfuzzer_crash_report'].config.tags"
+[
+    {
+        "area_path": "My\\Iteration\\Path",
+        "iteration_path": "Iteration\\Path\\Default\\Here"
+    }
+]
+$
+```
+
+As we can see, the tag `area_path` is the value we specified, and because we
+didn't specify `iteration_path` it uses the default from the template.

--- a/docs/managing-templates.md
+++ b/docs/managing-templates.md
@@ -137,20 +137,20 @@ Now let's make use of our new template.
 
 ## Adding a required field
 
-In may cases, we want users of the template to provide more detail, such as
+In many cases, we want users of the template to provide more detail, such as
 data that can be used to tailor the notifications based on the target at
 hand. This is accomplished via a [form fields](declarative-templates.md#example-form-fields).
 
 Let's make a new template that enables notifications via [Azure Devops Work
 Items](notifications/ado.md), where we require the user to specify the Area
-Path that the work items OneFuzz will create.
+Path for the work items that OneFuzz will create.
 
 This example will demonstrate setting the following:
-* `Project` via the project name specified during job creation.
-* `Area Path` via the new required field.
+* `Project` via a project name specified during job creation.
+* `Area Path` via a new required field.
 * `Iteration Path` via a new optional field, with a default value in the template.
 
-1. Enable support for declarative templates.
+1. Enable support for declarative templates. This is required because declarative templates are not yet stabilized.
     ```
     onefuzz config --enable_feature job_templates
     ```
@@ -162,7 +162,7 @@ This example will demonstrate setting the following:
     ```json 
     {
       "config": {
-        "base_url": "https://dev.azure.com/org_name",
+        "base_url": "https://dev.azure.com/<your-org-name-here>",
         "auth_token": "ADO_AUTH_TOKEN",
         "type": "Bug",
         "project": "{{ job.project }}",
@@ -186,6 +186,7 @@ This example will demonstrate setting the following:
       }
     }
     ```
+Note the use of `task.tags` throughout the template. The next steps will define how values get assigned to this dictionary.
 4. With your preferred text editor, add the following to user fields to the end of the `user_fields` list.
     1. A required field that specifies the tag name `area_path`.
         ```json
@@ -223,7 +224,7 @@ This example will demonstrate setting the following:
     ```
     onefuzz job_templates manage upload libfuzzer_linux_ado_areapath @./libfuzzer_linux_ado_areapath.json
     ```
-6. Refresh the template cache
+6. Refresh the template cache.
     ```
     onefuzz job_templates refresh
     ```
@@ -284,4 +285,4 @@ $
 ```
 
 As we can see, the tag `area_path` is the value we specified, and because we
-didn't specify `iteration_path` it uses the default from the template.
+didn't specify `iteration_path`, it uses the default from the template.

--- a/docs/managing-templates.md
+++ b/docs/managing-templates.md
@@ -162,7 +162,7 @@ This example will demonstrate setting the following:
     ```json 
     {
       "config": {
-        "base_url": "https://dev.azure.com/<your-org-name-here>",
+            "base_url": "https://dev.azure.com/<your-org-name-here>",
         "auth_token": "ADO_AUTH_TOKEN",
         "type": "Bug",
         "project": "{{ job.project }}",
@@ -186,7 +186,7 @@ This example will demonstrate setting the following:
       }
     }
     ```
-Note the use of `task.tags` throughout the template. The next steps will define how values get assigned to this dictionary.
+    > NOTE: The use of `task.tags` throughout the template. The next steps will define how values get assigned to this dictionary.
 4. With your preferred text editor, add the following to user fields to the end of the `user_fields` list.
     1. A required field that specifies the tag name `area_path`.
         ```json
@@ -224,6 +224,7 @@ Note the use of `task.tags` throughout the template. The next steps will define 
     ```
     onefuzz job_templates manage upload libfuzzer_linux_ado_areapath @./libfuzzer_linux_ado_areapath.json
     ```
+    > NOTE: Using @./filename allows specifying read the contents of a file, rather than specifying JSON on the command line.
 6. Refresh the template cache.
     ```
     onefuzz job_templates refresh
@@ -252,6 +253,7 @@ an optional argument.
 Let's create a job using this template and verify the tags are as we expect.
 Since the parameters we added only modify the `libfuzzer_crash_report` task,
 we'll search just for the that task.
+
 ```
 $ onefuzz job_templates submit libfuzzer_linux_ado_areapath myproject myname build1 linux My\\Iteration\\Path
 WARNING:onefuzz:job_templates are a preview-feature and may change in an upcoming release

--- a/docs/managing-templates.md
+++ b/docs/managing-templates.md
@@ -41,6 +41,7 @@ notifications](notifications/teams.md) for new unique crash reports to an existi
     ```
     onefuzz job_templates manage upload libfuzzer_with_teams @./libfuzzer_linux.json
     ```
+    > NOTE: Using @./filename allows specifying read the contents of a file, rather than specifying JSON on the command line.
 
 ## Using the SDK
 

--- a/docs/managing-templates.md
+++ b/docs/managing-templates.md
@@ -162,29 +162,32 @@ This example will demonstrate setting the following:
 3. With your preferred text editor, add the following to the `notifications` list:
     ```json 
     {
-      "config": {
-            "base_url": "https://dev.azure.com/<your-org-name-here>",
-        "auth_token": "ADO_AUTH_TOKEN",
-        "type": "Bug",
-        "project": "{{ job.project }}",
-        "ado_fields": {
-          "System.AreaPath": "{{ task.tags['area_path'] }}",
-          "Microsoft.VSTS.Scheduling.StoryPoints": "1",
-          "System.IterationPath": "{{ task.tags['iteration_path'] }}",
-          "System.Title": "{{ report.crash_site }} - {{ report.executable }}",
-          "Microsoft.VSTS.TCM.ReproSteps": "This is my call stack: <ul> {% for item in report.call_stack %} <li> {{ item }} </li> {% endfor %} </ul>"
-        },
-        "comment": "This is my comment. {{ report.input_sha256 }} {{ input_url }} <br> <pre>{{ repro_cmd }}</pre>",
-        "unique_fields": ["System.Title", "System.AreaPath"],
-        "on_duplicate": {
-          "comment": "Another <a href='{{ input_url }}'>POC</a> was found in <a href='{{ target_url }}'>target</a>. <br> <pre>{{ repro_cmd }}</pre>",
-          "set_state": { "Resolved": "Active" },
-          "ado_fields": {
-            "System.IterationPath": "{{ task.tags['iteration_path'] }}"
-          },
-          "increment": ["Microsoft.VSTS.Scheduling.StoryPoints"]
+        "container_type": "unique_reports",
+        "notification": {
+            "config": {
+                "base_url": "https://dev.azure.com/<your-org-name-here>",
+                "auth_token": "ADO_AUTH_TOKEN",
+                "type": "Bug",
+                "project": "{{ job.project }}",
+                "ado_fields": {
+                    "System.AreaPath": "{{ task.tags['area_path'] }}",
+                    "Microsoft.VSTS.Scheduling.StoryPoints": "1",
+                    "System.IterationPath": "{{ task.tags['iteration_path'] }}",
+                    "System.Title": "{{ report.crash_site }} - {{ report.executable }}",
+                    "Microsoft.VSTS.TCM.ReproSteps": "This is my call stack: <ul> {% for item in report.call_stack %} <li> {{ item }} </li> {% endfor %} </ul>"
+                },
+                "comment": "This is my comment. {{ report.input_sha256 }} {{ input_url }} <br> <pre>{{ repro_cmd }}</pre>",
+                "unique_fields": ["System.Title", "System.AreaPath"],
+                "on_duplicate": {
+                    "comment": "Another <a href='{{ input_url }}'>POC</a> was found in <a href='{{ target_url }}'>target</a>. <br> <pre>{{ repro_cmd }}</pre>",
+                    "set_state": { "Resolved": "Active" },
+                    "ado_fields": {
+                        "System.IterationPath": "{{ task.tags['iteration_path'] }}"
+                    },
+                    "increment": ["Microsoft.VSTS.Scheduling.StoryPoints"]
+                }
+            }
         }
-      }
     }
     ```
     > NOTE: The use of `task.tags` throughout the template. The next steps will define how values get assigned to this dictionary.


### PR DESCRIPTION
Add a job_template example that demonstrates customization of the arguments to the job. 

This example demonstrates setting the Area and Iteration paths for Azure Devops work items.