### PR TITLE
rename telemetry key names at the service level

### DIFF
--- a/src/agent/onefuzz-agent/src/tasks/config.rs
+++ b/src/agent/onefuzz-agent/src/tasks/config.rs
@@ -35,12 +35,8 @@ pub struct CommonConfig {
 
     pub heartbeat_queue: Option<Url>,
 
-    // TODO: remove the alias once the service has been updated to match
-    #[serde(alias = "instrumentation_key")]
     pub instance_telemetry_key: Option<InstanceTelemetryKey>,
 
-    // TODO: remove the alias once the service has been updated to match
-    #[serde(alias = "telemetry_key")]
     pub microsoft_telemetry_key: Option<MicrosoftTelemetryKey>,
 
     #[serde(default)]

--- a/src/agent/onefuzz-supervisor/src/config.rs
+++ b/src/agent/onefuzz-supervisor/src/config.rs
@@ -27,12 +27,8 @@ pub struct StaticConfig {
 
     pub multi_tenant_domain: Option<String>,
 
-    // TODO: remove the alias once the service has been updated to match
-    #[serde(alias = "instrumentation_key")]
     pub instance_telemetry_key: Option<InstanceTelemetryKey>,
 
-    // TODO: remove the alias once the service has been updated to match
-    #[serde(alias = "telemetry_key")]
     pub microsoft_telemetry_key: Option<MicrosoftTelemetryKey>,
 
     pub heartbeat_queue: Option<Url>,
@@ -51,12 +47,8 @@ struct RawStaticConfig {
 
     pub multi_tenant_domain: Option<String>,
 
-    // TODO: remove the alias once the service has been updated to match
-    #[serde(alias = "instrumentation_key")]
     pub instance_telemetry_key: Option<InstanceTelemetryKey>,
 
-    // TODO: remove the alias once the service has been updated to match
-    #[serde(alias = "telemetry_key")]
     pub microsoft_telemetry_key: Option<MicrosoftTelemetryKey>,
 
     pub heartbeat_queue: Option<Url>,

--- a/src/api-service/__app__/onefuzzlib/extension.py
+++ b/src/api-service/__app__/onefuzzlib/extension.py
@@ -103,13 +103,13 @@ def build_pool_config(pool: Pool) -> str:
     config = AgentConfig(
         pool_name=pool.name,
         onefuzz_url=get_instance_url(),
-        instrumentation_key=os.environ.get("APPINSIGHTS_INSTRUMENTATIONKEY"),
         heartbeat_queue=get_queue_sas(
             "node-heartbeat",
             StorageType.config,
             add=True,
         ),
-        telemetry_key=os.environ.get("ONEFUZZ_TELEMETRY"),
+        instance_telemetry_key=os.environ.get("APPINSIGHTS_INSTRUMENTATIONKEY"),
+        microsoft_telemetry_key=os.environ.get("ONEFUZZ_TELEMETRY"),
         instance_id=get_instance_id(),
     )
 

--- a/src/api-service/__app__/onefuzzlib/proxy.py
+++ b/src/api-service/__app__/onefuzzlib/proxy.py
@@ -222,8 +222,8 @@ class Proxy(ORMMixin):
             ),
             forwards=forwards,
             region=self.region,
-            instrumentation_key=os.environ.get("APPINSIGHTS_INSTRUMENTATIONKEY"),
-            telemetry_key=os.environ.get("ONEFUZZ_TELEMETRY"),
+            instance_telemetry_key=os.environ.get("APPINSIGHTS_INSTRUMENTATIONKEY"),
+            microsoft_telemetry_key=os.environ.get("ONEFUZZ_TELEMETRY"),
             instance_id=get_instance_id(),
         )
 

--- a/src/api-service/__app__/onefuzzlib/tasks/config.py
+++ b/src/api-service/__app__/onefuzzlib/tasks/config.py
@@ -205,8 +205,8 @@ def build_task_config(
         job_id=job_id,
         task_id=task_id,
         task_type=task_config.task.type,
-        instrumentation_key=os.environ.get("APPINSIGHTS_INSTRUMENTATIONKEY"),
-        telemetry_key=os.environ.get("ONEFUZZ_TELEMETRY"),
+        instance_telemetry_key=os.environ.get("APPINSIGHTS_INSTRUMENTATIONKEY"),
+        microsoft_telemetry_key=os.environ.get("ONEFUZZ_TELEMETRY"),
         heartbeat_queue=get_queue_sas(
             "task-heartbeat",
             StorageType.config,

--- a/src/api-service/__app__/pool/__init__.py
+++ b/src/api-service/__app__/pool/__init__.py
@@ -31,8 +31,8 @@ def set_config(pool: Pool) -> Pool:
     pool.config = AgentConfig(
         pool_name=pool.name,
         onefuzz_url=get_instance_url(),
-        instrumentation_key=os.environ.get("APPINSIGHTS_INSTRUMENTATIONKEY"),
-        telemetry_key=os.environ.get("ONEFUZZ_TELEMETRY"),
+        instance_telemetry_key=os.environ.get("APPINSIGHTS_INSTRUMENTATIONKEY"),
+        microsoft_telemetry_key=os.environ.get("ONEFUZZ_TELEMETRY"),
         heartbeat_queue=get_queue_sas(
             "node-heartbeat",
             StorageType.config,

--- a/src/proxy-manager/src/config.rs
+++ b/src/proxy-manager/src/config.rs
@@ -45,15 +45,8 @@ pub struct Forward {
 #[derive(Debug, Deserialize, Serialize, PartialEq, Clone)]
 pub struct ConfigData {
     pub instance_id: Uuid,
-
-    // TODO: remove the alias once the service has been updated to match
-    #[serde(alias = "instrumentation_key")]
     pub instance_telemetry_key: Option<InstanceTelemetryKey>,
-
-    // TODO: remove the alias once the service has been updated to match
-    #[serde(alias = "telemetry_key")]
     pub microsoft_telemetry_key: Option<MicrosoftTelemetryKey>,
-
     pub region: String,
     pub url: Url,
     pub notification: Url,

--- a/src/pytypes/onefuzztypes/models.py
+++ b/src/pytypes/onefuzztypes/models.py
@@ -362,8 +362,8 @@ class AgentConfig(BaseModel):
     onefuzz_url: str
     pool_name: PoolName
     heartbeat_queue: Optional[str]
-    instrumentation_key: Optional[str]
-    telemetry_key: Optional[str]
+    instance_telemetry_key: Optional[str]
+    microsoft_telemetry_key: Optional[str]
     multi_tenant_domain: Optional[str]
     instance_id: UUID
 
@@ -373,8 +373,8 @@ class TaskUnitConfig(BaseModel):
     job_id: UUID
     task_id: UUID
     task_type: TaskType
-    instrumentation_key: Optional[str]
-    telemetry_key: Optional[str]
+    instance_telemetry_key: Optional[str]
+    microsoft_telemetry_key: Optional[str]
     heartbeat_queue: str
     # command_queue: str
     input_queue: Optional[str]
@@ -433,8 +433,8 @@ class ProxyConfig(BaseModel):
     notification: str
     region: Region
     forwards: List[Forward]
-    instrumentation_key: Optional[str]
-    telemetry_key: Optional[str]
+    instance_telemetry_key: Optional[str]
+    microsoft_telemetry_key: Optional[str]
     instance_id: UUID
 
 


### PR DESCRIPTION
In #766, the telemetry keys were renamed to reduce confusion.  However, this broke the telemetry keys within the agent due to a known issue using flattened json with aliases (See https://github.com/serde-rs/serde/issues/1976).

This PR removes the aliases and fixes the agent level telemetry & logging.