### PR TITLE
only record the first failure if a task has multiple failures

### DIFF
--- a/src/api-service/__app__/onefuzzlib/tasks/main.py
+++ b/src/api-service/__app__/onefuzzlib/tasks/main.py
@@ -204,6 +204,12 @@ class Task(BASE_TASK, ORMMixin):
             )
             return
 
+        if self.error is not None:
+            logging.debug(
+                "ignoring additional task error %s:%s", self.job_id, self.task_id
+            )
+            return
+
         logging.error("task failed %s:%s - %s", self.job_id, self.task_id, error)
 
         self.error = error


### PR DESCRIPTION
In the case a task fails multiple times (such as with multiple VMs), we only record the first failure.