### PR TITLE
Renames application insights keys to be more clear

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -35,8 +35,8 @@ nodes and the service API running in the Azure Functions instance.
 
 1. The rust library [onefuzz::telemetry](../src/agent/onefuzz-telemetry/src/lib.rs)
    provides a detailed set of telemetry types, as well as the function
-   `can_share`, which gates if a given telemetry field should be sent to the
-   Microsoft central telemetry instance.
+   `can_share_with_microsoft`, which gates if a given telemetry field should be
+   sent to the Microsoft central telemetry instance.
 1. The Python library
    [onefuzzlib.telemetry](../src/api-service/__app__/onefuzzlib/telemetry.py)
    provides a filtering mechanism to identify a per-object set of filtering

--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -1643,6 +1643,7 @@ version = "0.1.0"
 dependencies = [
  "appinsights",
  "log",
+ "serde",
  "tokio",
  "uuid",
 ]

--- a/src/agent/onefuzz-agent/src/local/common.rs
+++ b/src/agent/onefuzz-agent/src/local/common.rs
@@ -166,13 +166,11 @@ pub fn build_common_config(args: &ArgMatches<'_>) -> Result<CommonConfig> {
     };
 
     let config = CommonConfig {
-        heartbeat_queue: None,
-        instrumentation_key: None,
-        telemetry_key: None,
         job_id,
         task_id,
         instance_id,
         setup_dir,
+        ..Default::default()
     };
     Ok(config)
 }

--- a/src/agent/onefuzz-agent/src/managed/cmd.rs
+++ b/src/agent/onefuzz-agent/src/managed/cmd.rs
@@ -23,7 +23,10 @@ pub async fn run(args: &clap::ArgMatches<'_>) -> Result<()> {
 }
 
 fn init_telemetry(config: &CommonConfig) {
-    onefuzz_telemetry::set_appinsights_clients(config.instrumentation_key, config.telemetry_key);
+    onefuzz_telemetry::set_appinsights_clients(
+        config.instance_telemetry_key.clone(),
+        config.microsoft_telemetry_key.clone(),
+    );
 }
 
 pub fn args(name: &str) -> App<'static, 'static> {

--- a/src/agent/onefuzz-agent/src/tasks/config.rs
+++ b/src/agent/onefuzz-agent/src/tasks/config.rs
@@ -5,7 +5,10 @@
 use crate::tasks::{analysis, coverage, fuzz, heartbeat::*, merge, report};
 use anyhow::Result;
 use onefuzz::machine_id::{get_machine_id, get_scaleset_name};
-use onefuzz_telemetry::{self as telemetry, Event::task_start, EventData, Role};
+use onefuzz_telemetry::{
+    self as telemetry, Event::task_start, EventData, InstanceTelemetryKey, MicrosoftTelemetryKey,
+    Role,
+};
 use reqwest::Url;
 use serde::{self, Deserialize};
 use std::path::PathBuf;
@@ -26,11 +29,15 @@ pub struct CommonConfig {
 
     pub instance_id: Uuid,
 
-    pub instrumentation_key: Option<Uuid>,
-
     pub heartbeat_queue: Option<Url>,
 
-    pub telemetry_key: Option<Uuid>,
+    // TODO: remove the alias once the service has been updated to match
+    #[serde(alias = "instrumentation_key")]
+    pub instance_telemetry_key: Option<InstanceTelemetryKey>,
+
+    // TODO: remove the alias once the service has been updated to match
+    #[serde(alias = "telemetry_key")]
+    pub microsoft_telemetry_key: Option<MicrosoftTelemetryKey>,
 
     #[serde(default)]
     pub setup_dir: PathBuf,

--- a/src/agent/onefuzz-supervisor/src/config.rs
+++ b/src/agent/onefuzz-supervisor/src/config.rs
@@ -6,6 +6,7 @@ use onefuzz::{
     http::{is_auth_error_code, ResponseExt},
     jitter::delay_with_jitter,
 };
+use onefuzz_telemetry::{InstanceTelemetryKey, MicrosoftTelemetryKey};
 use reqwest_retry::SendRetry;
 use std::{
     path::{Path, PathBuf},
@@ -25,9 +26,13 @@ pub struct StaticConfig {
 
     pub onefuzz_url: Url,
 
-    pub instrumentation_key: Option<Uuid>,
+    // TODO: remove the alias once the service has been updated to match
+    #[serde(alias = "instrumentation_key")]
+    pub instance_telemetry_key: Option<InstanceTelemetryKey>,
 
-    pub telemetry_key: Option<Uuid>,
+    // TODO: remove the alias once the service has been updated to match
+    #[serde(alias = "telemetry_key")]
+    pub microsoft_telemetry_key: Option<MicrosoftTelemetryKey>,
 
     pub heartbeat_queue: Option<Url>,
 
@@ -43,9 +48,13 @@ struct RawStaticConfig {
 
     pub onefuzz_url: Url,
 
-    pub instrumentation_key: Option<Uuid>,
+    // TODO: remove the alias once the service has been updated to match
+    #[serde(alias = "instrumentation_key")]
+    pub instance_telemetry_key: Option<InstanceTelemetryKey>,
 
-    pub telemetry_key: Option<Uuid>,
+    // TODO: remove the alias once the service has been updated to match
+    #[serde(alias = "telemetry_key")]
+    pub microsoft_telemetry_key: Option<MicrosoftTelemetryKey>,
 
     pub heartbeat_queue: Option<Url>,
 
@@ -73,8 +82,8 @@ impl StaticConfig {
             credentials,
             pool_name: config.pool_name,
             onefuzz_url: config.onefuzz_url,
-            instrumentation_key: config.instrumentation_key,
-            telemetry_key: config.telemetry_key,
+            microsoft_telemetry_key: config.microsoft_telemetry_key,
+            instance_telemetry_key: config.instance_telemetry_key,
             heartbeat_queue: config.heartbeat_queue,
             instance_id: config.instance_id,
         };
@@ -103,17 +112,19 @@ impl StaticConfig {
             None
         };
 
-        let instrumentation_key = if let Ok(key) = std::env::var("ONEFUZZ_INSTRUMENTATION_KEY") {
-            Some(Uuid::parse_str(&key)?)
-        } else {
-            None
-        };
+        let instance_telemetry_key =
+            if let Ok(key) = std::env::var("ONEFUZZ_INSTANCE_TELEMETRY_KEY") {
+                Some(InstanceTelemetryKey::new(Uuid::parse_str(&key)?))
+            } else {
+                None
+            };
 
-        let telemetry_key = if let Ok(key) = std::env::var("ONEFUZZ_TELEMETRY_KEY") {
-            Some(Uuid::parse_str(&key)?)
-        } else {
-            None
-        };
+        let microsoft_telemetry_key =
+            if let Ok(key) = std::env::var("ONEFUZZ_MICROSOFT_TELEMETRY_KEY") {
+                Some(MicrosoftTelemetryKey::new(Uuid::parse_str(&key)?))
+            } else {
+                None
+            };
 
         let credentials =
             ClientCredentials::new(client_id, client_secret, onefuzz_url.to_string(), tenant)
@@ -124,8 +135,8 @@ impl StaticConfig {
             credentials,
             pool_name,
             onefuzz_url,
-            instrumentation_key,
-            telemetry_key,
+            instance_telemetry_key,
+            microsoft_telemetry_key,
             heartbeat_queue,
         })
     }

--- a/src/agent/onefuzz-supervisor/src/main.rs
+++ b/src/agent/onefuzz-supervisor/src/main.rs
@@ -6,8 +6,6 @@ extern crate async_trait;
 #[macro_use]
 extern crate downcast_rs;
 #[macro_use]
-extern crate serde;
-#[macro_use]
 extern crate clap;
 #[macro_use]
 extern crate anyhow;
@@ -226,7 +224,8 @@ async fn run_agent(config: StaticConfig) -> Result<()> {
 }
 
 fn init_telemetry(config: &StaticConfig) {
-    let inst_key = config.instrumentation_key;
-    let tele_key = config.telemetry_key;
-    telemetry::set_appinsights_clients(inst_key, tele_key);
+    telemetry::set_appinsights_clients(
+        config.instance_telemetry_key.clone(),
+        config.microsoft_telemetry_key.clone(),
+    );
 }

--- a/src/agent/onefuzz-telemetry/Cargo.toml
+++ b/src/agent/onefuzz-telemetry/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT"
 appinsights = "0.1"
 log = "0.4"
 uuid = { version = "0.8", features = ["serde", "v4"] }
+serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]
 tokio = { version = "0.2" }

--- a/src/agent/onefuzz/src/lib.rs
+++ b/src/agent/onefuzz/src/lib.rs
@@ -8,9 +8,6 @@ extern crate anyhow;
 extern crate lazy_static;
 
 #[macro_use]
-extern crate serde;
-
-#[macro_use]
 extern crate onefuzz_telemetry;
 
 pub mod asan;

--- a/src/proxy-manager/Cargo.lock
+++ b/src/proxy-manager/Cargo.lock
@@ -1021,6 +1021,7 @@ version = "0.1.0"
 dependencies = [
  "appinsights",
  "log",
+ "serde",
  "uuid",
 ]
 

--- a/src/proxy-manager/src/config.rs
+++ b/src/proxy-manager/src/config.rs
@@ -3,7 +3,9 @@
 
 use crate::proxy;
 use anyhow::Result;
-use onefuzz_telemetry::{set_appinsights_clients, EventData, Role};
+use onefuzz_telemetry::{
+    set_appinsights_clients, EventData, InstanceTelemetryKey, MicrosoftTelemetryKey, Role,
+};
 use reqwest_retry::SendRetry;
 use serde::{Deserialize, Serialize};
 use std::{fs::File, io::BufReader, path::PathBuf};
@@ -43,8 +45,15 @@ pub struct Forward {
 #[derive(Debug, Deserialize, Serialize, PartialEq, Clone)]
 pub struct ConfigData {
     pub instance_id: Uuid,
-    pub instrumentation_key: Option<Uuid>,
-    pub telemetry_key: Option<Uuid>,
+
+    // TODO: remove the alias once the service has been updated to match
+    #[serde(alias = "instrumentation_key")]
+    pub instance_telemetry_key: Option<InstanceTelemetryKey>,
+
+    // TODO: remove the alias once the service has been updated to match
+    #[serde(alias = "telemetry_key")]
+    pub microsoft_telemetry_key: Option<MicrosoftTelemetryKey>,
+
     pub region: String,
     pub url: Url,
     pub notification: Url,
@@ -73,7 +82,10 @@ impl Config {
         let data: ConfigData =
             serde_json::from_reader(r).map_err(|source| ProxyError::ParseError { source })?;
 
-        set_appinsights_clients(data.instrumentation_key, data.telemetry_key);
+        set_appinsights_clients(
+            data.instance_telemetry_key.clone(),
+            data.microsoft_telemetry_key.clone(),
+        );
 
         onefuzz_telemetry::set_property(EventData::Region(data.region.to_owned()));
         onefuzz_telemetry::set_property(EventData::Version(env!("ONEFUZZ_VERSION").to_string()));


### PR DESCRIPTION
* renames `telemetry_key` to `microsoft_telemetry_key`
* renames `instrumentation_key` to `instance_telemetry_key`
* renames `can_share` to `can_share_with_microsoft`
* renames the `applicationinsights-rs` instances to `internal` and `microsoft` respective of the keys used during construction.

This clarifies the underlying use of Application Insights keys and uses struct tuple to ensure the keys are used correctly via rust's type checker.