### PR TITLE
use license rather than license_file for python packages

### DIFF
--- a/src/cli/setup.py
+++ b/src/cli/setup.py
@@ -38,7 +38,7 @@ setuptools.setup(
     url="https://github.com/microsoft/onefuzz/",
     author="Microsoft Corporation",
     author_email="fuzzing@microsoft.com",
-    license_file="LICENSE",
+    license="MIT",
     packages=setuptools.find_packages(),
     entry_points={"console_scripts": ["onefuzz = onefuzz.__main__:main"]},
     install_requires=requirements,

--- a/src/pytypes/setup.py
+++ b/src/pytypes/setup.py
@@ -38,7 +38,7 @@ setuptools.setup(
     url="https://github.com/microsoft/onefuzz/",
     author="Microsoft Corporation",
     author_email="fuzzing@microsoft.com",
-    license_file="LICENSE",
+    license="MIT",
     packages=setuptools.find_packages(),
     install_requires=requirements,
     zip_safe=False,


### PR DESCRIPTION
Use the correct field for specifying the license for the onefuzz python pacakges following [setup tools documentation](https://packaging.python.org/guides/distributing-packages-using-setuptools/#license)