### PR TITLE
add status job commands

### DIFF
--- a/src/cli/onefuzz/status/cmd.py
+++ b/src/cli/onefuzz/status/cmd.py
@@ -3,17 +3,99 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-from typing import List, Optional
+from collections import defaultdict
+from typing import DefaultDict, List, Optional, Set
 from uuid import UUID
 
-from ..api import Command
+from onefuzztypes.enums import ContainerType, JobState
+from onefuzztypes.primitives import Container
+
+from ..api import UUID_EXPANSION, Command
 from .cache import JobFilter
 from .raw import raw
 from .top import Top
 
 
+def short(value: UUID) -> str:
+    return str(value).split("-")[0]
+
+
 class Status(Command):
     """ Monitor status of Onefuzz Instance """
+
+    def project(
+        self,
+        *,
+        project: str,
+        name: str,
+        build: Optional[str] = None,
+        all_jobs: Optional[bool] = False,
+    ) -> None:
+        job_state = JobState.available()
+        if all_jobs:
+            job_state = [x for x in JobState]
+
+        for job in self.onefuzz.jobs.list(job_state=job_state):
+            if job.config.project != project:
+                continue
+            if job.config.name != name:
+                continue
+            if build is not None and job.config.build != build:
+                continue
+
+            self.job(job.job_id)
+
+    def job(self, job_id: UUID_EXPANSION) -> None:
+        job = self.onefuzz.jobs.get(job_id)
+
+        print(f"job: {job.job_id}")
+        print(
+            f"project:{job.config.project} name:{job.config.name} build:{job.config.build}"
+        )
+        print("\ntasks:")
+
+        tasks = self.onefuzz.tasks.list(job_id=job.job_id, state=[])
+        with_errors = []
+        for task in tasks:
+            if task.error:
+                with_errors.append(task)
+                continue
+            print(
+                f"{short(task.task_id)} "
+                f"target:{task.config.task.target_exe} "
+                f"state:{task.state.name} "
+                f"type:{task.config.task.type.name}"
+            )
+
+        if with_errors:
+            print("\ntasks with errors:")
+            entries = []
+            for task in with_errors:
+                if not task.error:
+                    continue
+
+                message = (
+                    f"{short(task.task_id)} type:{task.config.task.type.name} "
+                    f"target:{task.config.task.target_exe}"
+                    f"\nerror:\n{task.error.errors[-1].strip()}"
+                )
+                entries.append(message)
+            print("\n\n".join(entries))
+
+        containers: DefaultDict[ContainerType, Set[Container]] = defaultdict(set)
+        for task in tasks:
+            for container in task.config.containers:
+                if container.type not in containers:
+                    containers[container.type] = set()
+                containers[container.type].add(container.name)
+
+        print("\ncontainers:")
+        for container_type in containers:
+            for container_name in containers[container_type]:
+                count = len(self.onefuzz.containers.files.list(container_name).files)
+                print(
+                    f"{container_type.name:<15} count:{count:<5} name:{container_name}"
+                )
 
     def raw(self) -> None:
         """ Raw status update stream """

--- a/src/cli/onefuzz/status/cmd.py
+++ b/src/cli/onefuzz/status/cmd.py
@@ -92,10 +92,17 @@ class Status(Command):
         print("\ncontainers:")
         for container_type in containers:
             for container_name in containers[container_type]:
-                count = len(self.onefuzz.containers.files.list(container_name).files)
-                print(
-                    f"{container_type.name:<15} count:{count:<5} name:{container_name}"
-                )
+                try:
+                    count = len(
+                        self.onefuzz.containers.files.list(container_name).files
+                    )
+                    print(
+                        f"{container_type.name:<15} count:{count:<5} name:{container_name}"
+                    )
+                except Exception:
+                    print(
+                        f"{container_type.name:<15} INACCESSABLE CONTAINER name:{container_name}"
+                    )
 
     def raw(self) -> None:
         """ Raw status update stream """

--- a/src/cli/onefuzz/status/cmd.py
+++ b/src/cli/onefuzz/status/cmd.py
@@ -74,10 +74,12 @@ class Status(Command):
                 if not task.error:
                     continue
 
+                errors = "\n".join([x.strip() for x in task.error.errors])
+
                 message = (
                     f"{short(task.task_id)} type:{task.config.task.type.name} "
                     f"target:{task.config.task.target_exe}"
-                    f"\nerror:\n{task.error.errors[-1].strip()}"
+                    f"\nerror:\n{errors}"
                 )
                 entries.append(message)
             print("\n\n".join(entries))
@@ -101,7 +103,7 @@ class Status(Command):
                     )
                 except Exception:
                     print(
-                        f"{container_type.name:<15} INACCESSABLE CONTAINER name:{container_name}"
+                        f"{container_type.name:<15} INACCESSIBLE CONTAINER name:{container_name}"
                     )
 
     def raw(self) -> None:


### PR DESCRIPTION
Adds `onefuzz status job` and `onefuzz status project` subcommands that give a brief summary of the job.   The former takes a job_id.  The later takes a project, name, and optionally build and iterates over jobs to find the identified jobs.

```
$ onefuzz status job ffe3e2da-283a-408f-a2de-edf1c7435547
job: ffe3e2da-283a-408f-a2de-edf1c7435547
project:test-b2835691 name:linux-trivial-crash-asan build:0

tasks:
a93ad5ab target:fuzz_target_1 state:stopped type:libfuzzer_crash_report
d788700e target:fuzz_target_1 state:stopped type:libfuzzer_coverage

tasks with errors:
a350cb0e type:libfuzzer_fuzz target:fuzz_target_1
error:
node reimaged during task execution

containers:
setup           count:1     name:oft-setup-223f76a2007a5beeabb3d25a24eb77ad
crashes         count:7     name:oft-crashes-9416b0eb53945d218c21193f0a8ccba7
readonly_inputs count:2     name:oft-readonly-inputs-9416b0eb53945d218c21193f0a8ccba7
reports         count:7     name:oft-reports-9416b0eb53945d218c21193f0a8ccba7
unique_reports  count:4     name:oft-unique-reports-9416b0eb53945d218c21193f0a8ccba7
no_repro        count:0     name:oft-no-repro-9416b0eb53945d218c21193f0a8ccba7
```