### PR TITLE
fix logging to show corpus accounts found

### DIFF
--- a/src/api-service/__app__/onefuzzlib/azure/storage.py
+++ b/src/api-service/__app__/onefuzzlib/azure/storage.py
@@ -117,5 +117,5 @@ def corpus_accounts() -> List[str]:
 
         results.append(account.id)
 
-    logging.info("corpus accounts: %s", corpus_accounts)
+    logging.info("corpus accounts: %s", results)
     return results


### PR DESCRIPTION
As is, this logs a ref to the current function, rather than the list of discovered accounts.