### PR TITLE
handle SkuNotAvailable errors when creating VM Scalesets

### DIFF
--- a/src/api-service/__app__/onefuzzlib/azure/vmss.py
+++ b/src/api-service/__app__/onefuzzlib/azure/vmss.py
@@ -8,7 +8,7 @@ import os
 from typing import Any, Dict, List, Optional, Union, cast
 from uuid import UUID
 
-from azure.core.exceptions import ResourceNotFoundError
+from azure.core.exceptions import ResourceExistsError, ResourceNotFoundError
 from azure.mgmt.compute.models import (
     ResourceSku,
     ResourceSkuRestrictionsType,
@@ -321,6 +321,12 @@ def create_vmss(
         compute_client.virtual_machine_scale_sets.begin_create_or_update(
             resource_group, name, params
         )
+    except ResourceExistsError as err:
+        if "SkuNotAvailable" in repr(err):
+            return Error(
+                code=ErrorCode.VM_CREATE_FAILED, errors=["creating vmss: %s" % err]
+            )
+        raise err
     except (ResourceNotFoundError, CloudError) as err:
         if "The request failed due to conflict with a concurrent request" in repr(err):
             logging.debug(


### PR DESCRIPTION
Example exception that is now handled:
```
Exception while executing function: Functions.timer_workers 
Result: Failure
Exception: ResourceExistsError: (SkuNotAvailable) The requested size for resource '/subscriptions/GUID/resourceGroups/RESOURCE_GROUP_NAME/providers/Microsoft.Compute/virtualMachineScaleSets/GUID' is currently not available in location 'REGION' zones '' for subscription 'GUID'. Please try another size or deploy to a different location or zones. See https://aka.ms/azureskunotavailable for details.
```

NOTE: This change uses the `repr` of the exception to remove the complexity of searching through nested ODataV4Format errors that make up the exception record.