### PR TITLE
Enable coverage module filtering (only) for both platforms

### DIFF
--- a/src/agent/coverage/Cargo.toml
+++ b/src/agent/coverage/Cargo.toml
@@ -5,6 +5,10 @@ authors = ["fuzzing@microsoft.com"]
 license = "MIT"
 edition = "2018"
 
+[features]
+default = []
+symbol-filter = []  # Remove after impl'd
+
 [dependencies]
 anyhow = "1.0"
 bincode = "1.3"

--- a/src/agent/coverage/examples/block_coverage.rs
+++ b/src/agent/coverage/examples/block_coverage.rs
@@ -4,11 +4,11 @@
 use std::process::Command;
 
 use anyhow::Result;
+use coverage::code::{CmdFilter, CmdFilterDef};
 use structopt::StructOpt;
 
 #[derive(Debug, PartialEq, StructOpt)]
 struct Opt {
-    #[cfg(target_os = "linux")]
     #[structopt(short, long)]
     filter: Option<std::path::PathBuf>,
 
@@ -16,17 +16,31 @@ struct Opt {
     cmd: Vec<String>,
 }
 
+impl Opt {
+    pub fn load_filter_or_default(&self) -> Result<CmdFilter> {
+        if let Some(path) = &self.filter {
+            let data = std::fs::read(path)?;
+            let def: CmdFilterDef = serde_json::from_slice(&data)?;
+            CmdFilter::new(def)
+        } else {
+            Ok(CmdFilter::default())
+        }
+    }
+}
+
 #[cfg(target_os = "windows")]
 fn main() -> Result<()> {
     env_logger::init();
 
     let opt = Opt::from_args();
+    let filter = opt.load_filter_or_default()?;
+
     log::info!("recording coverage for: {:?}", opt.cmd);
 
     let mut cmd = Command::new(&opt.cmd[0]);
     cmd.args(&opt.cmd[1..]);
 
-    let coverage = coverage::block::windows::record(cmd)?;
+    let coverage = coverage::block::windows::record(cmd, filter)?;
 
     for (module, cov) in coverage.iter() {
         let total = cov.blocks.len();
@@ -41,18 +55,11 @@ fn main() -> Result<()> {
 #[cfg(target_os = "linux")]
 fn main() -> Result<()> {
     use coverage::block::linux::Recorder;
-    use coverage::code::{CmdFilter, CmdFilterDef};
 
     env_logger::init();
 
     let opt = Opt::from_args();
-    let filter = if let Some(path) = &opt.filter {
-        let data = std::fs::read(path)?;
-        let def: CmdFilterDef = serde_json::from_slice(&data)?;
-        CmdFilter::new(def)?
-    } else {
-        CmdFilter::default()
-    };
+    let filter = opt.load_filter_or_default()?;
 
     let mut cmd = Command::new(&opt.cmd[0]);
     cmd.args(&opt.cmd[1..]);

--- a/src/agent/coverage/src/block/windows.rs
+++ b/src/agent/coverage/src/block/windows.rs
@@ -15,9 +15,9 @@ use crate::block::CommandBlockCov;
 use crate::cache::ModuleCache;
 use crate::code::{CmdFilter, ModulePath};
 
-pub fn record(cmd: Command) -> Result<CommandBlockCov> {
+pub fn record(cmd: Command, filter: CmdFilter) -> Result<CommandBlockCov> {
     let mut cache = ModuleCache::default();
-    let recorder = Recorder::new(&mut cache);
+    let recorder = Recorder::new(&mut cache, filter);
     let timeout = Duration::from_secs(5);
     let mut handler = RecorderEventHandler::new(recorder, timeout);
     handler.run(cmd)?;
@@ -87,10 +87,9 @@ pub struct Recorder<'a> {
 }
 
 impl<'a> Recorder<'a> {
-    pub fn new(cache: &'a mut ModuleCache) -> Self {
+    pub fn new(cache: &'a mut ModuleCache, filter: CmdFilter) -> Self {
         let breakpoints = Breakpoints::default();
         let coverage = CommandBlockCov::default();
-        let filter = CmdFilter::default();
 
         Self {
             breakpoints,

--- a/src/agent/coverage/src/code.rs
+++ b/src/agent/coverage/src/code.rs
@@ -349,7 +349,6 @@ enum RuleDef {
     },
 
     // Temporarily disable symbol filtering rules.
-    // #[cfg_attr(feature = "symbol-filter", allow(unused))]
     #[cfg_attr(not(feature = "symbol-filter"), serde(skip), allow(unused))]
     Filter(Box<Filter>),
 }

--- a/src/agent/coverage/src/code.rs
+++ b/src/agent/coverage/src/code.rs
@@ -343,6 +343,10 @@ struct ModuleRuleDef {
 enum RuleDef {
     Include { include: bool },
     Exclude { exclude: bool },
+
+    // Temporarily disable symbol filtering rules.
+    // #[cfg_attr(feature = "symbol-filter", allow(unused))]
+    #[cfg_attr(not(feature = "symbol-filter"), serde(skip), allow(unused))]
     Filter(Box<Filter>),
 }
 

--- a/src/agent/coverage/src/code.rs
+++ b/src/agent/coverage/src/code.rs
@@ -393,6 +393,7 @@ impl CmdFilter {
 
         Ok(Self { regexes, rules })
     }
+
     pub fn includes_module(&self, module: &ModulePath) -> bool {
         match self.regexes.matches(&module.path_lossy()).iter().next() {
             Some(index) => {

--- a/src/agent/coverage/src/code.rs
+++ b/src/agent/coverage/src/code.rs
@@ -341,8 +341,12 @@ struct ModuleRuleDef {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 enum RuleDef {
-    Include { include: bool },
-    Exclude { exclude: bool },
+    Include {
+        include: bool,
+    },
+    Exclude {
+        exclude: bool,
+    },
 
     // Temporarily disable symbol filtering rules.
     // #[cfg_attr(feature = "symbol-filter", allow(unused))]

--- a/src/agent/coverage/src/code/tests.rs
+++ b/src/agent/coverage/src/code/tests.rs
@@ -33,6 +33,7 @@ fn test_module_filter_def_exclude_bool() {
     assert!(matches!(def.rule, RuleDef::Exclude { exclude: false }));
 }
 
+#[cfg(feature = "symbol-filter")]
 #[test]
 fn test_module_filter_def_include_filter() {
     let text = r#"{ "module": "abc.exe", "include": [] }"#;
@@ -58,6 +59,7 @@ fn test_module_filter_def_include_filter() {
     }
 }
 
+#[cfg(feature = "symbol-filter")]
 #[test]
 fn test_module_filter_def_exclude_filter() {
     let text = r#"{ "module": "abc.exe", "exclude": [] }"#;
@@ -79,6 +81,7 @@ fn test_module_filter_def_exclude_filter() {
     }
 }
 
+#[cfg(feature = "symbol-filter")]
 #[test]
 fn test_include_exclude() {
     let include_false = Rule::from(RuleDef::Include { include: false });
@@ -94,6 +97,7 @@ fn test_include_exclude() {
     assert!(matches!(exclude_false, Rule::IncludeModule(true)));
 }
 
+#[cfg(feature = "symbol-filter")]
 macro_rules! from_json {
     ($tt: tt) => {{
         let text = stringify!($tt);
@@ -103,22 +107,28 @@ macro_rules! from_json {
     }};
 }
 
+#[cfg(feature = "symbol-filter")]
 #[cfg(target_os = "windows")]
 const EXE: &str = r"c:\bin\fuzz.exe";
 
+#[cfg(feature = "symbol-filter")]
 #[cfg(target_os = "linux")]
 const EXE: &str = "/bin/fuzz.exe";
 
+#[cfg(feature = "symbol-filter")]
 #[cfg(target_os = "windows")]
 const LIB: &str = r"c:\lib\libpthread.dll";
 
+#[cfg(feature = "symbol-filter")]
 #[cfg(target_os = "linux")]
 const LIB: &str = "/lib/libpthread.so.0";
 
+#[cfg(feature = "symbol-filter")]
 fn module(s: &str) -> ModulePath {
     ModulePath::new(s.into()).unwrap()
 }
 
+#[cfg(feature = "symbol-filter")]
 #[test]
 fn test_cmd_filter_empty_def() {
     let filter = from_json!([]);
@@ -139,6 +149,7 @@ fn test_cmd_filter_empty_def() {
     assert!(filter.includes_symbol(&lib, "pthread_yield"));
 }
 
+#[cfg(feature = "symbol-filter")]
 #[test]
 fn test_cmd_filter_module_include_list() {
     let filter = from_json!([
@@ -166,6 +177,7 @@ fn test_cmd_filter_module_include_list() {
     assert!(filter.includes_symbol(&lib, "__asan_load8"));
 }
 
+#[cfg(feature = "symbol-filter")]
 #[test]
 fn test_cmd_filter_exclude_list() {
     let filter = from_json!([
@@ -194,6 +206,7 @@ fn test_cmd_filter_exclude_list() {
     assert!(filter.includes_symbol(&lib, "__asan_load8"));
 }
 
+#[cfg(feature = "symbol-filter")]
 #[test]
 fn test_cmd_filter_include_list_and_exclude_default() {
     // The 2nd rule in this list excludes all modules and symbols not explicitly

--- a/src/agent/input-tester/src/crash_detector.rs
+++ b/src/agent/input-tester/src/crash_detector.rs
@@ -324,7 +324,8 @@ pub fn test_process<'a>(
         command.env(k, v);
     }
 
-    let recorder = cache.map(BlockCoverageRecorder::new);
+    let filter = coverage::code::CmdFilter::default();
+    let recorder = cache.map(|c| BlockCoverageRecorder::new(c, filter));
     let start_time = Instant::now();
     let mut event_handler = CrashDetectorEventHandler::new(
         stdout_reader,


### PR DESCRIPTION
- Add coverage filtering to Windows generic coverage recording
- Temporarily disable deserialization of symbol filter rules