### PR TITLE
Use custom serialization for block coverage

### DIFF
--- a/src/agent/coverage/examples/block_coverage.rs
+++ b/src/agent/coverage/examples/block_coverage.rs
@@ -69,47 +69,8 @@ fn main() -> Result<()> {
     let mut recorder = Recorder::new(&mut cache, filter);
     recorder.record(cmd)?;
 
-    for (module_path, cov) in recorder.coverage().iter() {
-        let mut hit = 0;
-        let mut found = 0;
-
-        let name = module_path.name_lossy();
-
-        log::info!("{}", module_path);
-
-        for block in cov.blocks.values() {
-            found += 1;
-
-            if block.count > 0 {
-                hit += 1;
-            }
-
-            let marker = if block.count == 0 { " " } else { "x" };
-
-            let module = recorder
-                .module_cache()
-                .cached
-                .get(module_path)
-                .expect("unreachable: module with coverage not in recorder cache");
-
-            if let Some(sym) = module.module.symbols.find(block.offset) {
-                let sym_offset = block.offset - sym.image_offset;
-                log::debug!(
-                    "  [{}] {}+{:x} ({}+{:x})",
-                    marker,
-                    name,
-                    block.offset,
-                    sym.name,
-                    sym_offset,
-                );
-            } else {
-                log::debug!("  [{}] {}+{:x}", marker, name, block.offset);
-            }
-        }
-
-        let percent = 100.0 * (hit as f64) / (found as f64);
-        log::info!("block coverage = {}/{} ({:.2}%)", hit, found, percent);
-    }
+    let coverage = serde_json::to_string_pretty(recorder.coverage())?;
+    println!("{}", coverage);
 
     Ok(())
 }

--- a/src/agent/coverage/src/block.rs
+++ b/src/agent/coverage/src/block.rs
@@ -427,7 +427,7 @@ mod tests {
         let text = r#"{"/lib/some.dll":[{"offset":"0x2","count":0},{"offset":"0x30","count":1},{"offset":"0x400","count":0}],"/main.exe":[{"offset":"0x1","count":1},{"offset":"0x20","count":0},{"offset":"0x300","count":1}]}"#;
 
         #[cfg(target_os = "windows")]
-        let text = r#"{"c:\lib\some.dll":[{"offset":"0x2","count":0},{"offset":"0x30","count":1},{"offset":"0x400","count":0}],"c:\main.exe":[{"offset":"0x1","count":1},{"offset":"0x20","count":0},{"offset":"0x300","count":1}]}"#;
+        let text = r#"{"c:\\lib\\some.dll":[{"offset":"0x2","count":0},{"offset":"0x30","count":1},{"offset":"0x400","count":0}],"c:\\main.exe":[{"offset":"0x1","count":1},{"offset":"0x20","count":0},{"offset":"0x300","count":1}]}"#;
 
         assert_eq!(ser, text);
 

--- a/src/agent/coverage/src/block.rs
+++ b/src/agent/coverage/src/block.rs
@@ -101,6 +101,13 @@ impl ModuleCov {
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct BlockCov {
     /// Offset of the block, relative to the module base load address.
+    //
+    // These offsets are represented as `u64` values, but since they are offsets
+    // within an assumed well-formed module, they should never exceed a `u32`.
+    // We thus assume that they can be losslessly serialized to an `f64`.
+    //
+    // If we need to handle malformed binaries or arbitrary addresses, then this
+    // will need revision.
     pub offset: u64,
 
     /// Number of times a block was seen to be executed, relative to some input

--- a/src/agent/coverage/src/block.rs
+++ b/src/agent/coverage/src/block.rs
@@ -16,7 +16,8 @@ use crate::code::ModulePath;
 /// Block coverage for a command invocation.
 ///
 /// Organized by module.
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+#[serde(transparent)]
 pub struct CommandBlockCov {
     modules: BTreeMap<ModulePath, ModuleCov>,
 }
@@ -65,7 +66,9 @@ impl CommandBlockCov {
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(transparent)]
 pub struct ModuleCov {
+    #[serde(with = "array")]
     pub blocks: BTreeMap<u64, BlockCov>,
 }
 
@@ -98,6 +101,7 @@ impl ModuleCov {
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct BlockCov {
     /// Offset of the block, relative to the module base load address.
+    #[serde(with = "hex")]
     pub offset: u64,
 
     /// Number of times a block was seen to be executed, relative to some input
@@ -116,6 +120,99 @@ pub struct BlockCov {
 impl BlockCov {
     pub fn new(offset: u64) -> Self {
         Self { offset, count: 0 }
+    }
+}
+
+mod array {
+    use std::collections::BTreeMap;
+    use std::fmt;
+
+    use serde::de::{self, Deserializer, Visitor};
+    use serde::ser::{SerializeSeq, Serializer};
+
+    use super::BlockCov;
+
+    type BlockCovMap = BTreeMap<u64, BlockCov>;
+
+    pub fn serialize<S>(data: &BlockCovMap, ser: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut seq = ser.serialize_seq(Some(data.len()))?;
+        for (_, v) in data {
+            seq.serialize_element(v)?;
+        }
+        seq.end()
+    }
+
+    pub fn deserialize<'d, D>(de: D) -> Result<BlockCovMap, D::Error>
+    where
+        D: Deserializer<'d>,
+    {
+        de.deserialize_seq(FlattenVisitor)
+    }
+
+    struct FlattenVisitor;
+
+    impl<'d> Visitor<'d> for FlattenVisitor {
+        type Value = BlockCovMap;
+
+        fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            write!(f, "array of blocks")
+        }
+
+        fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+        where
+            A: de::SeqAccess<'d>,
+        {
+            let mut map = Self::Value::default();
+
+            while let Some(block) = seq.next_element::<BlockCov>()? {
+                map.insert(block.offset, block);
+            }
+
+            Ok(map)
+        }
+    }
+}
+
+mod hex {
+    use std::fmt;
+
+    use serde::de::{self, Deserializer, Visitor};
+    use serde::ser::Serializer;
+
+    pub fn serialize<S>(data: &u64, ser: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let s = format!("0x{:x}", data);
+        ser.serialize_str(&s)
+    }
+
+    pub fn deserialize<'d, D>(de: D) -> Result<u64, D::Error>
+    where
+        D: Deserializer<'d>,
+    {
+        de.deserialize_str(HexVisitor)
+    }
+
+    struct HexVisitor;
+
+    impl<'d> Visitor<'d> for HexVisitor {
+        type Value = u64;
+
+        fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            write!(f, "lowercase hex string with `0x` prefix")
+        }
+
+        fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            let h = s.strip_prefix("0x").unwrap_or(s);
+            u64::from_str_radix(h, 16).map_err(de::Error::custom)
+        }
     }
 }
 
@@ -279,5 +376,59 @@ mod tests {
         ]);
 
         assert_eq!(total, expected);
+    }
+
+    #[test]
+    fn test_block_cov_serde() {
+        let block = BlockCov { offset: 0x123, count: 456 };
+
+        let ser = serde_json::to_string(&block).unwrap();
+
+        let text = r#"{"offset":"0x123","count":456}"#;
+        assert_eq!(ser, text);
+
+        let de: BlockCov = serde_json::from_str(&ser).unwrap();
+        assert_eq!(de, block);
+    }
+
+    #[test]
+    fn test_cmd_cov_serde() {
+        #[cfg(target_os = "linux")]
+        const MAIN_EXE: &str = "/main.exe";
+
+        #[cfg(target_os = "linux")]
+        const SOME_DLL: &str = "/lib/some.dll";
+
+        #[cfg(target_os = "windows")]
+        const MAIN_EXE: &str = r"c:\main.exe";
+
+        #[cfg(target_os = "windows")]
+        const SOME_DLL: &str = r"c:\lib\some.dll";
+
+        let main_exe = module_path(MAIN_EXE);
+        let some_dll = module_path(SOME_DLL);
+
+        let cov = {
+            let mut cov = CommandBlockCov::default();
+            cov.insert(&main_exe, vec![0x1, 0x20, 0x300].into_iter());
+            cov.increment(&main_exe, 0x1);
+            cov.increment(&main_exe, 0x300);
+            cov.insert(&some_dll, vec![0x2, 0x30, 0x400].into_iter());
+            cov.increment(&some_dll, 0x30);
+            cov
+        };
+
+        let ser = serde_json::to_string(&cov).unwrap();
+
+        #[cfg(target_os = "linux")]
+        let text = r#"{"/lib/some.dll":[{"offset":"0x2","count":0},{"offset":"0x30","count":1},{"offset":"0x400","count":0}],"/main.exe":[{"offset":"0x1","count":1},{"offset":"0x20","count":0},{"offset":"0x300","count":1}]}"#;
+
+        #[cfg(target_os = "windows")]
+        let text = r#"{"c:\lib\some.dll":[{"offset":"0x2","count":0},{"offset":"0x30","count":1},{"offset":"0x400","count":0}],"c:\main.exe":[{"offset":"0x1","count":1},{"offset":"0x20","count":0},{"offset":"0x300","count":1}]}"#;
+
+        assert_eq!(ser, text);
+
+        let de: CommandBlockCov = serde_json::from_str(&ser).unwrap();
+        assert_eq!(de, cov);
     }
 }

--- a/src/agent/coverage/src/block.rs
+++ b/src/agent/coverage/src/block.rs
@@ -139,7 +139,7 @@ mod array {
         S: Serializer,
     {
         let mut seq = ser.serialize_seq(Some(data.len()))?;
-        for (_, v) in data {
+        for v in data.values() {
             seq.serialize_element(v)?;
         }
         seq.end()

--- a/src/agent/coverage/src/block.rs
+++ b/src/agent/coverage/src/block.rs
@@ -380,7 +380,10 @@ mod tests {
 
     #[test]
     fn test_block_cov_serde() {
-        let block = BlockCov { offset: 0x123, count: 456 };
+        let block = BlockCov {
+            offset: 0x123,
+            count: 456,
+        };
 
         let ser = serde_json::to_string(&block).unwrap();
 


### PR DESCRIPTION
Update command block coverage serialization to support a more compact JSON format. See tests for examples.