### PR TITLE
make missing symbols for coverage tasks more explicit

### DIFF
--- a/src/agent/onefuzz-agent/src/tasks/coverage/recorder.rs
+++ b/src/agent/onefuzz-agent/src/tasks/coverage/recorder.rs
@@ -25,7 +25,7 @@ pub struct CoverageRecorder {
     script_dir: OwnedDir,
 }
 
-const SYMBOL_EXTRACT_ERROR: &str = "Target appears to be missing sancov instrumentation.  This error can happen due to missing coverage symbols.";
+const SYMBOL_EXTRACT_ERROR: &str = "Target appears to be missing sancov instrumentation. This error can also happen if symbols for the target are not available.";
 
 impl CoverageRecorder {
     pub fn new(config: Arc<Config>) -> Self {


### PR DESCRIPTION
This moves from:

```
"Error: coverage extraction from C:\users\bcaswell\projects\bugs\andrew-coverage-fail\setup\oft-setup-5c77cfe1b181520ab0b33a16286a690a\fuzz.exe failed when processing file "11f6ad8ec52a2984abaafd7c3b516503785c2072".  target appears to be missing sancov instrumentation",
```

To even more explicit:
```
Error: Target appears to be missing sancov instrumentation.  This error can happen due to missing coverage symbols.
target_exe: C:\users\bcaswell\projects\bugs\andrew-coverage-fail\setup\oft-setup-5c77cfe1b181520ab0b33a16286a690a\fuzz.exe
input: "11f6ad8ec52a2984abaafd7c3b516503785c2072"
debugger stdout:
...
[+] disabling sympath
[+] processing fuzz.exe
[+] no tables  fuzz.exe
[+] processing C:\WINDOWS\SYSTEM32\kernel.appcore.dll
[+] no tables  C:\WINDOWS\SYSTEM32\kernel.appcore.dll
[+] processing C:\WINDOWS\System32\KERNELBASE.dll
[+] no tables  C:\WINDOWS\System32\KERNELBASE.dll
[+] processing C:\WINDOWS\System32\RPCRT4.dll
[+] no tables  C:\WINDOWS\System32\RPCRT4.dll
[+] processing C:\WINDOWS\System32\msvcrt.dll
[+] no tables  C:\WINDOWS\System32\msvcrt.dll
[+] processing C:\WINDOWS\System32\KERNEL32.DLL
[+] no tables  C:\WINDOWS\System32\KERNEL32.DLL
[+] processing ntdll.dll
[+] no tables  ntdll.dll
Error: unable to find sancov counter symbols [at DumpCounters (line 114 col 9)]
...
```