### PR TITLE
fix racy tests for expected failures in web requests

### DIFF
--- a/src/agent/reqwest-retry/src/lib.rs
+++ b/src/agent/reqwest-retry/src/lib.rs
@@ -205,9 +205,7 @@ mod test {
 
         if let Err(err) = &resp {
             let as_text = format!("{}", err);
-            assert!(
-                as_text.contains("Maximum number of attempts reached for this request")
-            );
+            assert!(as_text.contains(MAX_RETRY_ERROR_MESSAGE));
         } else {
             anyhow::bail!("response to {} was expected to fail", invalid_url);
         }

--- a/src/agent/reqwest-retry/src/lib.rs
+++ b/src/agent/reqwest-retry/src/lib.rs
@@ -192,13 +192,13 @@ mod test {
 
     #[tokio::test]
     async fn retry_should_fail() -> Result<()> {
-        let invalid_url = "http://localhost:81/test.txt";
+        let invalid_url = "http://127.0.0.1:81/test.txt";
         let resp = reqwest::Client::new()
             .get(invalid_url)
             .send_retry(
                 Duration::from_secs(1),
-                Duration::from_secs(3),
-                3i32,
+                Duration::from_secs(120),
+                2i32,
                 to_backoff_response,
             )
             .await;
@@ -207,7 +207,6 @@ mod test {
             let as_text = format!("{}", err);
             assert!(
                 as_text.contains("Maximum number of attempts reached for this request")
-                    || as_text.contains("os error 10061")
             );
         } else {
             anyhow::bail!("response to {} was expected to fail", invalid_url);

--- a/src/agent/reqwest-retry/src/lib.rs
+++ b/src/agent/reqwest-retry/src/lib.rs
@@ -197,7 +197,7 @@ mod test {
             .get(invalid_url)
             .send_retry(
                 Duration::from_secs(1),
-                Duration::from_secs(120),
+                Duration::from_secs(300),
                 2i32,
                 to_backoff_response,
             )


### PR DESCRIPTION
Thanks primarily due to lookups on `localhost` but also impacted by host-based firewalls silently dropping packets, this test could be racy.

This addresses those issues.