### PR TITLE
remove workaround for an issue addressed in latest mypy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
         isort --profile black ./onefuzz ./examples/ ./tests/ --check
         pytest -v tests
         ../ci/disable-py-cache.sh
-        mypy . --ignore-missing-imports
+        mypy --ignore-missing-imports ./onefuzz ./examples ./tests
 
         # set a minimum confidence to ignore known false positives
         vulture --min-confidence 61 onefuzz

--- a/src/pytypes/onefuzztypes/primitives.py
+++ b/src/pytypes/onefuzztypes/primitives.py
@@ -4,7 +4,7 @@
 # Licensed under the MIT License.
 
 from enum import Enum
-from typing import Any, Dict, NewType, Union, cast
+from typing import Any, Dict, NewType, Union
 from uuid import UUID
 
 from onefuzztypes.validators import check_alnum, check_alnum_dash
@@ -15,30 +15,22 @@ Directory = NewType("Directory", str)
 File = NewType("File", str)
 
 
-# We ignore typing for the following super().__new__ calls
-# specifically because mypy does not handle subclassing
-# builtins well.  As is, mypy generates the error
-# 'Too many arguments for "__new__" of "object"'
-#
-# However, this works in practice.
-
-
 class Region(str):
     def __new__(cls, value: str) -> "Region":
         check_alnum(value)
-        obj = super().__new__(cls, value)  # type: ignore
-        return cast(Region, obj)
+        obj = super().__new__(cls, value)
+        return obj
 
 
 class Container(str):
     def __new__(cls, value: str) -> "Container":
         check_alnum_dash(value)
-        obj = super().__new__(cls, value)  # type: ignore
-        return cast(Container, obj)
+        obj = super().__new__(cls, value)
+        return obj
 
 
 class PoolName(str):
     def __new__(cls, value: str) -> "PoolName":
         check_alnum_dash(value)
-        obj = super().__new__(cls, value)  # type: ignore
-        return cast(PoolName, obj)
+        obj = super().__new__(cls, value)
+        return obj


### PR DESCRIPTION
Previous releases of `mypy` did not handle subclassing builtins well.  Now that has been addressed in mypy, this removes the workaround.