### PR TITLE
handle error condition when creating a container that is being deleted

### DIFF
--- a/src/api-service/__app__/onefuzzlib/azure/containers.py
+++ b/src/api-service/__app__/onefuzzlib/azure/containers.py
@@ -10,7 +10,7 @@ import urllib.parse
 from typing import Dict, Optional, Union, cast
 
 from azure.common import AzureHttpError, AzureMissingResourceHttpError
-from azure.core.exceptions import ResourceNotFoundError
+from azure.core.exceptions import ResourceExistsError, ResourceNotFoundError
 from azure.storage.blob import (
     BlobClient,
     BlobSasPermissions,
@@ -123,7 +123,9 @@ def create_container(
         client = get_blob_service(account).get_container_client(container)
         try:
             client.create_container(metadata=metadata)
-        except AzureHttpError as err:
+        except (ResourceExistsError, AzureHttpError) as err:
+            # note: resource exists error happens during creation if the container
+            # is being deleted
             logging.error(
                 (
                     "unable to create container.  account: %s "


### PR DESCRIPTION
When users try to create a container immediately after deleting it, Azure will fail saying the deletion is in-progress.

catching ResourceExistsError during create handles this error.