### PR TITLE
remove azure-mgmt-web from prereq deployments

### DIFF
--- a/src/deployment/requirements.txt
+++ b/src/deployment/requirements.txt
@@ -6,7 +6,6 @@ azure-mgmt-eventgrid==3.0.0rc7
 azure-mgmt-resource==10.2.0
 azure-mgmt-servicebus==0.6.0
 azure-mgmt-storage==16.0.0
-azure-mgmt-web==0.48.0
 azure-storage-blob==12.5.0
 azure-storage-queue==12.1.3
 cryptography<3.0.0,>=2.3.1


### PR DESCRIPTION
We don't use `azure-mgmt-web` during deployment.  This removes it from requirements.txt