### PR TITLE
ignore RUSTSEC-2019-0036

### DIFF
--- a/src/ci/agent.sh
+++ b/src/ci/agent.sh
@@ -31,7 +31,8 @@ cd src/agent
 cargo fmt -- --check
 # RUSTSEC-2020-0016: a dependency net2 (pulled in from tokio) is deprecated
 # RUSTSEC-2020-0036: a dependency failure (pulled from proc-maps) is deprecated
-cargo audit --deny warnings --deny unmaintained --deny unsound --deny yanked --ignore RUSTSEC-2020-0016 --ignore RUSTSEC-2020-0036
+# RUSTSEC-2019-0036: a dependency failure (pulled from proc-maps) has type confusion vulnerability
+cargo audit --deny warnings --deny unmaintained --deny unsound --deny yanked --ignore RUSTSEC-2020-0016 --ignore RUSTSEC-2020-0036 --ignore RUSTSEC-2019-0036
 cargo-license -j > data/licenses.json
 cargo build --release --locked
 cargo clippy --release -- -D warnings


### PR DESCRIPTION
This ignores [RUSTSEC-2019-0036](https://rustsec.org/advisories/RUSTSEC-2019-0036), a type confusion bug in  [failure](https://crates.io/crates/failure) (see https://github.com/rust-lang-nursery/failure/issues/336).  

At the moment,  [failure](https://crates.io/crates/failure) is only brought in as a nested dependency of [proc-maps](https://crates.io/crates/proc-maps) and does not implement the pattern required to hit the type confusion bug.  Additionally, the  [failure](https://crates.io/crates/failure) dependency is only used on OSX which we don't support (see https://github.com/rbspy/proc-maps/pull/7).

As such, this security issue does not impact OneFuzz at the moment, but we should work to remove the dependency.  Future updates to third-party dependencies may expose the vulnerability.  This is a short-term fix for CICD only.

Issue to addressing this long term: #655