### PR TITLE
cleanup syncdir events

### DIFF
--- a/src/agent/onefuzz/src/syncdir.rs
+++ b/src/agent/onefuzz/src/syncdir.rs
@@ -164,10 +164,10 @@ impl SyncedDir {
             fs::create_dir_all(&path).await?;
 
             while let Some(item) = monitor.next().await {
-                event!(event.clone(); EventData::Path = item.display().to_string());
                 let file_name = item
                     .file_name()
                     .ok_or_else(|| anyhow!("invalid file path"))?;
+                event!(event.clone(); EventData::Path = file_name.to_string_lossy());
                 let destination = path.join(file_name);
                 if let Err(err) = fs::copy(&item, &destination).await {
                     let error_message = format!(
@@ -178,7 +178,7 @@ impl SyncedDir {
                     if !item.exists() {
                         // guarding against cases where a temporary file was detected
                         // but was deleted before the copy
-                        warn!("{}", error_message);
+                        debug!("{}", error_message);
                         continue;
                     }
                     bail!("{}", error_message);
@@ -201,7 +201,7 @@ impl SyncedDir {
                     if !item.exists() {
                         // guarding against cases where a temporary file was detected
                         // but was deleted before the upload
-                        warn!("{}", error_message);
+                        debug!("{}", error_message);
                         continue;
                     }
                     bail!("{}", error_message);


### PR DESCRIPTION
This does the following:

1. set log verbosity on the guard from temp file vanish to debug
2. only display the filename for syncdir events.  

This means, instead of:
```
[2021-03-27T01:12:08Z INFO  onefuzz::syncdir] new_coverage path:/home/USERNAME/projects/onefuzz/onefuzz/src/agent/onefuzz-agent/00000000-0000-0000-0000-000000000000/ccea6ac6-79be-46ba-bdd9-df1f0e56ec96/inputs_dir/.1a0670e5ab896fcf914af212d80555b6305d3fb5.BE5fc8
```

We see:
```
[2021-03-27T01:12:08Z INFO  onefuzz::syncdir] new_coverage path:1a0670e5ab896fcf914af212d80555b6305d3fb5.BE5fc8
```