### PR TITLE
handle non-utf8 from libfuzzer stderr

### DIFF
--- a/src/agent/onefuzz-agent/src/tasks/fuzz/libfuzzer_fuzz.rs
+++ b/src/agent/onefuzz-agent/src/tasks/fuzz/libfuzzer_fuzz.rs
@@ -143,11 +143,16 @@ impl LibFuzzerFuzzTask {
             .stderr
             .as_mut()
             .ok_or_else(|| format_err!("stderr not captured"))?;
-        let stderr = BufReader::new(stderr);
+        let mut stderr = BufReader::new(stderr);
 
         let mut libfuzzer_output = Vec::new();
-        let mut lines = stderr.lines();
-        while let Some(line) = lines.next_line().await? {
+        loop {
+            let mut buf = vec![];
+            let bytes_read = stderr.read_until(b'\n', &mut buf).await?;
+            if bytes_read == 0 && buf.is_empty() {
+                break;
+            }
+            let line = String::from_utf8_lossy(&buf).to_string();
             if let Some(stats_sender) = stats_sender {
                 if let Err(err) = try_report_iter_update(stats_sender, worker_id, run_id, &line) {
                     error!("could not parse fuzzing interation update: {}", err);


### PR DESCRIPTION
Moves to using String::from_utf8_lossy to cleanly ignore non-utf8 output from libfuzzers.