### PR TITLE
set default SignalR transport

### DIFF
--- a/src/deployment/azuredeploy.json
+++ b/src/deployment/azuredeploy.json
@@ -211,6 +211,10 @@
                             "value": "[listkeys(resourceId('Microsoft.SignalRService/SignalR', variables('signalr-name')), '2018-10-01').primaryConnectionString]"
                         },
                         {
+                            "name": "AzureSignalRServiceTransportType",
+                            "value": "Transient"
+                        },
+                        {
                             "name": "ONEFUZZ_INSTANCE_NAME",
                             "value": "[parameters('name')]"
                         },


### PR DESCRIPTION
This removes the unhelpful warning generated by the Azure Functions SignalR integration stating "Unsupported service transport type: . Use default Transient instead."

Ref: https://github.com/Azure/azure-functions-signalrservice-extension/issues/156