### PR TITLE
allow unnecessary_wraps in coverage

### DIFF
--- a/src/agent/coverage/src/block/windows.rs
+++ b/src/agent/coverage/src/block/windows.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(clippy::unnecessary_wraps)]
+
 use std::collections::BTreeMap;
 use std::process::Command;
 use std::time::{Duration, Instant};


### PR DESCRIPTION
Addresses a warning from `clippy` with a raised priority warning.