### PR TITLE
handle OperationNotAllowed errors when creating VMSS

### DIFF
--- a/src/api-service/__app__/onefuzzlib/azure/vmss.py
+++ b/src/api-service/__app__/onefuzzlib/azure/vmss.py
@@ -322,9 +322,10 @@ def create_vmss(
             resource_group, name, params
         )
     except ResourceExistsError as err:
-        if "SkuNotAvailable" in repr(err):
+        err_str = str(err)
+        if "SkuNotAvailable" in err_str or "OperationNotAllowed" in err_str:
             return Error(
-                code=ErrorCode.VM_CREATE_FAILED, errors=["creating vmss: %s" % err]
+                code=ErrorCode.VM_CREATE_FAILED, errors=[f"creating vmss: {err_str}"]
             )
         raise err
     except (ResourceNotFoundError, CloudError) as err:


### PR DESCRIPTION
Catch errors from Azure as scaleset creation failures rather than exceptions.

This failure happens when Azure disallows creation of scalesets.  This can be triggered by quota issues.

As an example, when the subscription doesn't have quota, users will see this error:

ResourceExistsError: (OperationNotAllowed) Operation could not be completed as it results in exceeding approved Total Regional Cores quota. Additional details - Deployment Model: Resource Manager, Location: eastus2, Current Limit: 100, Current Usage: 100, Additional Required: 20, (Minimum) New Limit Required: 120. Submit a request for Quota increase at <REDACTED> by specifying parameters listed in the ‘Details’ section for deployment to succeed. Please read more about quota limits at https://docs.microsoft.com/en-us/azure/azure-supportability/regional-quota-requests.