### PR TITLE
disable py-cache prior to mypy on cli

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,8 +104,9 @@ jobs:
         flake8 .
         black onefuzz examples tests --check
         isort --profile black ./onefuzz ./examples/ ./tests/ --check
-        mypy . --ignore-missing-imports
         pytest -v tests
+        ../ci/disable-py-cache.sh
+        mypy . --ignore-missing-imports
 
         # set a minimum confidence to ignore known false positives
         vulture --min-confidence 61 onefuzz

--- a/src/ci/disable-py-cache.sh
+++ b/src/ci/disable-py-cache.sh
@@ -15,4 +15,4 @@ set -ex
 SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
 
 sed -i "s/^from memoization import cached/##### from memoization import cached/" $(find . -name '*.py' -not -path .python_packages)
-sed -i "s/^@cached/##### @cached/" $(find . -name '*.py' -not -path .python_packages)
+sed -i "s/@cached/##### @cached/" $(find . -name '*.py' -not -path .python_packages)

--- a/src/ci/enable-py-cache.sh
+++ b/src/ci/enable-py-cache.sh
@@ -14,4 +14,4 @@ set -ex
 SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
 
 sed -i "s/^##### from memoization import cached/from memoization import cached/" $(find . -name '*.py' -not -path .python_packages)
-sed -i "s/^##### @cached/@cached/" $(find . -name '*.py' -not -path .python_packages)
+sed -i "s/##### @cached/@cached/" $(find . -name '*.py' -not -path .python_packages)

--- a/src/cli/onefuzz/api.py
+++ b/src/cli/onefuzz/api.py
@@ -178,7 +178,7 @@ class Files(Endpoint):
         """ get a file from a container """
         self.logger.debug("getting file from container: %s:%s", container, filename)
         client = self._get_client(container)
-        downloaded = cast(bytes, client.download_blob(filename))
+        downloaded = client.download_blob(filename)
         return downloaded
 
     def upload_file(

--- a/src/cli/onefuzz/api.py
+++ b/src/cli/onefuzz/api.py
@@ -11,7 +11,7 @@ import subprocess  # nosec
 import uuid
 from enum import Enum
 from shutil import which
-from typing import Callable, Dict, List, Optional, Tuple, Type, TypeVar, cast
+from typing import Callable, Dict, List, Optional, Tuple, Type, TypeVar
 from uuid import UUID
 
 import pkg_resources


### PR DESCRIPTION
Removes `@cached` memoization from the CLI prior to running mypy, similar to #322 provides for the service code

This is needed as the latest version of memoization, v0.3.2, provides support for preserving type signatures, but does not handle memoization of class methods.  (See https://github.com/lonelyenvoy/python-memoization/issues/18)