### PR TITLE
pre-define clusterfuzz as a dependency

### DIFF
--- a/src/agent/libclusterfuzz/README.md
+++ b/src/agent/libclusterfuzz/README.md
@@ -1,0 +1,3 @@
+An upcoming PR will include rust code ported from clusterfuzz.  This is
+intended to enable our component governmence process to pick this up such that
+we can have our legal review prior to the inclusion of the code.

--- a/src/agent/libclusterfuzz/README.md
+++ b/src/agent/libclusterfuzz/README.md
@@ -1,3 +1,3 @@
 An upcoming PR will include rust code ported from clusterfuzz.  This is
-intended to enable our component governmence process to pick this up such that
+intended to enable our component governance process to pick this up such that
 we can have our legal review prior to the inclusion of the code.

--- a/src/agent/libclusterfuzz/cgmanifest.json
+++ b/src/agent/libclusterfuzz/cgmanifest.json
@@ -2,11 +2,10 @@
   "Registrations": [
     {
       "Component": {
-        "Type": "python",
-        "Other": {
-          "Name": "clusterfuzz",
-          "Version": "2.4.0",
-          "DownloadUrl": "https://github.com/google/clusterfuzz/archive/v2.4.0.zip"
+        "Type": "git",
+        "Git": {
+          "RepositoryUrl": "https://github.com/google/clusterfuzz",
+          "CommitHash": "d85aed776d120e6df26aa1cd0335fc7a53d76816"
         }
       }
     }

--- a/src/agent/libclusterfuzz/cgmanifest.json
+++ b/src/agent/libclusterfuzz/cgmanifest.json
@@ -1,0 +1,14 @@
+{
+  "Registrations": [
+    {
+      "Component": {
+        "Type": "python",
+        "Other": {
+          "Name": "clusterfuzz",
+          "Version": "2.4.0",
+          "DownloadUrl": "https://github.com/google/clusterfuzz/archive/v2.4.0.zip"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
An upcoming PR will include rust code ported from clusterfuzz.  This is intended to enable our component governance process to pick this up such that we can have our legal review prior to the inclusion of the code.