### PR TITLE
Add 'setup_dir' to LD_LIBRARY_PATH for unix based libfuzzer targets

### DIFF
--- a/src/agent/onefuzz/src/env.rs
+++ b/src/agent/onefuzz/src/env.rs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use anyhow::Result;
+use std::ffi::OsString;
+use std::path::PathBuf;
+
+pub const PATH: &str = "PATH";
+
+pub fn get_path_with_directory(to_add: &PathBuf) -> Result<OsString> {
+    match std::env::var_os(PATH) {
+        Some(path) => {
+            let mut paths: Vec<_> = std::env::split_paths(&path).collect();
+            if !paths.contains(to_add) {
+                paths.push(to_add.clone())
+            }
+            Ok(std::env::join_paths(paths)?)
+        }
+        None => Ok(to_add.clone().into()),
+    }
+}

--- a/src/agent/onefuzz/src/env.rs
+++ b/src/agent/onefuzz/src/env.rs
@@ -8,15 +8,17 @@ use std::path::PathBuf;
 pub const PATH: &str = "PATH";
 pub const LD_LIBRARY_PATH: &str = "LD_LIBRARY_PATH";
 
+pub fn update_path(path: OsString, to_add: &PathBuf) -> Result<OsString> {
+    let mut paths: Vec<_> = std::env::split_paths(&path).collect();
+    if !paths.contains(to_add) {
+        paths.push(to_add.clone())
+    }
+    Ok(std::env::join_paths(paths)?)
+}
+
 pub fn get_path_with_directory(variable: &str, to_add: &PathBuf) -> Result<OsString> {
     match std::env::var_os(variable) {
-        Some(path) => {
-            let mut paths: Vec<_> = std::env::split_paths(&path).collect();
-            if !paths.contains(to_add) {
-                paths.push(to_add.clone())
-            }
-            Ok(std::env::join_paths(paths)?)
-        }
+        Some(path) => update_path(path, to_add),
         None => Ok(to_add.clone().into()),
     }
 }

--- a/src/agent/onefuzz/src/env.rs
+++ b/src/agent/onefuzz/src/env.rs
@@ -6,9 +6,10 @@ use std::ffi::OsString;
 use std::path::PathBuf;
 
 pub const PATH: &str = "PATH";
+pub const LD_LIBRARY_PATH: &str = "LD_LIBRARY_PATH";
 
-pub fn get_path_with_directory(to_add: &PathBuf) -> Result<OsString> {
-    match std::env::var_os(PATH) {
+pub fn get_path_with_directory(variable: &str, to_add: &PathBuf) -> Result<OsString> {
+    match std::env::var_os(variable) {
         Some(path) => {
             let mut paths: Vec<_> = std::env::split_paths(&path).collect();
             if !paths.contains(to_add) {

--- a/src/agent/onefuzz/src/input_tester.rs
+++ b/src/agent/onefuzz/src/input_tester.rs
@@ -271,7 +271,7 @@ impl<'a> Tester<'a> {
             if self.add_setup_to_ld_library_path {
                 let new_path = match env.get(LD_LIBRARY_PATH) {
                     Some(v) => update_path(v.clone().into(), &setup_dir)?,
-                    None => get_path_with_directory(PATH, &setup_dir)?,
+                    None => get_path_with_directory(LD_LIBRARY_PATH, &setup_dir)?,
                 };
                 env.insert(
                     LD_LIBRARY_PATH.to_string(),

--- a/src/agent/onefuzz/src/input_tester.rs
+++ b/src/agent/onefuzz/src/input_tester.rs
@@ -5,6 +5,7 @@
 
 use crate::{
     asan::{add_asan_log_env, check_asan_path, check_asan_string, AsanLog},
+    env::{get_path_with_directory, update_path, LD_LIBRARY_PATH, PATH},
     expand::Expand,
     process::run_cmd,
 };
@@ -25,6 +26,8 @@ pub struct Tester<'a> {
     check_asan_stderr: bool,
     check_debugger: bool,
     check_retry_count: u64,
+    add_setup_to_ld_library_path: bool,
+    add_setup_to_path: bool,
 }
 
 #[derive(Debug)]
@@ -58,6 +61,8 @@ impl<'a> Tester<'a> {
             check_asan_stderr: false,
             check_debugger: false,
             check_retry_count: 0,
+            add_setup_to_ld_library_path: false,
+            add_setup_to_path: false,
         }
     }
 
@@ -92,6 +97,20 @@ impl<'a> Tester<'a> {
     pub fn check_retry_count(self, value: u64) -> Self {
         Self {
             check_retry_count: value,
+            ..self
+        }
+    }
+
+    pub fn add_setup_to_ld_library_path(self, value: bool) -> Self {
+        Self {
+            add_setup_to_ld_library_path: value,
+            ..self
+        }
+    }
+
+    pub fn add_setup_to_path(self, value: bool) -> Self {
+        Self {
+            add_setup_to_path: value,
             ..self
         }
     }
@@ -239,6 +258,25 @@ impl<'a> Tester<'a> {
             let mut env: HashMap<String, String> = HashMap::new();
             for (k, v) in self.environ {
                 env.insert(k.clone(), expand.evaluate_value(v)?);
+            }
+
+            let setup_dir = &self.setup_dir.to_path_buf();
+            if self.add_setup_to_path {
+                let new_path = match env.get(PATH) {
+                    Some(v) => update_path(v.clone().into(), &setup_dir)?,
+                    None => get_path_with_directory(PATH, &setup_dir)?,
+                };
+                env.insert(PATH.to_string(), new_path.to_string_lossy().to_string());
+            }
+            if self.add_setup_to_ld_library_path {
+                let new_path = match env.get(LD_LIBRARY_PATH) {
+                    Some(v) => update_path(v.clone().into(), &setup_dir)?,
+                    None => get_path_with_directory(PATH, &setup_dir)?,
+                };
+                env.insert(
+                    LD_LIBRARY_PATH.to_string(),
+                    new_path.to_string_lossy().to_string(),
+                );
             }
 
             if let Some(asan_dir) = &asan_dir {

--- a/src/agent/onefuzz/src/lib.rs
+++ b/src/agent/onefuzz/src/lib.rs
@@ -13,6 +13,7 @@ extern crate onefuzz_telemetry;
 pub mod asan;
 pub mod az_copy;
 pub mod blob;
+pub mod env;
 pub mod expand;
 pub mod fs;
 pub mod heartbeat;

--- a/src/agent/onefuzz/src/libfuzzer.rs
+++ b/src/agent/onefuzz/src/libfuzzer.rs
@@ -177,12 +177,16 @@ impl<'a> LibFuzzer<'a> {
         let mut options = self.options.to_owned();
         options.push("{input}".to_string());
 
-        let tester = Tester::new(&self.setup_dir, &self.exe, &options, &self.env)
+        let mut tester = Tester::new(&self.setup_dir, &self.exe, &options, &self.env)
             .check_asan_stderr(true)
             .check_retry_count(retry)
-            .add_setup_to_ld_library_path(true)
             .add_setup_to_path(true)
             .set_optional(timeout, |tester, timeout| tester.timeout(timeout));
+
+        if cfg!(target_family = "unix") {
+            tester = tester.add_setup_to_ld_library_path(true);
+        }
+
         tester.test_input(test_input.as_ref()).await
     }
 

--- a/src/agent/onefuzz/src/libfuzzer.rs
+++ b/src/agent/onefuzz/src/libfuzzer.rs
@@ -58,6 +58,13 @@ impl<'a> LibFuzzer<'a> {
             .stderr(Stdio::piped())
             .arg("-help=1");
 
+        if cfg!(target_family = "unix") {
+            cmd.env(
+                LD_LIBRARY_PATH,
+                get_path_with_directory(LD_LIBRARY_PATH, &self.setup_dir)?,
+            );
+        }
+
         let expand = Expand::new()
             .target_exe(&self.exe)
             .target_options(&self.options)
@@ -173,6 +180,8 @@ impl<'a> LibFuzzer<'a> {
         let tester = Tester::new(&self.setup_dir, &self.exe, &options, &self.env)
             .check_asan_stderr(true)
             .check_retry_count(retry)
+            .add_setup_to_ld_library_path(true)
+            .add_setup_to_path(true)
             .set_optional(timeout, |tester, timeout| tester.timeout(timeout));
         tester.test_input(test_input.as_ref()).await
     }
@@ -197,6 +206,13 @@ impl<'a> LibFuzzer<'a> {
             .stderr(Stdio::piped())
             .arg("-merge=1")
             .arg(corpus_dir.as_ref());
+
+        if cfg!(target_family = "unix") {
+            cmd.env(
+                LD_LIBRARY_PATH,
+                get_path_with_directory(LD_LIBRARY_PATH, &self.setup_dir)?,
+            );
+        }
 
         for dir in corpus_dirs {
             cmd.arg(dir.as_ref());

--- a/src/agent/onefuzz/src/libfuzzer.rs
+++ b/src/agent/onefuzz/src/libfuzzer.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 use crate::{
+    env::{get_path_with_directory, PATH},
     expand::Expand,
     input_tester::{TestResult, Tester},
 };
@@ -50,6 +51,7 @@ impl<'a> LibFuzzer<'a> {
         let mut cmd = Command::new(&self.exe);
 
         cmd.kill_on_drop(true)
+            .env(PATH, get_path_with_directory(&self.setup_dir)?)
             .env_remove("RUST_LOG")
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
@@ -100,6 +102,7 @@ impl<'a> LibFuzzer<'a> {
 
         let mut cmd = Command::new(&self.exe);
         cmd.kill_on_drop(true)
+            .env(PATH, get_path_with_directory(&self.setup_dir)?)
             .env_remove("RUST_LOG")
             .stdout(Stdio::null())
             .stderr(Stdio::piped());
@@ -181,6 +184,7 @@ impl<'a> LibFuzzer<'a> {
         let mut cmd = Command::new(&self.exe);
 
         cmd.kill_on_drop(true)
+            .env(PATH, get_path_with_directory(&self.setup_dir)?)
             .env_remove("RUST_LOG")
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())

--- a/src/agent/onefuzz/src/libfuzzer.rs
+++ b/src/agent/onefuzz/src/libfuzzer.rs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 use crate::{
-    env::{get_path_with_directory, PATH},
+    env::{get_path_with_directory, LD_LIBRARY_PATH, PATH},
     expand::Expand,
     input_tester::{TestResult, Tester},
 };
@@ -51,7 +51,7 @@ impl<'a> LibFuzzer<'a> {
         let mut cmd = Command::new(&self.exe);
 
         cmd.kill_on_drop(true)
-            .env(PATH, get_path_with_directory(&self.setup_dir)?)
+            .env(PATH, get_path_with_directory(PATH, &self.setup_dir)?)
             .env_remove("RUST_LOG")
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
@@ -102,7 +102,7 @@ impl<'a> LibFuzzer<'a> {
 
         let mut cmd = Command::new(&self.exe);
         cmd.kill_on_drop(true)
-            .env(PATH, get_path_with_directory(&self.setup_dir)?)
+            .env(PATH, get_path_with_directory(PATH, &self.setup_dir)?)
             .env_remove("RUST_LOG")
             .stdout(Stdio::null())
             .stderr(Stdio::piped());
@@ -115,6 +115,13 @@ impl<'a> LibFuzzer<'a> {
         // Pass custom option arguments.
         for o in expand.evaluate(self.options)? {
             cmd.arg(o);
+        }
+
+        if cfg!(target_family = "unix") {
+            cmd.env(
+                LD_LIBRARY_PATH,
+                get_path_with_directory(LD_LIBRARY_PATH, &self.setup_dir)?,
+            );
         }
 
         // check if a max_time is already set
@@ -184,7 +191,7 @@ impl<'a> LibFuzzer<'a> {
         let mut cmd = Command::new(&self.exe);
 
         cmd.kill_on_drop(true)
-            .env(PATH, get_path_with_directory(&self.setup_dir)?)
+            .env(PATH, get_path_with_directory(PATH, &self.setup_dir)?)
             .env_remove("RUST_LOG")
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())


### PR DESCRIPTION
Similar to #680, but for linux

Note: This also adds setup_dir to LD_LIBRARY_PATH and PATH to input tester, which #680 did not include (but should have)