### PR TITLE
set default value for ephemeral disks at the server request parser

### DIFF
--- a/src/pytypes/onefuzztypes/requests.py
+++ b/src/pytypes/onefuzztypes/requests.py
@@ -176,7 +176,7 @@ class ScalesetCreate(BaseRequest):
     region: Optional[Region]
     size: int
     spot_instances: bool
-    ephemeral_os_disks: bool
+    ephemeral_os_disks: bool = Field(default=False)
     tags: Dict[str, str]
 
     @validator("size", allow_reuse=True)


### PR DESCRIPTION
This fixes an issue for an older CLI (2.4.0) trying to create a scaleset on a new instance (2.12.0).