### PR TITLE
address telemetry log message locality

### DIFF
--- a/src/agent/onefuzz-agent/src/local/cmd.rs
+++ b/src/agent/onefuzz-agent/src/local/cmd.rs
@@ -1,8 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+use std::time::Duration;
+
 use anyhow::Result;
-use clap::{App, SubCommand};
+use clap::{App, Arg, SubCommand};
+use tokio::time::timeout;
 
 use crate::local::{
     common::add_common_config, generic_analysis, generic_crash_report, generic_generator,
@@ -22,28 +25,52 @@ const GENERIC_GENERATOR: &str = "generator";
 const GENERIC_ANALYSIS: &str = "analysis";
 const GENERIC_TEST_INPUT: &str = "test-input";
 
+const TIMEOUT: &str = "timeout";
+
 pub async fn run(args: &clap::ArgMatches<'_>) -> Result<()> {
-    match args.subcommand() {
-        (RADAMSA, Some(sub)) => radamsa::run(sub).await,
-        (LIBFUZZER, Some(sub)) => libfuzzer::run(sub).await,
-        (LIBFUZZER_FUZZ, Some(sub)) => libfuzzer_fuzz::run(sub).await,
-        (LIBFUZZER_COVERAGE, Some(sub)) => libfuzzer_coverage::run(sub).await,
-        (LIBFUZZER_CRASH_REPORT, Some(sub)) => libfuzzer_crash_report::run(sub).await,
-        (LIBFUZZER_MERGE, Some(sub)) => libfuzzer_merge::run(sub).await,
-        (GENERIC_ANALYSIS, Some(sub)) => generic_analysis::run(sub).await,
-        (GENERIC_CRASH_REPORT, Some(sub)) => generic_crash_report::run(sub).await,
-        (GENERIC_GENERATOR, Some(sub)) => generic_generator::run(sub).await,
-        (GENERIC_TEST_INPUT, Some(sub)) => test_input::run(sub).await,
-        (LIBFUZZER_TEST_INPUT, Some(sub)) => libfuzzer_test_input::run(sub).await,
-        _ => {
-            anyhow::bail!("missing subcommand\nUSAGE: {}", args.usage());
+    let running_duration = value_t!(args, TIMEOUT, u64).ok();
+
+    let run = async {
+        match args.subcommand() {
+            (RADAMSA, Some(sub)) => radamsa::run(sub).await,
+            (LIBFUZZER, Some(sub)) => libfuzzer::run(sub).await,
+            (LIBFUZZER_FUZZ, Some(sub)) => libfuzzer_fuzz::run(sub).await,
+            (LIBFUZZER_COVERAGE, Some(sub)) => libfuzzer_coverage::run(sub).await,
+            (LIBFUZZER_CRASH_REPORT, Some(sub)) => libfuzzer_crash_report::run(sub).await,
+            (LIBFUZZER_MERGE, Some(sub)) => libfuzzer_merge::run(sub).await,
+            (GENERIC_ANALYSIS, Some(sub)) => generic_analysis::run(sub).await,
+            (GENERIC_CRASH_REPORT, Some(sub)) => generic_crash_report::run(sub).await,
+            (GENERIC_GENERATOR, Some(sub)) => generic_generator::run(sub).await,
+            (GENERIC_TEST_INPUT, Some(sub)) => test_input::run(sub).await,
+            (LIBFUZZER_TEST_INPUT, Some(sub)) => libfuzzer_test_input::run(sub).await,
+            _ => {
+                anyhow::bail!("missing subcommand\nUSAGE: {}", args.usage());
+            }
         }
+    };
+
+    if let Some(minutes) = running_duration {
+        if let Ok(run) = timeout(Duration::from_secs(minutes * 60), run).await {
+            run
+        } else {
+            info!("The running timeout period has elapsed");
+            Ok(())
+        }
+    } else {
+        run.await
     }
 }
 
 pub fn args(name: &str) -> App<'static, 'static> {
     SubCommand::with_name(name)
         .about("pre-release local fuzzing")
+        .arg(
+            Arg::with_name(TIMEOUT)
+                .long(TIMEOUT)
+                .help("The maximum running time in minutes")
+                .takes_value(true)
+                .required(false),
+        )
         .subcommand(add_common_config(radamsa::args(RADAMSA)))
         .subcommand(add_common_config(libfuzzer::args(LIBFUZZER)))
         .subcommand(add_common_config(libfuzzer_fuzz::args(LIBFUZZER_FUZZ)))

--- a/src/agent/onefuzz-agent/src/tasks/stats/common.rs
+++ b/src/agent/onefuzz-agent/src/tasks/stats/common.rs
@@ -21,7 +21,7 @@ pub async fn monitor_stats(path: Option<String>, format: Option<StatsFormat>) ->
                     StatsFormat::AFL => afl::read_stats(&path).await,
                 };
                 if let Ok(stats) = stats {
-                    event_entries!(runtime_stats; stats);
+                    log_events!(runtime_stats; stats);
                 }
                 delay_with_jitter(STATS_DELAY).await;
             }

--- a/src/agent/onefuzz-agent/src/tasks/stats/common.rs
+++ b/src/agent/onefuzz-agent/src/tasks/stats/common.rs
@@ -4,7 +4,7 @@
 use super::afl;
 use anyhow::{Error, Result};
 use onefuzz::jitter::delay_with_jitter;
-use onefuzz_telemetry::{track_event, Event::runtime_stats};
+use onefuzz_telemetry::Event::runtime_stats;
 use serde::Deserialize;
 pub const STATS_DELAY: std::time::Duration = std::time::Duration::from_secs(30);
 
@@ -21,7 +21,7 @@ pub async fn monitor_stats(path: Option<String>, format: Option<StatsFormat>) ->
                     StatsFormat::AFL => afl::read_stats(&path).await,
                 };
                 if let Ok(stats) = stats {
-                    track_event(runtime_stats, stats);
+                    event_entries!(runtime_stats; stats);
                 }
                 delay_with_jitter(STATS_DELAY).await;
             }

--- a/src/agent/onefuzz-telemetry/src/lib.rs
+++ b/src/agent/onefuzz-telemetry/src/lib.rs
@@ -545,7 +545,7 @@ pub fn log_message(level: appinsights::telemetry::SeverityLevel, msg: String) {
 }
 
 #[macro_export]
-macro_rules! event_entries {
+macro_rules! log_events {
     ($name: expr; $events: expr) => {{
         onefuzz_telemetry::track_event(&$name, &$events);
         log::info!(
@@ -566,7 +566,7 @@ macro_rules! event {
 
         })*;
 
-        event_entries!($name; events);
+        log_events!($name; events);
     }};
 }
 

--- a/src/agent/onefuzz-telemetry/src/lib.rs
+++ b/src/agent/onefuzz-telemetry/src/lib.rs
@@ -492,7 +492,7 @@ pub fn set_property(entry: EventData) {
     }
 }
 
-pub fn format_events(events : &[EventData]) -> String {
+pub fn format_events(events: &[EventData]) -> String {
     events
         .iter()
         .map(|x| x.as_values())
@@ -548,10 +548,13 @@ pub fn log_message(level: appinsights::telemetry::SeverityLevel, msg: String) {
 macro_rules! event_entries {
     ($name: expr; $events: expr) => {{
         onefuzz_telemetry::track_event(&$name, &$events);
-        log::info!("{} {}", $name.as_str(), onefuzz_telemetry::format_events(&$events));
+        log::info!(
+            "{} {}",
+            $name.as_str(),
+            onefuzz_telemetry::format_events(&$events)
+        );
     }};
 }
-
 
 #[macro_export]
 macro_rules! event {

--- a/src/proxy-manager/Cargo.lock
+++ b/src/proxy-manager/Cargo.lock
@@ -1165,6 +1165,7 @@ dependencies = [
  "clap",
  "env_logger",
  "futures",
+ "log",
  "onefuzz-telemetry",
  "reqwest",
  "reqwest-retry",

--- a/src/proxy-manager/Cargo.toml
+++ b/src/proxy-manager/Cargo.toml
@@ -21,3 +21,4 @@ url = { version = "2.2", features = ["serde"] }
 reqwest-retry = { path = "../agent/reqwest-retry"}
 onefuzz-telemetry = { path = "../agent/onefuzz-telemetry" }
 uuid = "0.8"
+log = "0.4"


### PR DESCRIPTION
Prior to this fix, all logging would show up as:

```
[2021-03-26T19:53:31Z INFO  onefuzz_telemetry] Starting libFuzzer crash report task
```

This moves the actual calls to `log::log!()` to the macros, which puts it in the source file in question.

Now the events look like:
```
[2021-03-26T21:20:14Z INFO  onefuzz_agent::tasks::report::libfuzzer_report] Starting libFuzzer crash report task
```

Most importantly, this allows us to use env_logger's ability to filter on a per module basis in a meaningful fashion.  As an example, this allows:
```
RUST_LOG="info,onefuzz::syncdir=warn,onefuzz_agent::tasks::fuzz::libfuzzer=warn"
```