### PR TITLE
remove unused Event generation from the pre-2.0.0 SignalR integration

### DIFF
--- a/src/api-service/__app__/onefuzzlib/notifications/main.py
+++ b/src/api-service/__app__/onefuzzlib/notifications/main.py
@@ -4,7 +4,7 @@
 # Licensed under the MIT License.
 
 import logging
-from typing import Dict, List, Optional, Sequence, Tuple
+from typing import List, Optional, Sequence, Tuple
 from uuid import UUID
 
 from memoization import cached
@@ -19,13 +19,9 @@ from onefuzztypes.models import (
     Result,
     TeamsTemplate,
 )
-from onefuzztypes.primitives import Container, Event
+from onefuzztypes.primitives import Container
 
-from ..azure.containers import (
-    container_exists,
-    get_container_metadata,
-    get_file_sas_url,
-)
+from ..azure.containers import container_exists, get_file_sas_url
 from ..azure.queue import send_message
 from ..azure.storage import StorageType
 from ..events import send_event
@@ -105,25 +101,8 @@ def get_queue_tasks() -> Sequence[Tuple[Task, Sequence[str]]]:
     return results
 
 
-@cached(ttl=60)
-def container_metadata(container: Container) -> Optional[Dict[str, str]]:
-    return get_container_metadata(container, StorageType.corpus)
-
-
 def new_files(container: Container, filename: str) -> None:
-    results: Dict[str, Event] = {"container": container, "file": filename}
-
-    metadata = container_metadata(container)
-    if metadata:
-        results["metadata"] = metadata
-
     report = get_report(container, filename)
-    if report:
-        results["executable"] = report.executable
-        results["crash_type"] = report.crash_type
-        results["crash_site"] = report.crash_site
-        results["job_id"] = report.job_id
-        results["task_id"] = report.task_id
 
     notifications = get_notifications(container)
     if notifications:

--- a/src/pytypes/onefuzztypes/primitives.py
+++ b/src/pytypes/onefuzztypes/primitives.py
@@ -3,14 +3,11 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-from enum import Enum
-from typing import Any, Dict, NewType, Union
-from uuid import UUID
+from typing import Any, Dict, NewType
 
 from onefuzztypes.validators import check_alnum, check_alnum_dash
 
 Extension = Dict[str, Any]
-Event = Union[str, int, UUID, Enum, Dict[str, str]]
 Directory = NewType("Directory", str)
 File = NewType("File", str)
 


### PR DESCRIPTION
Remove a vestige of the adhoc events used by the previous SingalR integration for container updates.