### PR TITLE
create proxy-configs container during install

### DIFF
--- a/src/deployment/azuredeploy.json
+++ b/src/deployment/azuredeploy.json
@@ -599,6 +599,14 @@
         {
             "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
             "apiVersion": "2018-03-01-preview",
+            "name": "[concat(variables('storageAccountNameFunc'), '/default/', 'proxy-configs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountNameFunc'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
+            "apiVersion": "2018-03-01-preview",
             "name": "[concat(variables('storageAccountNameFunc'), '/default/', 'task-configs')]",
             "dependsOn": [
                 "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountNameFunc'))]"


### PR DESCRIPTION
A recent change to the service requires all `service` containers must be pre-created.