### PR TITLE
automatic retry on wget failure

### DIFF
--- a/src/ci/azcopy.sh
+++ b/src/ci/azcopy.sh
@@ -7,10 +7,10 @@ set -ex
 
 mkdir -p artifacts/azcopy
 
-wget -O azcopy.zip https://aka.ms/downloadazcopy-v10-windows
+wget --retry-connrefused -t 30 --waitretry=5 -O azcopy.zip https://aka.ms/downloadazcopy-v10-windows
 unzip azcopy.zip
 mv azcopy_windows*/* artifacts/azcopy/
 
-wget -O azcopy.tgz https://aka.ms/downloadazcopy-v10-linux
+wget --retry-connrefused -t 30 --waitretry=5 -O azcopy.tgz https://aka.ms/downloadazcopy-v10-linux
 tar zxvf azcopy.tgz
 mv azcopy_linux_amd64*/* artifacts/azcopy/


### PR DESCRIPTION
aka.ms is having stability issues.  We've seen multiple build failures due to:

```
$ wget -O azcopy.zip https://aka.ms/downloadazcopy-v10-windows
--2021-03-10 19:03:54-- https://aka.ms/downloadazcopy-v10-windows
Resolving aka.ms (aka.ms)... 23.223.13.99
Connecting to aka.ms (aka.ms)|23.223.13.99|:443... connected.
OpenSSL: error:14094438:SSL routines:ssl3_read_bytes:tlsv1 alert internal error
Unable to establish SSL connection.
$
```

This PR should help by making wget automatically retry on failure.  This will try up to 30 times, waiting 5 seconds between each attempt.