### PR TITLE
allow nodes with multiple tasks to continue on task stop

### DIFF
--- a/src/api-service/__app__/timer_workers/__init__.py
+++ b/src/api-service/__app__/timer_workers/__init__.py
@@ -50,6 +50,7 @@ def main(mytimer: func.TimerRequest, dashboard: func.Out[str]) -> None:  # noqa:
     # get to empty scalesets, which can safely be deleted.
 
     Node.mark_outdated_nodes()
+    Node.cleanup_busy_nodes_without_work()
     nodes = Node.search_states(states=NodeState.needs_work())
     for node in sorted(nodes, key=lambda x: x.machine_id):
         logging.info("update node: %s", node.machine_id)


### PR DESCRIPTION
As is, when multiple tasks are running on a single node, if any one of them stops, the node gets reimaged.

This changes the behavior such that when a node with multiple tasks has one task stop, the other tasks will continue.