### PR TITLE
handle tokens from x-ms-token-aad-id-token

### DIFF
--- a/docs/webhook_events.md
+++ b/docs/webhook_events.md
@@ -303,9 +303,6 @@ Each event will be submitted via HTTP POST to the user provided URL.
                     "type": "string"
                 }
             },
-            "required": [
-                "application_id"
-            ],
             "title": "UserInfo",
             "type": "object"
         }
@@ -399,9 +396,6 @@ Each event will be submitted via HTTP POST to the user provided URL.
                     "type": "string"
                 }
             },
-            "required": [
-                "application_id"
-            ],
             "title": "UserInfo",
             "type": "object"
         }
@@ -1470,9 +1464,6 @@ Each event will be submitted via HTTP POST to the user provided URL.
                     "type": "string"
                 }
             },
-            "required": [
-                "application_id"
-            ],
             "title": "UserInfo",
             "type": "object"
         }
@@ -1598,9 +1589,6 @@ Each event will be submitted via HTTP POST to the user provided URL.
                     "type": "string"
                 }
             },
-            "required": [
-                "application_id"
-            ],
             "title": "UserInfo",
             "type": "object"
         }
@@ -1735,9 +1723,6 @@ Each event will be submitted via HTTP POST to the user provided URL.
                     "type": "string"
                 }
             },
-            "required": [
-                "application_id"
-            ],
             "title": "UserInfo",
             "type": "object"
         }
@@ -2864,9 +2849,6 @@ Each event will be submitted via HTTP POST to the user provided URL.
                     "type": "string"
                 }
             },
-            "required": [
-                "application_id"
-            ],
             "title": "UserInfo",
             "type": "object"
         }

--- a/src/api-service/__app__/onefuzzlib/endpoint_authorization.py
+++ b/src/api-service/__app__/onefuzzlib/endpoint_authorization.py
@@ -33,6 +33,9 @@ def is_agent(token_data: UserInfo) -> bool:
         principal_id: UUID = get_scaleset_principal_id()
         return principal_id == token_data.object_id
 
+    if not token_data.application_id:
+        return False
+
     pools = Pool.search(query={"client_id": [token_data.application_id]})
     if len(pools) > 0:
         return True

--- a/src/api-service/__app__/onefuzzlib/user_credentials.py
+++ b/src/api-service/__app__/onefuzzlib/user_credentials.py
@@ -51,7 +51,7 @@ def parse_jwt_token(request: func.HttpRequest) -> Result[UserInfo]:
     # This token has already been verified by the azure authentication layer
     token = jwt.decode(token_str, verify=False)
 
-    application_id = UUID(token["appid"])
+    application_id = UUID(token["appid"]) if "appid" in token else None
     object_id = UUID(token["oid"]) if "oid" in token else None
     upn = token.get("upn")
     return UserInfo(application_id=application_id, object_id=object_id, upn=upn)

--- a/src/api-service/__app__/onefuzzlib/user_credentials.py
+++ b/src/api-service/__app__/onefuzzlib/user_credentials.py
@@ -3,6 +3,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+from typing import Optional
 from uuid import UUID
 
 import azure.functions as func
@@ -11,30 +12,44 @@ from onefuzztypes.enums import ErrorCode
 from onefuzztypes.models import Error, Result, UserInfo
 
 
-def parse_jwt_token(request: func.HttpRequest) -> Result[UserInfo]:
-    """ Obtains the Access Token from the Authorization Header """
-
+def get_bearer_token(request: func.HttpRequest) -> Optional[str]:
     auth: str = request.headers.get("Authorization", None)
     if not auth:
-        return Error(
-            code=ErrorCode.INVALID_REQUEST, errors=["Authorization header is expected"]
-        )
+        return None
 
     parts = auth.split()
 
     if len(parts) != 2:
-        return Error(
-            code=ErrorCode.INVALID_REQUEST, errors=["Invalid authorization header"]
-        )
+        return None
 
     if parts[0].lower() != "bearer":
+        return None
+
+    return parts[1]
+
+
+def get_auth_token(request: func.HttpRequest) -> Optional[str]:
+    token = get_bearer_token(request)
+    if token is not None:
+        return token
+
+    token_header = request.headers.get("x-ms-token-aad-id-token", None)
+    if token_header is None:
+        return None
+    return str(token_header)
+
+
+def parse_jwt_token(request: func.HttpRequest) -> Result[UserInfo]:
+    """ Obtains the Access Token from the Authorization Header """
+    token_str = get_auth_token(request)
+    if token_str is None:
         return Error(
             code=ErrorCode.INVALID_REQUEST,
-            errors=["Authorization header must start with Bearer"],
+            errors=["unable to find authorization token"],
         )
 
     # This token has already been verified by the azure authentication layer
-    token = jwt.decode(parts[1], verify=False)
+    token = jwt.decode(token_str, verify=False)
 
     application_id = UUID(token["appid"])
     object_id = UUID(token["oid"]) if "oid" in token else None

--- a/src/pytypes/onefuzztypes/models.py
+++ b/src/pytypes/onefuzztypes/models.py
@@ -37,7 +37,7 @@ from .primitives import Container, PoolName, Region
 
 
 class UserInfo(BaseModel):
-    application_id: UUID
+    application_id: Optional[UUID]
     object_id: Optional[UUID]
     upn: Optional[str]
 


### PR DESCRIPTION
In cases where the Authorization header is not available, check x-ms-token-aad-id-token for the JWT token of the requesting user.

Note: this header is expected per documentation:

https://github.com/MicrosoftDocs/azure-docs/blob/master/articles/app-service/app-service-authentication-how-to.md#retrieve-tokens-in-app-code