### PR TITLE
add names for poller logging

### DIFF
--- a/src/agent/onefuzz-agent/src/tasks/coverage/libfuzzer_coverage.rs
+++ b/src/agent/onefuzz-agent/src/tasks/coverage/libfuzzer_coverage.rs
@@ -89,7 +89,7 @@ pub struct CoverageTask {
 impl CoverageTask {
     pub fn new(config: Config) -> Self {
         let config = Arc::new(config);
-        let poller = InputPoller::new();
+        let poller = InputPoller::new("libfuzzer-coverage");
         Self { config, poller }
     }
 

--- a/src/agent/onefuzz-agent/src/tasks/generic/input_poller.rs
+++ b/src/agent/onefuzz-agent/src/tasks/generic/input_poller.rs
@@ -109,7 +109,7 @@ pub struct InputPoller<M> {
 
 impl<M> InputPoller<M> {
     pub fn new(name: impl AsRef<str>) -> Self {
-        let name= name.as_ref().to_owned();
+        let name = name.as_ref().to_owned();
         let state = Some(State::Ready);
         Self {
             state,
@@ -126,12 +126,20 @@ impl<M> InputPoller<M> {
     ) -> Result<()> {
         self.batch_dir = Some(to_process.clone());
         to_process.init_pull().await?;
-        info!("batch processing directory: {} - {}", self.name, to_process.path.display());
+        info!(
+            "batch processing directory: {} - {}",
+            self.name,
+            to_process.path.display()
+        );
 
         let mut read_dir = fs::read_dir(&to_process.path).await?;
         while let Some(file) = read_dir.next().await {
             let path = file?.path();
-            info!("processing batch-downloaded input: {} - {}", self.name, path.display());
+            info!(
+                "processing batch-downloaded input: {} - {}",
+                self.name,
+                path.display()
+            );
 
             // Compute the file name relative to the synced directory, and thus the
             // container.
@@ -184,7 +192,11 @@ impl<M> InputPoller<M> {
                 State::Downloaded(_msg, _url, input, _tempdir) => {
                     // if we can't get the filename, just pass the whole thing to logging
                     let filename = input.file_name().unwrap_or_else(|| input.as_ref());
-                    info!("processing {} input: {}", self.name, filename.to_string_lossy());
+                    info!(
+                        "processing {} input: {}",
+                        self.name,
+                        filename.to_string_lossy()
+                    );
                 }
                 _ => {}
             }

--- a/src/agent/onefuzz-agent/src/tasks/generic/input_poller/tests.rs
+++ b/src/agent/onefuzz-agent/src/tasks/generic/input_poller/tests.rs
@@ -100,7 +100,7 @@ fn url_input_name(url: &Url) -> String {
 }
 
 fn fixture() -> InputPoller<Msg> {
-    InputPoller::new()
+    InputPoller::new("test")
 }
 
 fn url_fixture(msg: Msg) -> Url {

--- a/src/agent/onefuzz-agent/src/tasks/report/generic.rs
+++ b/src/agent/onefuzz-agent/src/tasks/report/generic.rs
@@ -62,7 +62,7 @@ pub struct ReportTask {
 
 impl ReportTask {
     pub fn new(config: Config) -> Self {
-        let poller = InputPoller::new();
+        let poller = InputPoller::new("crash-report");
         Self { config, poller }
     }
 

--- a/src/agent/onefuzz-agent/src/tasks/report/libfuzzer_report.rs
+++ b/src/agent/onefuzz-agent/src/tasks/report/libfuzzer_report.rs
@@ -56,7 +56,7 @@ pub struct ReportTask {
 
 impl ReportTask {
     pub fn new(config: Config) -> Self {
-        let poller = InputPoller::new();
+        let poller = InputPoller::new("libfuzzer-crash-report");
         let config = Arc::new(config);
 
         Self { config, poller }


### PR DESCRIPTION
The polling logs now look like this:
```
[2021-03-27T01:48:57Z INFO  onefuzz_agent::tasks::generic::input_poller] processing libfuzzer-crash-report input: crash-54322de1dee85b932a3b5d850680eabed4fceb63  
```

Where it used to look like this:
```
[2021-03-27T01:48:57Z INFO  onefuzz_agent::tasks::generic::input_poller] processing input: /home/USER/GUID/GUID/.temp/.RANDOMSTRING/filename  
```