### PR TITLE
Re-adds POST for node endpoint

### DIFF
--- a/src/api-service/__app__/node/__init__.py
+++ b/src/api-service/__app__/node/__init__.py
@@ -106,5 +106,7 @@ def main(req: func.HttpRequest) -> func.HttpResponse:
         return delete(req)
     elif req.method == "PATCH":
         return patch(req)
+    elif req.method == "POST":
+        return post(req)
     else:
         raise Exception("invalid method")

--- a/src/api-service/__app__/node/function.json
+++ b/src/api-service/__app__/node/function.json
@@ -9,7 +9,8 @@
             "methods": [
                 "get",
                 "patch",
-                "delete"
+                "delete",
+                "post"
             ]
         },
         {


### PR DESCRIPTION
Re-adds the POST method for the `node` endpoint, which got accidentally dropped.