### PR TITLE
Fix incorrect offset in stack reports

### DIFF
--- a/src/agent/debugger/src/dbghelp.rs
+++ b/src/agent/debugger/src/dbghelp.rs
@@ -514,7 +514,7 @@ impl DebugHelpGuard {
         }
     }
 
-    pub fn stackwalk_ex<F: FnMut(&FrameContext, &STACKFRAME_EX) -> bool>(
+    pub fn stackwalk_ex<F: FnMut(&STACKFRAME_EX) -> bool>(
         &self,
         process_handle: HANDLE,
         thread_handle: HANDLE,
@@ -550,7 +550,7 @@ impl DebugHelpGuard {
                 break;
             }
 
-            if !f(&frame_context, &frame) {
+            if !f(&frame) {
                 break;
             }
         }

--- a/src/agent/debugger/src/debugger.rs
+++ b/src/agent/debugger/src/debugger.rs
@@ -699,7 +699,7 @@ impl Debugger {
         dbghlp.stackwalk_ex(
             self.target.process_handle(),
             self.target.current_thread_handle(),
-            |_frame_context, frame| {
+            |frame| {
                 return_address = frame.AddrReturn;
                 stack_pointer = frame.AddrStack;
 

--- a/src/agent/debugger/src/stack.rs
+++ b/src/agent/debugger/src/stack.rs
@@ -223,10 +223,8 @@ pub fn get_stack(
 
     let mut stack = vec![];
 
-    dbghlp.stackwalk_ex(process_handle, thread_handle, |frame_context, frame| {
-        // The program counter is the return address, potentially outside of the function
-        // performing the call. We subtract 1 to ensure the address is within the call.
-        let program_counter = frame_context.program_counter().saturating_sub(1);
+    dbghlp.stackwalk_ex(process_handle, thread_handle, |frame| {
+        let program_counter = frame.AddrPC.Offset;
 
         let debug_stack_frame = if resolve_symbols {
             if let Ok(module_info) = dbghlp.sym_get_module_info(process_handle, program_counter) {


### PR DESCRIPTION
The wrong PC was from the context record and incorrectly adjusted by 1 which worked well enough to see the correct function name and line numbers, but was the wrong offset.

The correct PC is passed in a STACKFRAME_EX struct.