### PR TITLE
Do not update scaleset configs of halting scalesets

### DIFF
--- a/src/api-service/__app__/onefuzzlib/workers/scalesets.py
+++ b/src/api-service/__app__/onefuzzlib/workers/scalesets.py
@@ -537,8 +537,16 @@ class Scaleset(BASE_SCALESET, ORMMixin):
     def update_configs(self) -> None:
         from .pools import Pool
 
+        if self.state == ScalesetState.halt:
+            logging.info(
+                "not updating configs, scaleset is set to be deleted: %s",
+                self.scaleset_id,
+            )
+            return
+
         if not self.needs_config_update:
             logging.debug("config update not needed: %s", self.scaleset_id)
+            return
 
         logging.info("updating scaleset configs: %s", self.scaleset_id)
 


### PR DESCRIPTION
This addresses an exception if a scaleset is set to have a configuration update after the scaleset deletion has started.

Example exception:

Exception: ResourceExistsError: (OperationNotAllowed) Operation 'Update Virtual Machine Scale Set' is not allowed on Virtual Machine Scale Set 'b242ea12-69e4-4984-90a5-c31b0d0b490a' since it is marked for deletion. For more information on your operations, please refer to https://aka.ms/activitylog.


Additionally, this will only update the configs if the scaleset has `needs_config_update` set.