### PR TITLE
simplify batch-processing log

### DIFF
--- a/src/agent/onefuzz-agent/src/tasks/generic/input_poller.rs
+++ b/src/agent/onefuzz-agent/src/tasks/generic/input_poller.rs
@@ -128,10 +128,8 @@ impl<M> InputPoller<M> {
 
         let mut read_dir = fs::read_dir(&to_process.path).await?;
         while let Some(file) = read_dir.next().await {
-            info!("Processing batch-downloaded input {:?}", file);
-
-            let file = file?;
-            let path = file.path();
+            let path = file?.path();
+            info!("Processing batch-downloaded input: {}", path.display());
 
             // Compute the file name relative to the synced directory, and thus the
             // container.
@@ -182,7 +180,7 @@ impl<M> InputPoller<M> {
                     delay_with_jitter(POLL_INTERVAL).await;
                 }
                 State::Downloaded(_msg, _url, input, _tempdir) => {
-                    info!("Processing downloaded input: {:?}", input);
+                    info!("Processing downloaded input: {}", input.display());
                 }
                 _ => {}
             }


### PR DESCRIPTION
Simplifies the logs from:

`Processing batch-downloaded input Ok(DirEntry(DirEntry("task_crashes_1/input-b4c3482194a6ebd275577ea52255fcea3358f3220c408d3c53b9f32b653e6586.txt")))`

to:

`Processing batch-downloaded input: task_crashes_1/input-b4c3482194a6ebd275577ea52255fcea3358f3220c408d3c53b9f32b653e6586.txt`