### PR TITLE
Use non-deprecated atomic method

### DIFF
--- a/src/agent/onefuzz-telemetry/src/lib.rs
+++ b/src/agent/onefuzz-telemetry/src/lib.rs
@@ -200,7 +200,7 @@ mod global {
     pub fn set_clients(instance: Option<TelemetryClient>, shared: Option<TelemetryClient>) {
         use Ordering::SeqCst;
 
-        let last_state = STATE.compare_and_swap(UNSET, SETTING, SeqCst);
+        let last_state = STATE.compare_exchange(UNSET, SETTING, SeqCst, SeqCst);
 
         if last_state == SETTING {
             panic!("race while setting telemetry client");
@@ -230,7 +230,7 @@ mod global {
     pub fn take_clients() -> Vec<TelemetryClient> {
         use Ordering::SeqCst;
 
-        let last_state = STATE.compare_and_swap(SET, SETTING, SeqCst);
+        let last_state = STATE.compare_exchange(SET, SETTING, SeqCst, SeqCst);
 
         if last_state == SETTING {
             panic!("race while taking telemetry client");

--- a/src/agent/onefuzz-telemetry/src/lib.rs
+++ b/src/agent/onefuzz-telemetry/src/lib.rs
@@ -207,7 +207,7 @@ mod global {
             Ok(SET) => panic!("tried to reset telemetry client"),
             Ok(UNSET) => {}
             Ok(state) => panic!("unknown telemetry client state while setting: {}", state),
-            Err(err) => panic!("failed to set telemetry client state: {}", err),
+            Err(state) => panic!("failed to set telemetry client state: {}", state),
         }
 
         unsafe {
@@ -235,7 +235,7 @@ mod global {
             Ok(SET) => {}
             Ok(UNSET) => panic!("tried to take unset telemetry client"),
             Ok(state) => panic!("unknown telemetry client state while taking: {}", state),
-            Err(err) => panic!("failed to take telemetry client state: {}", err),
+            Err(state) => panic!("failed to take telemetry client state: {}", state),
         }
 
         let instance = unsafe { CLIENTS.instance.take() };

--- a/src/agent/onefuzz-telemetry/src/lib.rs
+++ b/src/agent/onefuzz-telemetry/src/lib.rs
@@ -200,17 +200,15 @@ mod global {
     pub fn set_clients(instance: Option<TelemetryClient>, shared: Option<TelemetryClient>) {
         use Ordering::SeqCst;
 
-        let last_state = STATE.compare_exchange(UNSET, SETTING, SeqCst, SeqCst);
+        let result = STATE.compare_exchange(UNSET, SETTING, SeqCst, SeqCst);
 
-        if last_state == SETTING {
-            panic!("race while setting telemetry client");
+        match result {
+            Ok(SETTING) => panic!("race while setting telemetry client"),
+            Ok(SET) => panic!("tried to reset telemetry client"),
+            Ok(UNSET) => {}
+            Ok(state) => panic!("unknown telemetry client state while setting: {}", state),
+            Err(err) => panic!("failed to set telemetry client state: {}", err),
         }
-
-        if last_state == SET {
-            panic!("tried to reset telemetry client");
-        }
-
-        assert_eq!(last_state, UNSET, "unexpected telemetry client state");
 
         unsafe {
             CLIENTS.instance = instance.map(RwLock::new);
@@ -230,17 +228,15 @@ mod global {
     pub fn take_clients() -> Vec<TelemetryClient> {
         use Ordering::SeqCst;
 
-        let last_state = STATE.compare_exchange(SET, SETTING, SeqCst, SeqCst);
+        let result = STATE.compare_exchange(SET, SETTING, SeqCst, SeqCst);
 
-        if last_state == SETTING {
-            panic!("race while taking telemetry client");
+        match result {
+            Ok(SETTING) => panic!("race while taking telemetry client"),
+            Ok(SET) => {}
+            Ok(UNSET) => panic!("tried to take unset telemetry client"),
+            Ok(state) => panic!("unknown telemetry client state while taking: {}", state),
+            Err(err) => panic!("failed to take telemetry client state: {}", err),
         }
-
-        if last_state == UNSET {
-            panic!("tried to take unset telemetry client");
-        }
-
-        assert_eq!(last_state, SET, "unexpected telemetry client state");
 
         let instance = unsafe { CLIENTS.instance.take() };
         let shared = unsafe { CLIENTS.shared.take() };


### PR DESCRIPTION
As of `rustc` 1.50.0, [`AtomicUsize::compare_and_swap()`](https://doc.rust-lang.org/std/sync/atomic/struct.AtomicUsize.html#method.compare_and_swap) is deprecated.

The appropriate migration is described [here](https://doc.rust-lang.org/std/sync/atomic/struct.AtomicUsize.html#migrating-to-compare_exchange-and-compare_exchange_weak).