### PR TITLE
Continually try updating scaleset configs until successful

### DIFF
--- a/src/api-service/__app__/onefuzzlib/azure/vmss.py
+++ b/src/api-service/__app__/onefuzzlib/azure/vmss.py
@@ -133,7 +133,7 @@ def check_can_update(name: UUID) -> Any:
     if vmss is None:
         raise UnableToUpdate
 
-    if vmss.provisioning_state != "Succeeded":
+    if vmss.provisioning_state == "Updating":
         raise UnableToUpdate
 
     return vmss

--- a/src/api-service/__app__/timer_daily/__init__.py
+++ b/src/api-service/__app__/timer_daily/__init__.py
@@ -24,7 +24,8 @@ def main(mytimer: func.TimerRequest, dashboard: func.Out[str]) -> None:  # noqa:
     scalesets = Scaleset.search()
     for scaleset in scalesets:
         logging.info("updating scaleset configs: %s", scaleset.scaleset_id)
-        scaleset.update_configs()
+        scaleset.needs_config_update = True
+        scaleset.save()
 
     expired_webhook_logs = WebhookMessageLog.search_expired()
     for log_entry in expired_webhook_logs:

--- a/src/api-service/__app__/timer_workers/__init__.py
+++ b/src/api-service/__app__/timer_workers/__init__.py
@@ -17,6 +17,8 @@ from ..onefuzzlib.pools import Node, Pool, Scaleset
 def process_scaleset(scaleset: Scaleset) -> None:
     logging.debug("checking scaleset for updates: %s", scaleset.scaleset_id)
 
+    scaleset.update_configs()
+
     # if the scaleset is touched during cleanup, don't continue to process it
     if scaleset.cleanup_nodes():
         logging.debug("scaleset needed cleanup: %s", scaleset.scaleset_id)

--- a/src/pytypes/onefuzztypes/models.py
+++ b/src/pytypes/onefuzztypes/models.py
@@ -621,6 +621,7 @@ class Scaleset(BaseModel):
     region: Region
     size: int
     spot_instances: bool
+    needs_config_update: bool = Field(default=False)
     error: Optional[Error]
     nodes: Optional[List[ScalesetNodeState]]
     client_id: Optional[UUID]


### PR DESCRIPTION
As is, if a scaleset is "failed" for some reason (such as Azure VM allocation failed), the service does not attempt to push updated VM configs, which can cause our time-limited SAS tokens in the VM config to timeout.

This PR makes 2 changes:
1. attempts to perform any update as long as the scaleset isn't in the "Updating" state
2. moves the config update attempts from once per day configured once per day, but runs every 90 seconds until it's successful.