### PR TITLE
limit the amount of data recorded from libFuzzer's stderr

### DIFF
--- a/src/agent/onefuzz-agent/src/tasks/fuzz/libfuzzer_fuzz.rs
+++ b/src/agent/onefuzz-agent/src/tasks/fuzz/libfuzzer_fuzz.rs
@@ -38,7 +38,7 @@ const RUNTIME_STATS_PERIOD: Duration = Duration::from_secs(60);
 
 /// Maximum number of log message to safe in case of libFuzzer failing,
 /// arbitrarily chosen
-const LOGS_BUFFER_SIZE: usize = 1000;
+const LOGS_BUFFER_SIZE: usize = 1024;
 
 pub fn default_workers() -> usize {
     let cpus = num_cpus::get();
@@ -212,8 +212,7 @@ impl LibFuzzerFuzzTask {
             .ok_or_else(|| format_err!("stderr not captured"))?;
         let mut stderr = BufReader::new(stderr);
 
-        let mut libfuzzer_output: ArrayDeque<[String; LOGS_BUFFER_SIZE], Wrapping> =
-            ArrayDeque::new();
+        let mut libfuzzer_output: ArrayDeque<[_; LOGS_BUFFER_SIZE], Wrapping> = ArrayDeque::new();
 
         loop {
             let mut buf = vec![];


### PR DESCRIPTION
Upon failure, OneFuzz reports the stderr as part of the task failure.  In some cases, this could end up being an excessive amount of data kept in memory.  This limits the stderr saved in case of failure to at most the last 1024 lines.
