### PR TITLE
update error message when coverage extraction fails

### DIFF
--- a/src/agent/onefuzz-agent/src/tasks/coverage/recorder.rs
+++ b/src/agent/onefuzz-agent/src/tasks/coverage/recorder.rs
@@ -90,7 +90,16 @@ impl CoverageRecorder {
                         coverage_path.display()
                     )
                 })?;
-            bail!("no coverage files for input: {}", test_input.display());
+
+            let filename = test_input
+                .file_name()
+                .ok_or_else(|| format_err!("unable to identify coverage input filename"))?;
+
+            bail!(
+                "coverage extraction from {} failed when processing file {:?}.  target appears to be missing sancov instrumentation",
+                self.config.target_exe.display(),
+                filename
+            );
         }
 
         Ok(coverage_path)


### PR DESCRIPTION
As is, when coverage extraction failed due to instrumentation issues generates the error message:

`Error: no coverage files for input: C:\windows\TEMP\.tmpVFqsjw\479d1ab6410822bd7334f03b1fd599842415c8be`

This PR does a few things:
1. Specifies the filename, rather than generated temp directory name
2. Specifies the filename of the fuzzer
3. Specifies that it appears sancov instrumentation is missing

The same input should generate the following error with this PR:

`coverage extraction from c:\onefuzz\path\to\fuzz.exe failed when processing file "479d1ab6410822bd7334f03b1fd599842415c8be".  target appears to be missing sancov instrumentation`