### PR TITLE
remove unused back_channel_address entry

### DIFF
--- a/src/api-service/__app__/onefuzzlib/tasks/config.py
+++ b/src/api-service/__app__/onefuzzlib/tasks/config.py
@@ -188,7 +188,6 @@ def build_task_config(
             StorageType.config,
             add=True,
         ),
-        back_channel_address="https://%s/api/back_channel" % (get_instance_url()),
         instance_id=get_instance_id(),
     )
 

--- a/src/api-service/__app__/onefuzzlib/tasks/config.py
+++ b/src/api-service/__app__/onefuzzlib/tasks/config.py
@@ -13,7 +13,7 @@ from onefuzztypes.models import TaskConfig, TaskDefinition, TaskUnitConfig
 from onefuzztypes.primitives import Container
 
 from ..azure.containers import blob_exists, container_exists, get_container_sas_url
-from ..azure.creds import get_instance_id, get_instance_url
+from ..azure.creds import get_instance_id
 from ..azure.queue import get_queue_sas
 from ..azure.storage import StorageType
 from .defs import TASK_DEFINITIONS

--- a/src/pytypes/onefuzztypes/models.py
+++ b/src/pytypes/onefuzztypes/models.py
@@ -298,7 +298,6 @@ class TaskUnitConfig(BaseModel):
     telemetry_key: Optional[str]
     heartbeat_queue: str
     # command_queue: str
-    back_channel_address: str
     input_queue: Optional[str]
     supervisor_exe: Optional[str]
     supervisor_env: Optional[Dict[str, str]]


### PR DESCRIPTION
Removes the agent task config entry back_channel_address which is unimplemented (and broken).

As is, we generated the following config entry:
`"back_channel_address": "https://https://INSTANCE-NAME.azurewebsites.net/api/back_channel"`