### PR TITLE
set ephemeral disks off by default

### DIFF
--- a/src/cli/onefuzz/api.py
+++ b/src/cli/onefuzz/api.py
@@ -1279,7 +1279,7 @@ class Scaleset(Endpoint):
         vm_sku: Optional[str] = "Standard_D2s_v3",
         region: Optional[primitives.Region] = None,
         spot_instances: bool = False,
-        ephemeral_os_disks: bool = True,
+        ephemeral_os_disks: bool = False,
         tags: Optional[Dict[str, str]] = None,
     ) -> models.Scaleset:
         self.logger.debug("create scaleset")


### PR DESCRIPTION
Apparently, different regions can have different disk requirements for the same VM sku.  Until we can include identifying what the VM requirements are on a per-region basis, this should be off by default.