### PR TITLE
add missing scaleset nodes

### DIFF
--- a/src/api-service/__app__/onefuzzlib/workers/nodes.py
+++ b/src/api-service/__app__/onefuzzlib/workers/nodes.py
@@ -60,7 +60,7 @@ class Node(BASE_NODE, ORMMixin):
         # `save` only returns None when `new` is True and an object already
         # exists in Azure Tables. If we're in that case, don't send an event.
         result = node.save(new=new)
-        if result is None:
+        if result is not None:
             send_event(
                 EventNodeCreated(
                     machine_id=node.machine_id,

--- a/src/api-service/__app__/onefuzzlib/workers/nodes.py
+++ b/src/api-service/__app__/onefuzzlib/workers/nodes.py
@@ -57,10 +57,11 @@ class Node(BASE_NODE, ORMMixin):
             scaleset_id=scaleset_id,
             version=version,
         )
-        # `save` only returns None when `new` is True and an object already
-        # exists in Azure Tables. If we're in that case, don't send an event.
+        # `save` returns None if it's successfully saved.  If `new` is set to
+        # True, `save` returns an Error if an object already exists.  As such,
+        # only send an event if result is None
         result = node.save(new=new)
-        if result is not None:
+        if result is None:
             send_event(
                 EventNodeCreated(
                     machine_id=node.machine_id,


### PR DESCRIPTION
Scalesets can have nodes that never check in (such as broken OS setup scripts).

This will add nodes that Azure knows about but have not checked in such that the `dead node` detection will eventually reimage the node.

NOTE: If node setup takes longer than NODE_EXPIRATION_TIME (1 hour), this will cause the nodes to continuously get reimaged.