### PR TITLE
Actively tail worker stdio from supervisor agent

### DIFF
--- a/src/agent/onefuzz-supervisor/src/buffer.rs
+++ b/src/agent/onefuzz-supervisor/src/buffer.rs
@@ -1,0 +1,75 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TailBuffer {
+    data: Vec<u8>,
+    capacity: usize,
+}
+
+impl TailBuffer {
+    pub fn new(capacity: usize) -> Self {
+        let data = Vec::with_capacity(capacity);
+        Self { data, capacity }
+    }
+
+    pub fn data(&self) -> &[u8] {
+        &self.data
+    }
+
+    pub fn to_string_lossy(&self) -> String {
+        String::from_utf8_lossy(self.data()).to_string()
+    }
+}
+
+impl std::io::Write for TailBuffer {
+    fn write(&mut self, new_data: &[u8]) -> std::io::Result<usize> {
+        // Write the new data to the internal buffer, allocating internally as needed.
+        self.data.extend(new_data);
+
+        // Shift and truncate the buffer if it is too big.
+        if self.data.len() > self.capacity {
+            let lo = self.data.len() - self.capacity;
+            let range = lo..self.data.len();
+            self.data.copy_within(range, 0);
+            self.data.truncate(self.capacity);
+        }
+
+        Ok(new_data.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+
+    use super::*;
+
+    #[test]
+    fn test_tail_buffer() {
+        let mut buf = TailBuffer::new(5);
+
+        assert!(buf.data().is_empty());
+
+        buf.write(&[1, 2, 3]).unwrap();
+        assert_eq!(buf.data(), &[1, 2, 3]);
+
+        buf.write(&[]).unwrap();
+        assert_eq!(buf.data(), &[1, 2, 3]);
+
+        buf.write(&[4, 5]).unwrap();
+        assert_eq!(buf.data(), &[1, 2, 3, 4, 5]);
+
+        buf.write(&[6, 7, 8]).unwrap();
+        assert_eq!(buf.data(), &[4, 5, 6, 7, 8]);
+
+        buf.write(&[9, 10, 11, 12, 13]).unwrap();
+        assert_eq!(buf.data(), &[9, 10, 11, 12, 13]);
+
+        buf.write(&[14, 15, 16, 17, 18, 19, 20, 21, 22, 23]).unwrap();
+        assert_eq!(buf.data(), &[19, 20, 21, 22, 23]);
+    }
+}

--- a/src/agent/onefuzz-supervisor/src/buffer.rs
+++ b/src/agent/onefuzz-supervisor/src/buffer.rs
@@ -69,7 +69,8 @@ mod tests {
         buf.write(&[9, 10, 11, 12, 13]).unwrap();
         assert_eq!(buf.data(), &[9, 10, 11, 12, 13]);
 
-        buf.write(&[14, 15, 16, 17, 18, 19, 20, 21, 22, 23]).unwrap();
+        buf.write(&[14, 15, 16, 17, 18, 19, 20, 21, 22, 23])
+            .unwrap();
         assert_eq!(buf.data(), &[19, 20, 21, 22, 23]);
     }
 }

--- a/src/agent/onefuzz-supervisor/src/buffer.rs
+++ b/src/agent/onefuzz-supervisor/src/buffer.rs
@@ -69,8 +69,7 @@ mod tests {
         buf.write(&[9, 10, 11, 12, 13]).unwrap();
         assert_eq!(buf.data(), &[9, 10, 11, 12, 13]);
 
-        buf.write(&[14, 15, 16, 17, 18, 19, 20, 21, 22, 23])
-            .unwrap();
-        assert_eq!(buf.data(), &[19, 20, 21, 22, 23]);
+        buf.write(&[14, 15, 16, 17, 18, 19, 20, 21, 22]).unwrap();
+        assert_eq!(buf.data(), &[18, 19, 20, 21, 22]);
     }
 }

--- a/src/agent/onefuzz-supervisor/src/main.rs
+++ b/src/agent/onefuzz-supervisor/src/main.rs
@@ -31,6 +31,7 @@ use structopt::StructOpt;
 
 pub mod agent;
 pub mod auth;
+pub mod buffer;
 pub mod commands;
 pub mod config;
 pub mod coordinator;

--- a/src/agent/onefuzz-supervisor/src/worker.rs
+++ b/src/agent/onefuzz-supervisor/src/worker.rs
@@ -251,8 +251,14 @@ struct RedirectedChild {
 
 impl RedirectedChild {
     pub fn new(mut child: Child) -> Result<Self> {
-        let stderr = child.stderr.take().ok_or_else(|| format_err!("onefuzz-agent stderr not piped"))?;
-        let stdout = child.stdout.take().ok_or_else(|| format_err!("onefuzz-agent stdout not piped"))?;
+        let stderr = child
+            .stderr
+            .take()
+            .ok_or_else(|| format_err!("onefuzz-agent stderr not piped"))?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| format_err!("onefuzz-agent stdout not piped"))?;
         let streams = Some(StreamReaderThreads::new(stderr, stdout));
         Ok(Self { child, streams })
     }
@@ -305,8 +311,16 @@ impl StreamReaderThreads {
     }
 
     pub fn join(self) -> Result<CapturedStreams> {
-        let stderr = self.stderr.join().map_err(|_| format_err!("stderr tail thread panicked"))?.to_string_lossy();
-        let stdout = self.stdout.join().map_err(|_| format_err!("stdout tail thread panicked"))?.to_string_lossy();
+        let stderr = self
+            .stderr
+            .join()
+            .map_err(|_| format_err!("stderr tail thread panicked"))?
+            .to_string_lossy();
+        let stdout = self
+            .stdout
+            .join()
+            .map_err(|_| format_err!("stdout tail thread panicked"))?
+            .to_string_lossy();
 
         Ok(CapturedStreams { stderr, stdout })
     }
@@ -317,7 +331,9 @@ impl IWorkerChild for RedirectedChild {
         let output = if let Some(exit_status) = self.child.try_wait()? {
             let exit_status = exit_status.into();
             let streams = self.streams.take();
-            let streams = streams.ok_or_else(|| format_err!("onefuzz-agent streams not captured"))?.join()?;
+            let streams = streams
+                .ok_or_else(|| format_err!("onefuzz-agent streams not captured"))?
+                .join()?;
 
             Some(Output {
                 exit_status,
@@ -388,7 +404,6 @@ impl std::io::Write for CircularBuffer {
         Ok(())
     }
 }
-
 
 #[cfg(test)]
 pub mod double;

--- a/src/agent/onefuzz-supervisor/src/worker.rs
+++ b/src/agent/onefuzz-supervisor/src/worker.rs
@@ -285,6 +285,9 @@ impl StreamReaderThreads {
             let mut tmp = [0u8; MAX_TAIL_LEN];
 
             while let Ok(count) = stderr.read(&mut tmp) {
+                if count == 0 {
+                    break;
+                }
                 if let Err(err) = std::io::copy(&mut &tmp[..count], &mut buf) {
                     log::error!("error copying to circular buffer: {}", err);
                     break;
@@ -299,6 +302,10 @@ impl StreamReaderThreads {
             let mut tmp = [0u8; MAX_TAIL_LEN];
 
             while let Ok(count) = stdout.read(&mut tmp) {
+                if count == 0 {
+                    break;
+                }
+
                 if let Err(err) = std::io::copy(&mut &tmp[..count], &mut buf) {
                     log::error!("error copying to circular buffer: {}", err);
                     break;

--- a/src/agent/onefuzz-supervisor/src/worker.rs
+++ b/src/agent/onefuzz-supervisor/src/worker.rs
@@ -228,8 +228,6 @@ impl IWorkerRunner for WorkerRunner {
         cmd.arg("managed");
         cmd.arg("config.json");
         cmd.arg(setup_dir);
-        cmd.stderr(Stdio::piped());
-        cmd.stdout(Stdio::piped());
 
         let child = cmd.spawn().context("onefuzz-agent failed to start")?;
         let child = Box::new(child);

--- a/src/agent/onefuzz-supervisor/src/worker.rs
+++ b/src/agent/onefuzz-supervisor/src/worker.rs
@@ -3,7 +3,7 @@
 
 use std::{
     path::{Path, PathBuf},
-    process::{Child, Command},
+    process::{Child, Command, Stdio},
 };
 
 use anyhow::{Context as AnyhowContext, Result};
@@ -228,6 +228,8 @@ impl IWorkerRunner for WorkerRunner {
         cmd.arg("managed");
         cmd.arg("config.json");
         cmd.arg(setup_dir);
+        cmd.stderr(Stdio::piped());
+        cmd.stdout(Stdio::piped());
 
         let child = cmd.spawn().context("onefuzz-agent failed to start")?;
         let child = Box::new(child);

--- a/src/agent/onefuzz-supervisor/src/worker.rs
+++ b/src/agent/onefuzz-supervisor/src/worker.rs
@@ -3,7 +3,7 @@
 
 use std::{
     path::{Path, PathBuf},
-    process::{Child, Command, Stdio},
+    process::{Child, Command},
 };
 
 use anyhow::{Context as AnyhowContext, Result};

--- a/src/agent/onefuzz-supervisor/src/worker/tests.rs
+++ b/src/agent/onefuzz-supervisor/src/worker/tests.rs
@@ -226,3 +226,36 @@ async fn test_worker_done() {
     assert!(matches!(worker, Worker::Done(..)));
     assert_eq!(events, vec![]);
 }
+
+#[cfg(target_os = "linux")]
+#[test]
+fn test_redirected_child() {
+    use std::iter::repeat;
+    use std::process::Command;
+
+    // Assume OS pipe capacity of 16 pages, each 4096 bytes.
+    //
+    // For each stream,
+    //
+    //   1. Write enough of one char to fill up the OS pipe.
+    //   2. Write a smaller count (< tail size) of another char to overflow it.
+    //
+    // Our tailing buffer has size 4096, so we will expect to see all of the
+    // bytes from the second char, and the remainder from the first char.
+    let script = "import sys;\
+sys.stdout.write('A' * 65536 + 'B' * 4000);\
+sys.stderr.write('C' * 65536 + 'D' * 4000)";
+
+    let mut cmd = Command::new("python3");
+    cmd.args(&["-c", script]);
+
+    let mut redirected = RedirectedChild::spawn(cmd).unwrap();
+    redirected.child.wait().unwrap();
+    let captured = redirected.streams.unwrap().join().unwrap();
+
+    let stdout: String = repeat('A').take(96).chain(repeat('B').take(4000)).collect();
+    assert_eq!(captured.stdout, stdout);
+
+    let stderr: String = repeat('C').take(96).chain(repeat('D').take(4000)).collect();
+    assert_eq!(captured.stderr, stderr);
+}


### PR DESCRIPTION
In the supervisor agent, incrementally read from the running worker agent's redirected stderr and stdout, instead of waiting until it exits.

The worker agent's stderr and stdout are piped to the supervisor when tasks are run. The supervisor's `WorkerRunner` does _not_ use `wait_with_output()`, which handles this (at the cost of blocking). Instead, it makes repeated calls to to `try_wait()` on timer-based state transitions, and does not try to read the pipes until the worker exits. But when one of the child's pipes is full, the child can block forever waiting on a `write(2)`, such as in a `log` facade implementation.

This bug has not been caught because we control the child worker agent, and until recently, it mostly only wrote to these streams using `env_logger` at its default log level. But recent work: (1) set more-verbose `INFO` level default logging, (2) logged stderr/stdout lines of child processes of _the worker_, and (3) some user targets logged very verbosely for debugging. This surfaced the underlying issue.