### PR TITLE
check libfuzzer `-help=1` prior to starting the heartbeat

### DIFF
--- a/src/agent/onefuzz-agent/src/local/libfuzzer.rs
+++ b/src/agent/onefuzz-agent/src/local/libfuzzer.rs
@@ -21,6 +21,7 @@ use tokio::task::spawn;
 pub async fn run(args: &clap::ArgMatches<'_>) -> Result<()> {
     let fuzz_config = build_fuzz_config(args)?;
     let fuzzer = LibFuzzerFuzzTask::new(fuzz_config)?;
+    fuzzer.check_libfuzzer().await?;
     let fuzz_task = spawn(async move { fuzzer.run().await });
 
     let report_config = build_report_config(args)?;

--- a/src/agent/onefuzz-agent/src/tasks/config.rs
+++ b/src/agent/onefuzz-agent/src/tasks/config.rs
@@ -162,7 +162,7 @@ impl Config {
         match self {
             Config::LibFuzzerFuzz(config) => {
                 fuzz::libfuzzer_fuzz::LibFuzzerFuzzTask::new(config)?
-                    .check_run()
+                    .managed_run()
                     .await
             }
             Config::LibFuzzerReport(config) => {

--- a/src/agent/onefuzz-agent/src/tasks/config.rs
+++ b/src/agent/onefuzz-agent/src/tasks/config.rs
@@ -162,7 +162,7 @@ impl Config {
         match self {
             Config::LibFuzzerFuzz(config) => {
                 fuzz::libfuzzer_fuzz::LibFuzzerFuzzTask::new(config)?
-                    .run()
+                    .check_run()
                     .await
             }
             Config::LibFuzzerReport(config) => {

--- a/src/agent/onefuzz-agent/src/tasks/coverage/libfuzzer_coverage.rs
+++ b/src/agent/onefuzz-agent/src/tasks/coverage/libfuzzer_coverage.rs
@@ -106,19 +106,22 @@ impl CoverageTask {
         Ok(())
     }
 
-    pub async fn managed_run(&mut self) -> Result<()> {
-        info!("starting libFuzzer coverage task");
-
+    async fn check_libfuzzer(&self) -> Result<()> {
         if self.config.check_fuzzer_help {
-            let target = LibFuzzer::new(
+            let fuzzer = LibFuzzer::new(
                 &self.config.target_exe,
                 &self.config.target_options,
                 &self.config.target_env,
                 &self.config.common.setup_dir,
             );
-            target.check_help().await?;
+            fuzzer.check_help().await?;
         }
+        Ok(())
+    }
 
+    pub async fn managed_run(&mut self) -> Result<()> {
+        info!("starting libFuzzer coverage task");
+        self.check_libfuzzer().await?;
         self.config.coverage.init_pull().await?;
         self.process().await
     }

--- a/src/agent/onefuzz-agent/src/tasks/fuzz/libfuzzer_fuzz.rs
+++ b/src/agent/onefuzz-agent/src/tasks/fuzz/libfuzzer_fuzz.rs
@@ -80,6 +80,11 @@ impl LibFuzzerFuzzTask {
         }
     }
 
+    pub async fn check_run(&self) -> Result<()> {
+        self.check_libfuzzer().await?;
+        self.run().await
+    }
+
     pub async fn run(&self) -> Result<()> {
         self.init_directories().await?;
 
@@ -95,6 +100,19 @@ impl LibFuzzerFuzzTask {
         let fuzzers = self.run_fuzzers(Some(&stats_sender));
         futures::try_join!(resync, new_inputs, new_crashes, fuzzers, report_stats)?;
 
+        Ok(())
+    }
+
+    pub async fn check_libfuzzer(&self) -> Result<()> {
+        if self.config.check_fuzzer_help {
+            let fuzzer = LibFuzzer::new(
+                &self.config.target_exe,
+                &self.config.target_options,
+                &self.config.target_env,
+                &self.config.common.setup_dir,
+            );
+            fuzzer.check_help().await?;
+        }
         Ok(())
     }
 

--- a/src/agent/onefuzz-agent/src/tasks/fuzz/libfuzzer_fuzz.rs
+++ b/src/agent/onefuzz-agent/src/tasks/fuzz/libfuzzer_fuzz.rs
@@ -80,7 +80,7 @@ impl LibFuzzerFuzzTask {
         }
     }
 
-    pub async fn check_run(&self) -> Result<()> {
+    pub async fn managed_run(&self) -> Result<()> {
         self.check_libfuzzer().await?;
         self.run().await
     }


### PR DESCRIPTION
Currently, the a bad libfuzzer (such as missing a prereq dll) transitions from `setting_up`, to `running`, then to `failure`.

This PR, in combination with #530, will make `--wait_for_running` actually useful in determining if the libfuzzer target is meaningfully launched.