### PR TITLE
remove redundant cast

### DIFF
--- a/src/ci/disable-py-cache.sh
+++ b/src/ci/disable-py-cache.sh
@@ -15,4 +15,4 @@ set -ex
 SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
 
 sed -i "s/^from memoization import cached/##### from memoization import cached/" $(find . -name '*.py' -not -path .python_packages)
-sed -i "s/^@cached/##### @cached/" $(find . -name '*.py' -not -path .python_packages)
+sed -i "s/@cached/##### @cached/" $(find . -name '*.py' -not -path .python_packages)

--- a/src/ci/enable-py-cache.sh
+++ b/src/ci/enable-py-cache.sh
@@ -14,4 +14,4 @@ set -ex
 SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
 
 sed -i "s/^##### from memoization import cached/from memoization import cached/" $(find . -name '*.py' -not -path .python_packages)
-sed -i "s/^##### @cached/@cached/" $(find . -name '*.py' -not -path .python_packages)
+sed -i "s/##### @cached/@cached/" $(find . -name '*.py' -not -path .python_packages)

--- a/src/cli/onefuzz/api.py
+++ b/src/cli/onefuzz/api.py
@@ -178,7 +178,7 @@ class Files(Endpoint):
         """ get a file from a container """
         self.logger.debug("getting file from container: %s:%s", container, filename)
         client = self._get_client(container)
-        downloaded = cast(bytes, client.download_blob(filename))
+        downloaded = client.download_blob(filename)
         return downloaded
 
     def upload_file(


### PR DESCRIPTION
ContainerWrapper.download_blob returns bytes, which makes this call redundant.

Found via the latest version of mypy.