### PR TITLE
Simplify types used in stack walking

### DIFF
--- a/src/agent/coverage/src/code/tests.rs
+++ b/src/agent/coverage/src/code/tests.rs
@@ -103,6 +103,18 @@ macro_rules! from_json {
     }};
 }
 
+#[cfg(windows)]
+const EXE: &str = "c:\\bin\\fuzz.exe";
+
+#[cfg(not(windows))]
+const EXE: &str = "/bin/fuzz.exe";
+
+#[cfg(windows)]
+const LIB: &str = "c:\\lib\\libpthread.dll";
+
+#[cfg(not(windows))]
+const LIB: &str = "/lib/libpthread.so.0";
+
 fn module(s: &str) -> ModulePath {
     ModulePath::new(s.into()).unwrap()
 }
@@ -112,7 +124,8 @@ fn test_cmd_filter_empty_def() {
     let filter = from_json!([]);
 
     // All modules and symbols are included by default.
-    let exe = module("/bin/fuzz.exe");
+
+    let exe = module(EXE);
     assert!(filter.includes_module(&exe));
     assert!(filter.includes_symbol(&exe, "main"));
     assert!(filter.includes_symbol(&exe, "_start"));
@@ -120,7 +133,7 @@ fn test_cmd_filter_empty_def() {
     assert!(filter.includes_symbol(&exe, "__asan_memcpy"));
     assert!(filter.includes_symbol(&exe, "__asan_load8"));
 
-    let lib = module("/lib/libpthread.so.0");
+    let lib = module(LIB);
     assert!(filter.includes_module(&lib));
     assert!(filter.includes_symbol(&lib, "pthread_join"));
     assert!(filter.includes_symbol(&lib, "pthread_yield"));
@@ -136,7 +149,7 @@ fn test_cmd_filter_module_include_list() {
     ]);
 
     // The filtered module and its matching symbols are included.
-    let exe = module("/bin/fuzz.exe");
+    let exe = module(EXE);
     assert!(filter.includes_module(&exe));
     assert!(!filter.includes_symbol(&exe, "_start"));
     assert!(filter.includes_symbol(&exe, "main"));
@@ -145,7 +158,7 @@ fn test_cmd_filter_module_include_list() {
     assert!(!filter.includes_symbol(&exe, "__asan_load8"));
 
     // Other modules and their symbols are included by default.
-    let lib = module("/lib/libpthread.so.0");
+    let lib = module(LIB);
     assert!(filter.includes_module(&lib));
     assert!(filter.includes_symbol(&lib, "pthread_join"));
     assert!(filter.includes_symbol(&lib, "pthread_yield"));
@@ -163,7 +176,7 @@ fn test_cmd_filter_exclude_list() {
     ]);
 
     // The filtered module is included, and its matching symbols are excluded.
-    let exe = module("/bin/fuzz.exe");
+    let exe = module(EXE);
     assert!(filter.includes_module(&exe));
     assert!(!filter.includes_symbol(&exe, "_start"));
     assert!(filter.includes_symbol(&exe, "main"));
@@ -173,7 +186,7 @@ fn test_cmd_filter_exclude_list() {
     assert!(!filter.includes_symbol(&exe, "_start"));
 
     // Other modules and their symbols are included by default.
-    let lib = module("/lib/libpthread.so.0");
+    let lib = module(LIB);
     assert!(filter.includes_module(&lib));
     assert!(filter.includes_symbol(&lib, "pthread_join"));
     assert!(filter.includes_symbol(&lib, "pthread_yield"));
@@ -197,7 +210,7 @@ fn test_cmd_filter_include_list_and_exclude_default() {
     ]);
 
     // The filtered module is included, and only matching rules are included.
-    let exe = module("/bin/fuzz.exe");
+    let exe = module(EXE);
     assert!(filter.includes_module(&exe));
     assert!(!filter.includes_symbol(&exe, "_start"));
     assert!(filter.includes_symbol(&exe, "main"));
@@ -206,7 +219,7 @@ fn test_cmd_filter_include_list_and_exclude_default() {
     assert!(!filter.includes_symbol(&exe, "__asan_load8"));
 
     // Other modules and their symbols are excluded by default.
-    let lib = module("/lib/libpthread.so.0");
+    let lib = module(LIB);
     assert!(!filter.includes_module(&lib));
     assert!(!filter.includes_symbol(&lib, "pthread_yield"));
     assert!(!filter.includes_symbol(&lib, "pthread_join"));

--- a/src/agent/coverage/src/code/tests.rs
+++ b/src/agent/coverage/src/code/tests.rs
@@ -103,16 +103,16 @@ macro_rules! from_json {
     }};
 }
 
-#[cfg(windows)]
-const EXE: &str = "c:\\bin\\fuzz.exe";
+#[cfg(target_os = "windows")]
+const EXE: &str = r"c:\bin\fuzz.exe";
 
-#[cfg(not(windows))]
+#[cfg(target_os = "linux")]
 const EXE: &str = "/bin/fuzz.exe";
 
-#[cfg(windows)]
-const LIB: &str = "c:\\lib\\libpthread.dll";
+#[cfg(target_os = "windows")]
+const LIB: &str = r"c:\lib\libpthread.dll";
 
-#[cfg(not(windows))]
+#[cfg(target_os = "linux")]
 const LIB: &str = "/lib/libpthread.so.0";
 
 fn module(s: &str) -> ModulePath {

--- a/src/agent/debugger/src/stack.rs
+++ b/src/agent/debugger/src/stack.rs
@@ -18,11 +18,17 @@ use crate::dbghelp::{self, DebugHelpGuard, ModuleInfo, SymLineInfo};
 
 const UNKNOWN_MODULE: &str = "<UnknownModule>";
 
-/// The file and line number for frame in the calls stack.
+/// The file and line number for frames in the call stack.
 #[derive(Clone, Debug, Hash, PartialEq)]
 pub struct FileInfo {
     pub file: String,
     pub line: u32,
+}
+
+impl Display for FileInfo {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{}:{}", self.file, self.line)
+    }
 }
 
 impl From<&SymLineInfo> for FileInfo {
@@ -67,7 +73,7 @@ impl DebugFunctionLocation {
 impl Display for DebugFunctionLocation {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         if let Some(file_info) = &self.file_info {
-            write!(formatter, "{}:{}", file_info.file, file_info.line)?;
+            write!(formatter, "{}", file_info)?;
         } else {
             write!(formatter, "0x{:x}", self.displacement)?;
         }

--- a/src/agent/debugger/src/stack.rs
+++ b/src/agent/debugger/src/stack.rs
@@ -14,12 +14,27 @@ use serde::{Serialize, Serializer};
 use win_util::memory;
 use winapi::{shared::minwindef::DWORD, um::winnt::HANDLE};
 
-use crate::dbghelp::{self, DebugHelpGuard, ModuleInfo};
+use crate::dbghelp::{self, DebugHelpGuard, ModuleInfo, SymLineInfo};
 
 const UNKNOWN_MODULE: &str = "<UnknownModule>";
 
+/// The file and line number for frame in the calls stack.
 #[derive(Clone, Debug, Hash, PartialEq)]
-pub enum DebugFunctionLocation {
+pub struct FileInfo {
+    pub file: String,
+    pub line: u32,
+}
+
+impl From<&SymLineInfo> for FileInfo {
+    fn from(sym_line_info: &SymLineInfo) -> Self {
+        let file = sym_line_info.filename().to_string_lossy().into();
+        let line = sym_line_info.line_number();
+        FileInfo { file, line }
+    }
+}
+
+#[derive(Clone, Debug, Hash, PartialEq)]
+pub struct DebugFunctionLocation {
     /// File/line if available
     ///
     /// Should be stable - ASLR and JIT should not change source position,
@@ -27,18 +42,35 @@ pub enum DebugFunctionLocation {
     ///
     /// We mitigate this loss of precision by collecting multiple samples
     /// for the same hash bucket.
-    Line { file: String, line: u32 },
+    pub file_info: Option<FileInfo>,
 
     /// Offset if line information not available.
-    Offset { disp: u64 },
+    pub displacement: u64,
+}
+
+impl DebugFunctionLocation {
+    pub fn new(displacement: u64) -> Self {
+        DebugFunctionLocation {
+            displacement,
+            file_info: None,
+        }
+    }
+
+    pub fn new_with_file_info(displacement: u64, file_info: FileInfo) -> Self {
+        DebugFunctionLocation {
+            displacement,
+            file_info: Some(file_info),
+        }
+    }
 }
 
 impl Display for DebugFunctionLocation {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
-        match self {
-            DebugFunctionLocation::Line { file, line } => write!(formatter, "{}:{}", file, line)?,
-            DebugFunctionLocation::Offset { disp } => write!(formatter, "0x{:x}", disp)?,
-        };
+        if let Some(file_info) = &self.file_info {
+            write!(formatter, "{}:{}", file_info.file, file_info.line)?;
+        } else {
+            write!(formatter, "0x{:x}", self.displacement)?;
+        }
         Ok(())
     }
 }
@@ -72,14 +104,17 @@ impl DebugStackFrame {
 impl Display for DebugStackFrame {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         match self {
-            DebugStackFrame::Frame { function, location } => match location {
-                DebugFunctionLocation::Line { file, line } => {
-                    write!(formatter, "{} {}:{}", function, file, line)
+            DebugStackFrame::Frame { function, location } => {
+                if let Some(file_info) = &location.file_info {
+                    write!(
+                        formatter,
+                        "{} {}:{}",
+                        function, file_info.file, file_info.line
+                    )
+                } else {
+                    write!(formatter, "{}+0x{:x}", function, location.displacement)
                 }
-                DebugFunctionLocation::Offset { disp } => {
-                    write!(formatter, "{}+0x{:x}", function, disp)
-                }
-            },
+            }
             DebugStackFrame::CorruptFrame => formatter.write_str("<corrupt frame(s)>"),
         }
     }
@@ -96,16 +131,12 @@ impl Serialize for DebugStackFrame {
 
 #[derive(Debug, PartialEq, Serialize)]
 pub struct DebugStack {
-    frames: Vec<DebugStackFrame>,
+    pub frames: Vec<DebugStackFrame>,
 }
 
 impl DebugStack {
     pub fn new(frames: Vec<DebugStackFrame>) -> DebugStack {
         DebugStack { frames }
-    }
-
-    pub fn frames(&self) -> &[DebugStackFrame] {
-        &self.frames
     }
 
     pub fn stable_hash(&self) -> u64 {
@@ -131,7 +162,7 @@ impl DebugStack {
 impl Display for DebugStack {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         let mut first = true;
-        for frame in self.frames() {
+        for frame in &self.frames {
             if !first {
                 writeln!(formatter)?;
             }
@@ -161,27 +192,21 @@ fn get_function_location_in_module(
         let sym_line_info =
             dbghlp.sym_get_file_and_line(process_handle, program_counter, inline_context);
 
+        let displacement = sym_info.displacement();
         let location = match sym_line_info {
             // Don't use file/line for these magic line numbers.
             Ok(ref sym_line_info) if !sym_line_info.is_fake_line_number() => {
-                DebugFunctionLocation::Line {
-                    file: sym_line_info.filename().to_string_lossy().into(),
-                    line: sym_line_info.line_number(),
-                }
+                DebugFunctionLocation::new_with_file_info(displacement, sym_line_info.into())
             }
 
-            _ => DebugFunctionLocation::Offset {
-                disp: sym_info.displacement(),
-            },
+            _ => DebugFunctionLocation::new(displacement),
         };
 
         DebugStackFrame::new(function, location)
     } else {
         // No function - assume we have an exe with no pdb (so no exports). This should be
         // common, so we won't report an error. We do want a nice(ish) location though.
-        let location = DebugFunctionLocation::Offset {
-            disp: program_counter - module_info.base_address(),
-        };
+        let location = DebugFunctionLocation::new(program_counter - module_info.base_address());
         DebugStackFrame::new(module_info.name().to_string_lossy().into(), location)
     }
 }
@@ -199,7 +224,7 @@ fn get_frame_with_unknown_module(process_handle: HANDLE, program_counter: u64) -
                     .checked_sub(mi.base_address())
                     .expect("logic error computing fake rva");
 
-                let location = DebugFunctionLocation::Offset { disp: offset };
+                let location = DebugFunctionLocation::new(offset);
                 DebugStackFrame::new(UNKNOWN_MODULE.into(), location)
             } else {
                 DebugStackFrame::corrupt_frame()
@@ -268,19 +293,19 @@ mod test {
 
     macro_rules! frame {
         ($name: expr, disp: $disp: expr) => {
-            DebugStackFrame::new(
-                $name.to_string(),
-                DebugFunctionLocation::Offset { disp: $disp },
-            )
+            DebugStackFrame::new($name.to_string(), DebugFunctionLocation::new($disp))
         };
 
-        ($name: expr, line: ($file: expr, $line: expr)) => {
+        ($name: expr, disp: $disp: expr, line: ($file: expr, $line: expr)) => {
             DebugStackFrame::new(
                 $name.to_string(),
-                DebugFunctionLocation::Line {
-                    file: $file.to_string(),
-                    line: $line,
-                },
+                DebugFunctionLocation::new_with_file_info(
+                    $disp,
+                    FileInfo {
+                        file: $file.to_string(),
+                        line: $line,
+                    },
+                ),
             )
         };
     }
@@ -289,21 +314,22 @@ mod test {
     fn stable_stack_hash() {
         let frames = vec![
             frame!("ntdll", disp: 88442200),
-            frame!("usage", line: ("foo.c", 88)),
-            frame!("main", line: ("foo.c", 42)),
+            frame!("usage", disp: 10, line: ("foo.c", 88)),
+            frame!("main", disp: 20, line: ("foo.c", 42)),
         ];
         let stack = DebugStack::new(frames);
 
-        // Hard coded hash constant is what we want to ensure the hash function is stable.
-        assert_eq!(stack.stable_hash(), 8083364444338290471);
+        // Hard coded hash constant is what we want to ensure
+        // the hash function is relatively stable.
+        assert_eq!(stack.stable_hash(), 4643290346391834992);
     }
 
     #[test]
     fn stable_hash_ignore_jit() {
         let mut frames = vec![
             frame!("ntdll", disp: 88442200),
-            frame!("usage", line: ("foo.c", 88)),
-            frame!("main", line: ("foo.c", 42)),
+            frame!("usage", disp: 10, line: ("foo.c", 88)),
+            frame!("main", disp: 20, line: ("foo.c", 42)),
         ];
 
         let base_frames = frames.clone();
@@ -320,8 +346,8 @@ mod test {
     fn stable_hash_assuming_stack_corrupted() {
         let mut frames = vec![
             frame!("ntdll", disp: 88442200),
-            frame!("usage", line: ("foo.c", 88)),
-            frame!("main", line: ("foo.c", 42)),
+            frame!("usage", disp: 10, line: ("foo.c", 88)),
+            frame!("main", disp: 20, line: ("foo.c", 42)),
         ];
 
         let base_frames = frames.clone();

--- a/src/agent/debugger/src/stack.rs
+++ b/src/agent/debugger/src/stack.rs
@@ -112,11 +112,7 @@ impl Display for DebugStackFrame {
         match self {
             DebugStackFrame::Frame { function, location } => {
                 if let Some(file_info) = &location.file_info {
-                    write!(
-                        formatter,
-                        "{} {}:{}",
-                        function, file_info.file, file_info.line
-                    )
+                    write!(formatter, "{} {}", function, file_info)
                 } else {
                     write!(formatter, "{}+0x{:x}", function, location.displacement)
                 }

--- a/src/agent/input-tester/src/crash_detector.rs
+++ b/src/agent/input-tester/src/crash_detector.rs
@@ -423,6 +423,7 @@ mod tests {
             test_process(
                 r"C:\windows\system32\WindowsPowerShell\v1.0\powershell.exe",
                 &vec!["/nop".to_string(), "/c".to_string(), $script.to_string()],
+                &HashMap::default(),
                 $timeout,
                 /*ignore first chance exceptions*/ true,
                 None,

--- a/src/agent/reqwest-retry/src/lib.rs
+++ b/src/agent/reqwest-retry/src/lib.rs
@@ -205,9 +205,12 @@ mod test {
 
         if let Err(err) = &resp {
             let as_text = format!("{}", err);
-            assert!(as_text.contains("Maximum number of attempts reached for this request"));
+            assert!(
+                as_text.contains("Maximum number of attempts reached for this request")
+                    || as_text.contains("os error 10061")
+            );
         } else {
-            bail!("response to {} was expected to fail", invalid_url);
+            anyhow::bail!("response to {} was expected to fail", invalid_url);
         }
 
         Ok(())

--- a/src/ci/agent.sh
+++ b/src/ci/agent.sh
@@ -37,13 +37,10 @@ cargo build --release --locked
 cargo clippy --release -- -D warnings
 # export RUST_LOG=trace
 export RUST_BACKTRACE=full
-cargo test --release --manifest-path ./onefuzz-supervisor/Cargo.toml
+cargo test --release --workspace
 
 # TODO: re-enable integration tests.
 # cargo test --release --manifest-path ./onefuzz-agent/Cargo.toml --features integration_test -- --nocapture
-cargo test --release --manifest-path ./onefuzz-agent/Cargo.toml
-
-cargo test --release --manifest-path ./onefuzz/Cargo.toml
 
 cp target/release/onefuzz-agent* ../../artifacts/agent
 cp target/release/onefuzz-supervisor* ../../artifacts/agent


### PR DESCRIPTION
* removed some superfluous types related to stack walking on Windows
* include the function offset even if we have source information
* fixed test build
* run `cargo test --workspace` in CI

