### PR TITLE
coverage containers should be unique to the project/name/build/platform

### DIFF
--- a/src/cli/onefuzz/templates/__init__.py
+++ b/src/cli/onefuzz/templates/__init__.py
@@ -32,7 +32,7 @@ def _build_container_name(
     build: str,
     platform: OS,
 ) -> Container:
-    if container_type == ContainerType.setup:
+    if container_type in [ContainerType.setup, ContainerType.coverage]:
         guid = onefuzz.utils.namespaced_guid(
             project,
             name,


### PR DESCRIPTION
Right now, the coverage containers for the same target on different builds & operating systems collide.  This isn't useful, as the methods for instrumenting coverage are different for each OS and each build changes the potential for exposed coverage..