### PR TITLE
remove azure-mgmt-servicebus from deployment dependencies

### DIFF
--- a/src/deployment/requirements.txt
+++ b/src/deployment/requirements.txt
@@ -4,7 +4,6 @@ azure-cosmosdb-table==1.0.6
 azure-graphrbac==0.60.0
 azure-mgmt-eventgrid==3.0.0rc7
 azure-mgmt-resource==12.0.0
-azure-mgmt-servicebus==0.6.0
 azure-mgmt-storage==17.0.0
 azure-storage-blob==12.5.0
 azure-storage-queue==12.1.3


### PR DESCRIPTION
Remove ServiceBus dependency, as this isn't used in OneFuzz