### PR TITLE
optionally ignore dotfiles in syncdir monitors

### DIFF
--- a/src/agent/onefuzz-agent/src/tasks/fuzz/generator.rs
+++ b/src/agent/onefuzz-agent/src/tasks/fuzz/generator.rs
@@ -80,7 +80,7 @@ impl GeneratorTask {
             self.config.ensemble_sync_delay,
         );
 
-        let crash_dir_monitor = self.config.crashes.monitor_results(new_result);
+        let crash_dir_monitor = self.config.crashes.monitor_results(new_result, false);
 
         let fuzzer = self.fuzzing_loop(hb_client);
 

--- a/src/agent/onefuzz-agent/src/tasks/fuzz/libfuzzer_fuzz.rs
+++ b/src/agent/onefuzz-agent/src/tasks/fuzz/libfuzzer_fuzz.rs
@@ -91,8 +91,8 @@ impl LibFuzzerFuzzTask {
 
         // To be scheduled.
         let resync = self.continuous_sync_inputs();
-        let new_inputs = self.config.inputs.monitor_results(new_coverage);
-        let new_crashes = self.config.crashes.monitor_results(new_result);
+        let new_inputs = self.config.inputs.monitor_results(new_coverage, true);
+        let new_crashes = self.config.crashes.monitor_results(new_result, true);
 
         let (stats_sender, stats_receiver) = mpsc::unbounded_channel();
         let report_stats = report_runtime_stats(self.workers() as usize, stats_receiver, hb_client);

--- a/src/agent/onefuzz-agent/src/tasks/fuzz/supervisor.rs
+++ b/src/agent/onefuzz-agent/src/tasks/fuzz/supervisor.rs
@@ -71,7 +71,7 @@ pub async fn spawn(config: SupervisorConfig) -> Result<(), Error> {
         url: config.crashes.url.clone(),
     };
     crashes.init().await?;
-    let monitor_crashes = crashes.monitor_results(new_result);
+    let monitor_crashes = crashes.monitor_results(new_result, false);
 
     // setup reports
     let reports_dir = tempdir()?;
@@ -111,7 +111,7 @@ pub async fn spawn(config: SupervisorConfig) -> Result<(), Error> {
             delay_with_jitter(delay).await;
         }
     }
-    let monitor_inputs = inputs.monitor_results(new_coverage);
+    let monitor_inputs = inputs.monitor_results(new_coverage, false);
     let continuous_sync_task = inputs.continuous_sync(Pull, config.ensemble_sync_delay);
 
     let process = start_supervisor(

--- a/src/agent/onefuzz/src/syncdir.rs
+++ b/src/agent/onefuzz/src/syncdir.rs
@@ -155,7 +155,7 @@ impl SyncedDir {
         }
     }
 
-    async fn file_monitor_event(&self, event: Event) -> Result<()> {
+    async fn file_monitor_event(&self, event: Event, ignore_dotfiles: bool) -> Result<()> {
         debug!("monitoring {}", self.path.display());
         let mut monitor = DirectoryMonitor::new(self.path.clone());
         monitor.start()?;
@@ -164,10 +164,13 @@ impl SyncedDir {
             fs::create_dir_all(&path).await?;
 
             while let Some(item) = monitor.next().await {
-                event!(event.clone(); EventData::Path = item.display().to_string());
                 let file_name = item
                     .file_name()
                     .ok_or_else(|| anyhow!("invalid file path"))?;
+                if ignore_dotfiles && file_name.to_string_lossy().starts_with(".") {
+                    continue;
+                }
+                event!(event.clone(); EventData::Path = item.display().to_string());
                 let destination = path.join(file_name);
                 if let Err(err) = fs::copy(&item, &destination).await {
                     let error_message = format!(
@@ -188,6 +191,12 @@ impl SyncedDir {
             let mut uploader = BlobUploader::new(self.url.url().clone());
 
             while let Some(item) = monitor.next().await {
+                let file_name = item
+                    .file_name()
+                    .ok_or_else(|| anyhow!("invalid file path"))?;
+                if ignore_dotfiles && file_name.to_string_lossy().starts_with(".") {
+                    continue;
+                }
                 event!(event.clone(); EventData::Path = item.display().to_string());
 
                 if let Err(err) = uploader.upload(item.clone()).await {
@@ -221,7 +230,7 @@ impl SyncedDir {
     /// The intent of this is to support use cases where we usually want a directory
     /// to be initialized, but a user-supplied binary, (such as AFL) logically owns
     /// a directory, and may reset it.
-    pub async fn monitor_results(&self, event: Event) -> Result<()> {
+    pub async fn monitor_results(&self, event: Event, ignore_dotfiles: bool) -> Result<()> {
         loop {
             debug!("waiting to monitor {}", self.path.display());
 
@@ -231,7 +240,7 @@ impl SyncedDir {
             }
 
             debug!("starting monitor for {}", self.path.display());
-            self.file_monitor_event(event.clone()).await?;
+            self.file_monitor_event(event.clone(), ignore_dotfiles).await?;
         }
     }
 }

--- a/src/agent/onefuzz/src/syncdir.rs
+++ b/src/agent/onefuzz/src/syncdir.rs
@@ -167,7 +167,7 @@ impl SyncedDir {
                 let file_name = item
                     .file_name()
                     .ok_or_else(|| anyhow!("invalid file path"))?;
-                if ignore_dotfiles && file_name.to_string_lossy().starts_with(".") {
+                if ignore_dotfiles && file_name.to_string_lossy().starts_with('.') {
                     continue;
                 }
 
@@ -195,7 +195,7 @@ impl SyncedDir {
                 let file_name = item
                     .file_name()
                     .ok_or_else(|| anyhow!("invalid file path"))?;
-                if ignore_dotfiles && file_name.to_string_lossy().starts_with(".") {
+                if ignore_dotfiles && file_name.to_string_lossy().starts_with('.') {
                     continue;
                 }
                 event!(event.clone(); EventData::Path = item.display().to_string());

--- a/src/agent/onefuzz/src/syncdir.rs
+++ b/src/agent/onefuzz/src/syncdir.rs
@@ -240,7 +240,8 @@ impl SyncedDir {
             }
 
             debug!("starting monitor for {}", self.path.display());
-            self.file_monitor_event(event.clone(), ignore_dotfiles).await?;
+            self.file_monitor_event(event.clone(), ignore_dotfiles)
+                .await?;
         }
     }
 }


### PR DESCRIPTION
Currently hard-coded for libFuzzer, which uses dotfiles for temporary analysis.