### PR TITLE
make user triggered reimaging happen immediately

### DIFF
--- a/src/api-service/__app__/node/__init__.py
+++ b/src/api-service/__app__/node/__init__.py
@@ -85,7 +85,7 @@ def delete(req: func.HttpRequest) -> func.HttpResponse:
 def patch(req: func.HttpRequest) -> func.HttpResponse:
     request = parse_request(NodeGet, req)
     if isinstance(request, Error):
-        return not_ok(request, context="NodeRestart")
+        return not_ok(request, context="NodeReimage")
 
     node = Node.get_by_machine_id(request.machine_id)
     if not node:
@@ -94,7 +94,7 @@ def patch(req: func.HttpRequest) -> func.HttpResponse:
             context=request.machine_id,
         )
 
-    node.stop()
+    node.stop(done=True)
     if node.debug_keep_node:
         node.debug_keep_node = False
         node.save()

--- a/src/api-service/__app__/onefuzzlib/workers/nodes.py
+++ b/src/api-service/__app__/onefuzzlib/workers/nodes.py
@@ -281,8 +281,8 @@ class Node(BASE_NODE, ORMMixin):
         )
         return None
 
-    def stop(self) -> None:
-        self.to_reimage()
+    def stop(self, done: bool = False) -> None:
+        self.to_reimage(done=done)
         self.send_message(NodeCommand(stop=StopNodeCommand()))
 
     def set_shutdown(self) -> None:


### PR DESCRIPTION
As is, when a user triggers to reimage a node, it waits for the node to confirm the reimage.

This moves the model such that if the user triggers reimaging, the node is notified, but the reimage happens regardless of the node's confirmation.