### PR TITLE
increase function timeout to 15 minutes

### DIFF
--- a/src/api-service/__app__/host.json
+++ b/src/api-service/__app__/host.json
@@ -30,5 +30,5 @@
       "maxDequeueCount": 5
     }
   },
-  "functionTimeout": "00:05:00"
+  "functionTimeout": "00:15:00"
 }


### PR DESCRIPTION
This is a work-around until the 'update outdated nodes' process is simplified.

In the large scale testing, I pushed an updated build to an instance with 7 scale-sets and 4.5k nodes.  This resulted in a few hundred thousand updates to Azure Tables.  
