### PR TITLE
Update Linux tracer version

### DIFF
--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -1461,19 +1461,6 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50e4785f2c3b7589a0d0c1dd60285e1188adac4006e8abd6dd578e1567027363"
-dependencies = [
- "bitflags",
- "cc",
- "cfg-if 0.1.10",
- "libc",
- "void",
-]
-
-[[package]]
-name = "nix"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83450fe6a6142ddd95fb064b746083fc4ef1705fe81f64a64e1d4b39f54a1055"
@@ -1481,6 +1468,18 @@ dependencies = [
  "bitflags",
  "cc",
  "cfg-if 0.1.10",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ccba0cfe4fdf15982d1674c69b1fd80bad427d293849982668dfe454bd61f2"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if 1.0.0",
  "libc",
 ]
 
@@ -1572,7 +1571,7 @@ dependencies = [
  "input-tester",
  "lazy_static",
  "log",
- "nix 0.17.0",
+ "nix 0.19.1",
  "notify",
  "pete",
  "proc-maps",
@@ -1745,12 +1744,12 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pete"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d1e549819476ac90362292319a9d8c9ea1a98a9347931860cb32f4afbb3007"
+checksum = "5cd417123c2e101622037d1af9070a10f142d0798ad802dfd0796f982fee8b87"
 dependencies = [
  "libc",
- "nix 0.17.0",
+ "nix 0.19.1",
  "thiserror",
 ]
 
@@ -2822,12 +2821,6 @@ name = "version_check"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
-
-[[package]]
-name = "void"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "waker-fn"

--- a/src/agent/coverage/Cargo.toml
+++ b/src/agent/coverage/Cargo.toml
@@ -23,7 +23,7 @@ winapi = "0.3"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 object = "0.22"
-pete = "0.3"
+pete = "0.4"
 procfs = "0.8"
 
 [dev-dependencies]

--- a/src/agent/onefuzz/Cargo.toml
+++ b/src/agent/onefuzz/Cargo.toml
@@ -45,7 +45,7 @@ input-tester = { path = "../input-tester" }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 cpp_demangle = "0.3"
-nix = "0.17"
-pete = "0.3"
+nix = "0.19"
+pete = "0.4"
 proc-maps = "0.1"
 rstack = "0.3"

--- a/src/agent/onefuzz/src/input_tester.rs
+++ b/src/agent/onefuzz/src/input_tester.rs
@@ -110,10 +110,12 @@ impl<'a> Tester<'a> {
     #[cfg(target_os = "linux")]
     async fn test_input_debugger(
         &self,
-        mut argv: Vec<String>,
+        args: Vec<String>,
         env: HashMap<String, String>,
     ) -> Result<Option<Crash>> {
-        argv.insert(0, self.exe_path.display().to_string());
+        let mut cmd = std::process::Command::new(self.exe_path);
+        cmd.args(args);
+        cmd.envs(&env);
 
         let (sender, receiver) = std::sync::mpsc::channel();
 
@@ -123,7 +125,7 @@ impl<'a> Tester<'a> {
             // Spawn a triage run, but stop it before execing.
             //
             // This calls a blocking `wait()` internally, on the forked child.
-            let triage = crate::triage::TriageCommand::new(argv, env)?;
+            let triage = crate::triage::TriageCommand::new(cmd)?;
 
             // Share the new child ID with main thread.
             sender.send(triage.pid())?;

--- a/src/agent/onefuzz/src/triage.rs
+++ b/src/agent/onefuzz/src/triage.rs
@@ -397,5 +397,5 @@ fn continue_to_init_execve(tracer: &mut Ptracer) -> Result<Tracee> {
         tracer.restart(tracee, Restart::Continue)?;
     }
 
-    anyhow::bail!("did not see initial execve() in tracee while recording coverage");
+    anyhow::bail!("did not see initial execve() in tracee while triaging input");
 }


### PR DESCRIPTION
Update `pete` to 0.4, which enables and requires us to use `std::process::Child` for spawning tracees.

Toward #370.