### PR TITLE
import local relative paths

### DIFF
--- a/src/api-service/__app__/onefuzzlib/agent_events.py
+++ b/src/api-service/__app__/onefuzzlib/agent_events.py
@@ -25,9 +25,9 @@ from onefuzztypes.models import (
     WorkerRunningEvent,
 )
 
-from ..onefuzzlib.task_event import TaskEvent
-from ..onefuzzlib.tasks.main import Task
-from ..onefuzzlib.workers.nodes import Node, NodeTasks
+from .task_event import TaskEvent
+from .tasks.main import Task
+from .workers.nodes import Node, NodeTasks
 
 MAX_OUTPUT_SIZE = 4096
 

--- a/src/api-service/__app__/onefuzzlib/orm.py
+++ b/src/api-service/__app__/onefuzzlib/orm.py
@@ -40,8 +40,8 @@ from onefuzztypes.primitives import Container, PoolName, Region
 from pydantic import BaseModel, Field
 from typing_extensions import Protocol
 
-from ..onefuzzlib.secrets import save_to_keyvault
 from .azure.table import get_client
+from .secrets import save_to_keyvault
 from .telemetry import track_event_filtered
 from .updates import queue_update
 


### PR DESCRIPTION
rather than `..onefuzzlib.module`, just use `.module`