### PR TITLE
filter out deleted nodes as to prevent them from being saved later

### DIFF
--- a/src/api-service/__app__/onefuzzlib/pools.py
+++ b/src/api-service/__app__/onefuzzlib/pools.py
@@ -792,7 +792,7 @@ class Scaleset(BASE_SCALESET, ORMMixin):
                     "no longer in scaleset: %s:%s", self.scaleset_id, node.machine_id
                 )
                 node.delete()
-        nodes = [x for x in nodes if x.machine_id not in nodes]
+        nodes = [x for x in nodes if x.machine_id not in azure_nodes]
 
         nodes_to_reset = [x for x in nodes if x.state in NodeState.ready_for_reset()]
 

--- a/src/api-service/__app__/onefuzzlib/pools.py
+++ b/src/api-service/__app__/onefuzzlib/pools.py
@@ -792,7 +792,7 @@ class Scaleset(BASE_SCALESET, ORMMixin):
                     "no longer in scaleset: %s:%s", self.scaleset_id, node.machine_id
                 )
                 node.delete()
-        nodes = [x for x in nodes if x.machine_id not in azure_nodes]
+        nodes = [x for x in nodes if x.machine_id in azure_nodes]
 
         nodes_to_reset = [x for x in nodes if x.state in NodeState.ready_for_reset()]
 

--- a/src/api-service/__app__/onefuzzlib/pools.py
+++ b/src/api-service/__app__/onefuzzlib/pools.py
@@ -783,13 +783,16 @@ class Scaleset(BASE_SCALESET, ORMMixin):
             logging.info("no nodes need updating: %s", self.scaleset_id)
             return False
 
+        removed = []
         # Nodes do not exists in scalesets but in table due to unknown failure
         for node in nodes:
             if node.machine_id not in azure_nodes:
+                removed.append(node.machine_id)
                 logging.info(
                     "no longer in scaleset: %s:%s", self.scaleset_id, node.machine_id
                 )
                 node.delete()
+        nodes = [x for x in nodes if x.machine_id not in nodes]
 
         nodes_to_reset = [x for x in nodes if x.state in NodeState.ready_for_reset()]
 

--- a/src/api-service/__app__/onefuzzlib/pools.py
+++ b/src/api-service/__app__/onefuzzlib/pools.py
@@ -783,11 +783,9 @@ class Scaleset(BASE_SCALESET, ORMMixin):
             logging.info("no nodes need updating: %s", self.scaleset_id)
             return False
 
-        removed = []
         # Nodes do not exists in scalesets but in table due to unknown failure
         for node in nodes:
             if node.machine_id not in azure_nodes:
-                removed.append(node.machine_id)
                 logging.info(
                     "no longer in scaleset: %s:%s", self.scaleset_id, node.machine_id
                 )


### PR DESCRIPTION
In `Scaleset.cleanup_nodes`, nodes that are no longer part of the scaleset should get deleted.  Without filtering the list, the nodes could get re-saved to the Node table later on. 