### PR TITLE
Verify a workset only exists along with a reboot context

### DIFF
--- a/src/agent/onefuzz-supervisor/src/reboot.rs
+++ b/src/agent/onefuzz-supervisor/src/reboot.rs
@@ -55,10 +55,11 @@ impl Reboot {
 
     pub async fn load_context(&mut self) -> Result<Option<RebootContext>> {
         use std::io::ErrorKind;
+        let path = reboot_context_path()?;
 
-        info!("checking for saved reboot context");
+        info!("checking for saved reboot context: {}", path.display());
 
-        let data = fs::read(reboot_context_path()?).await;
+        let data = fs::read(&path).await;
 
         if let Err(err) = &data {
             if let ErrorKind::NotFound = err.kind() {
@@ -71,11 +72,9 @@ impl Reboot {
         let data = data?;
         let ctx = serde_json::from_slice(&data)?;
 
-        info!(
-            "loaded reboot context from {}",
-            reboot_context_path()?.display()
-        );
+        fs::remove_file(&path).await?;
 
+        info!("loaded reboot context");
         Ok(Some(ctx))
     }
 

--- a/src/agent/onefuzz-supervisor/src/setup.rs
+++ b/src/agent/onefuzz-supervisor/src/setup.rs
@@ -38,6 +38,8 @@ impl SetupRunner {
     pub async fn run(&mut self, work_set: &WorkSet) -> Result<SetupOutput> {
         info!("running setup for work set");
 
+        work_set.save_context().await?;
+
         // Download the setup container.
         let setup_url = work_set.setup_url.url();
         let setup_dir = work_set.setup_url.container();

--- a/src/agent/onefuzz-supervisor/src/work.rs
+++ b/src/agent/onefuzz-supervisor/src/work.rs
@@ -45,7 +45,7 @@ impl WorkSet {
         if let Err(err) = &data {
             if let ErrorKind::NotFound = err.kind() {
                 // If new image, there won't be any reboot context.
-                info!("no workset context found");
+                info!("no workset context found, assuming first launch");
                 return Ok(None);
             }
         }

--- a/src/agent/onefuzz-supervisor/src/work.rs
+++ b/src/agent/onefuzz-supervisor/src/work.rs
@@ -35,7 +35,7 @@ impl WorkSet {
         Ok(onefuzz::fs::onefuzz_root()?.join("workset_context.json"))
     }
 
-    pub async fn load_context() -> Result<Option<Self>> {
+    pub async fn load_from_fs_context() -> Result<Option<Self>> {
         let path = Self::context_path()?;
 
         info!("checking for workset context: {}", path.display());

--- a/src/integration-tests/integration-test.py
+++ b/src/integration-tests/integration-test.py
@@ -54,6 +54,7 @@ class Integration(BaseModel):
     wait_for_files: List[ContainerType]
     check_asan_log: Optional[bool] = Field(default=False)
     disable_check_debugger: Optional[bool] = Field(default=False)
+    reboot_after_setup: Optional[bool] = Field(default=False)
 
 
 TARGETS: Dict[str, Integration] = {
@@ -70,6 +71,7 @@ TARGETS: Dict[str, Integration] = {
         target_exe="fuzz.exe",
         inputs="seeds",
         wait_for_files=[ContainerType.unique_reports, ContainerType.coverage],
+        reboot_after_setup=True,
     ),
     "linux-libfuzzer-rust": Integration(
         template=TemplateType.libfuzzer,
@@ -203,6 +205,7 @@ class TestOnefuzz:
                     setup_dir=setup,
                     duration=1,
                     vm_count=1,
+                    reboot_after_setup=config.reboot_after_setup,
                 )
             elif config.template == TemplateType.radamsa:
                 job = self.of.template.radamsa.basic(


### PR DESCRIPTION
Adds the following:

1. Serializes a workset to disk during setup.
2. Upon deserializing a RebootContext, delete the file from disk (We support rebooting once and only once)
3. Check if a workset exists with a RebootContext
    1. If True, continuing processing
    2. if False, mark the tasks & node as "Done" with appropriate errors via:
        1. send WorkerEvent::Done events for each of the tasks in the work set
        2. send StateUpdateEvent::Done for the node