### PR TITLE
add setup_dir to the PATH for libfuzzer

### DIFF
--- a/src/agent/onefuzz/src/env.rs
+++ b/src/agent/onefuzz/src/env.rs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use anyhow::Result;
+use std::ffi::OsString;
+use std::path::PathBuf;
+
+pub const PATH: &str = "PATH";
+
+pub fn get_path_with_directory(to_add: &PathBuf) -> Result<OsString> {
+    match std::env::var_os(PATH) {
+        Some(path) => {
+            let mut paths: Vec<_> = std::env::split_paths(&path).collect();
+            if !paths.contains(to_add) {
+                paths.push(to_add.clone())
+            }
+            Ok(std::env::join_paths(paths)?)
+        }
+        None => Ok(to_add.clone().into()),
+    }
+}

--- a/src/agent/onefuzz/src/lib.rs
+++ b/src/agent/onefuzz/src/lib.rs
@@ -13,6 +13,7 @@ extern crate onefuzz_telemetry;
 pub mod asan;
 pub mod az_copy;
 pub mod blob;
+pub mod env;
 pub mod expand;
 pub mod fs;
 pub mod heartbeat;

--- a/src/agent/onefuzz/src/libfuzzer.rs
+++ b/src/agent/onefuzz/src/libfuzzer.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 use crate::{
+    env::{get_path_with_directory, PATH},
     expand::Expand,
     input_tester::{TestResult, Tester},
 };
@@ -50,6 +51,7 @@ impl<'a> LibFuzzer<'a> {
         let mut cmd = Command::new(&self.exe);
 
         cmd.kill_on_drop(true)
+            .env(PATH, get_path_with_directory(&self.setup_dir)?)
             .env_remove("RUST_LOG")
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
@@ -100,6 +102,7 @@ impl<'a> LibFuzzer<'a> {
 
         let mut cmd = Command::new(&self.exe);
         cmd.kill_on_drop(true)
+            .env(PATH, get_path_with_directory(&self.setup_dir)?)
             .env_remove("RUST_LOG")
             .stdout(Stdio::null())
             .stderr(Stdio::piped());
@@ -181,6 +184,7 @@ impl<'a> LibFuzzer<'a> {
         let mut cmd = Command::new(&self.exe);
 
         cmd.kill_on_drop(true)
+            .env(PATH, get_path_with_directory(&self.setup_dir)?)
             .env_remove("RUST_LOG")
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())


### PR DESCRIPTION
This is targeted to only adding the PATH for libFuzzer targets.

We should consider potentially adding `setup_dir` to PATH agent wide in the future, but that could be a breaking change for some environments.