### PR TITLE
use the cached Azure Identity instance

### DIFF
--- a/src/api-service/__app__/onefuzzlib/azure/storage.py
+++ b/src/api-service/__app__/onefuzzlib/azure/storage.py
@@ -9,12 +9,11 @@ import random
 from enum import Enum
 from typing import List, Tuple, cast
 
-from azure.identity import DefaultAzureCredential
 from azure.mgmt.storage import StorageManagementClient
 from memoization import cached
 from msrestazure.tools import parse_resource_id
 
-from .creds import get_base_resource_group, get_subscription
+from .creds import get_base_resource_group, get_subscription, get_identity
 
 
 class StorageType(Enum):
@@ -25,7 +24,7 @@ class StorageType(Enum):
 @cached
 def get_mgmt_client() -> StorageManagementClient:
     return StorageManagementClient(
-        credential=DefaultAzureCredential(), subscription_id=get_subscription()
+        credential=get_identity(), subscription_id=get_subscription()
     )
 
 


### PR DESCRIPTION
The azure storage interactions were not using the cached azure identity.

This caused two problems.
1. Increased the burden on IMS
2. Reduced the effectiveness of the monkeypatching that injects more python runtime workers and log reduction.