### PR TITLE
Upgrade to tokio 1.5.0

### DIFF
--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -66,7 +66,7 @@ dependencies = [
  "http",
  "log",
  "paste",
- "reqwest",
+ "reqwest 0.10.10",
  "serde",
  "serde_json",
  "sm",
@@ -752,6 +752,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11fce69af4d4582ea989e6adfc5c9b81fd2071ff89234e5c14675c82a85217df"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "nanorand",
+ "pin-project",
+ "spinning_top",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -865,9 +878,9 @@ checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "futures"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f55667319111d593ba876406af7c409c0ebb44dc4be6132a783ccf163ea14c1"
+checksum = "a9d5813545e459ad3ca1bff9915e9ad7f1a47dc6a91b627ce321d5863b7dd253"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -880,9 +893,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c2dd2df839b57db9ab69c2c9d8f3e8c81984781937fe2807dc6dcf3b2ad2939"
+checksum = "ce79c6a52a299137a6013061e0cf0e688fce5d7f1bc60125f520912fdb29ec25"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -890,15 +903,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15496a72fabf0e62bdc3df11a59a3787429221dd0710ba8ef163d6f7a9112c94"
+checksum = "098cd1c6dda6ca01650f1a37a794245eb73181d0d4d4e955e2f3c37db7af1815"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891a4b7b96d84d5940084b2a37632dd65deeae662c114ceaa2c879629c9c0ad1"
+checksum = "10f6cb7042eda00f0049b1d2080aa4b93442997ee507eb3828e8bd7577f94c9d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -907,9 +920,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71c2c65c57704c32f5241c1223167c2c3294fd34ac020c807ddbe6db287ba59"
+checksum = "365a1a1fb30ea1c03a830fdb2158f5236833ac81fa0ad12fe35b29cddc35cb04"
 
 [[package]]
 name = "futures-lite"
@@ -928,9 +941,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea405816a5139fb39af82c2beb921d52143f556038378d6db21183a5c37fbfb7"
+checksum = "668c6733a182cd7deb4f1de7ba3bf2120823835b3bcfbeacf7d2c4a773c1bb8b"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2 1.0.24",
@@ -940,21 +953,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85754d98985841b7d4f5e8e6fbfa4a4ac847916893ec511a2917ccd8525b8bb3"
+checksum = "5c5629433c555de3d82861a7a4e3794a4c40040390907cfbfd7143a92a426c23"
 
 [[package]]
 name = "futures-task"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa189ef211c15ee602667a6fcfe1c1fd9e07d42250d2156382820fba33c9df80"
+checksum = "ba7aa51095076f3ba6d9a1f702f74bd05ec65f555d70d2033d55ba8d69f581bc"
 
 [[package]]
 name = "futures-util"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1812c7ab8aedf8d6f2701a43e1243acdbcc2b36ab26e2ad421eb99ac963d96d1"
+checksum = "3c144ad54d60f23927f0a6b6d816e4271278b64f005ad65e4e35291d2de9c025"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -998,8 +1011,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
 dependencies = [
  "cfg-if 1.0.0",
+ "js-sys",
  "libc",
  "wasi 0.10.2+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1053,9 +1068,28 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio 0.2.25",
- "tokio-util",
+ "tokio-util 0.3.1",
  "tracing",
  "tracing-futures",
+]
+
+[[package]]
+name = "h2"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc018e188373e2777d0ef2467ebff62a08e66c3f5857b23c8fbec3018210dc00"
+dependencies = [
+ "bytes 1.0.1",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio 1.5.0",
+ "tokio-util 0.6.6",
+ "tracing",
 ]
 
 [[package]]
@@ -1121,6 +1155,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-body"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfb77c123b4e2f72a2069aeae0b4b4949cc7e966df277813fc16347e7549737"
+dependencies = [
+ "bytes 1.0.1",
+ "http",
+ "pin-project-lite 0.2.6",
+]
+
+[[package]]
 name = "httparse"
 version = "1.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1148,15 +1193,39 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.2.7",
  "http",
- "http-body",
+ "http-body 0.3.1",
  "httparse",
  "httpdate",
  "itoa",
  "pin-project",
- "socket2",
+ "socket2 0.3.19",
  "tokio 0.2.25",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bf09f61b52cfcf4c00de50df88ae423d6c02354e385a86341133b5338630ad1"
+dependencies = [
+ "bytes 1.0.1",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.2",
+ "http",
+ "http-body 0.4.1",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project",
+ "socket2 0.4.0",
+ "tokio 1.5.0",
  "tower-service",
  "tracing",
  "want",
@@ -1169,10 +1238,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d979acc56dcb5b8dddba3917601745e877576475aa046df3226eabdecef78eed"
 dependencies = [
  "bytes 0.5.6",
- "hyper",
+ "hyper 0.13.10",
  "native-tls",
  "tokio 0.2.25",
  "tokio-tls",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes 1.0.1",
+ "hyper 0.14.5",
+ "native-tls",
+ "tokio 1.5.0",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -1492,29 +1574,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mio-named-pipes"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0840c1c50fd55e521b247f949c241c9997709f23bd7f023b9762cd561e935656"
-dependencies = [
- "log",
- "mio 0.6.23",
- "miow 0.3.6",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "mio-uds"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0"
-dependencies = [
- "iovec",
- "libc",
- "mio 0.6.23",
-]
-
-[[package]]
 name = "miow"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1532,7 +1591,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
 dependencies = [
- "socket2",
+ "socket2 0.3.19",
  "winapi 0.3.9",
 ]
 
@@ -1543,6 +1602,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6584cf122f02fc0396420a116cd395a9a776ec4347dffe1c5119c3fcc917c060"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "nanorand"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac1378b66f7c93a1c0f8464a19bf47df8795083842e5090f4b7305973d5a22d0"
+dependencies = [
+ "getrandom 0.2.2",
 ]
 
 [[package]]
@@ -1570,7 +1638,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "670361df1bc2399ee1ff50406a0d422587dd3bb0da596e1978fe8e05dabddf4f"
 dependencies = [
  "libc",
- "socket2",
+ "socket2 0.3.19",
 ]
 
 [[package]]
@@ -1704,11 +1772,12 @@ dependencies = [
  "async-trait",
  "backoff",
  "base64",
- "bytes 0.5.6",
+ "bytes 1.0.1",
  "cpp_demangle",
  "debugger",
  "dunce",
  "futures",
+ "futures-util",
  "hex",
  "input-tester",
  "lazy_static",
@@ -1721,7 +1790,7 @@ dependencies = [
  "process_control",
  "rand 0.7.3",
  "regex",
- "reqwest",
+ "reqwest 0.11.3",
  "reqwest-retry",
  "ring",
  "rstack",
@@ -1735,8 +1804,9 @@ dependencies = [
  "strum_macros",
  "sysinfo 0.16.4",
  "tempfile",
- "tokio 0.2.25",
- "tokio-util",
+ "tokio 1.5.0",
+ "tokio-stream",
+ "tokio-util 0.6.6",
  "url",
  "urlparse",
  "uuid",
@@ -1756,6 +1826,7 @@ dependencies = [
  "clap",
  "crossterm",
  "env_logger",
+ "flume",
  "futures",
  "hex",
  "lazy_static",
@@ -1765,7 +1836,7 @@ dependencies = [
  "onefuzz-telemetry",
  "path-absolutize",
  "remove_dir_all 0.7.0",
- "reqwest",
+ "reqwest 0.11.3",
  "reqwest-retry",
  "serde",
  "serde_json",
@@ -1773,9 +1844,9 @@ dependencies = [
  "storage-queue",
  "tempfile",
  "thiserror",
- "tokio 0.2.25",
+ "tokio 1.5.0",
  "tokio-stream",
- "tokio-util",
+ "tokio-util 0.6.6",
  "tui",
  "url",
  "uuid",
@@ -1795,13 +1866,13 @@ dependencies = [
  "log",
  "onefuzz",
  "onefuzz-telemetry",
- "reqwest",
+ "reqwest 0.11.3",
  "reqwest-retry",
  "serde",
  "serde_json",
  "storage-queue",
  "structopt",
- "tokio 0.2.25",
+ "tokio 1.5.0",
  "url",
  "users",
  "uuid",
@@ -1816,7 +1887,7 @@ dependencies = [
  "lazy_static",
  "log",
  "serde",
- "tokio 0.2.25",
+ "tokio 1.5.0",
  "uuid",
  "z3-sys",
 ]
@@ -2342,9 +2413,9 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http",
- "http-body",
- "hyper",
- "hyper-tls",
+ "http-body 0.3.1",
+ "hyper 0.13.10",
+ "hyper-tls 0.4.3",
  "ipnet",
  "js-sys",
  "lazy_static",
@@ -2367,6 +2438,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2296f2fac53979e8ccbc4a1136b25dcefd37be9ed7e4a1f6b05a6029c84ff124"
+dependencies = [
+ "base64",
+ "bytes 1.0.1",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body 0.4.1",
+ "hyper 0.14.5",
+ "hyper-tls 0.5.0",
+ "ipnet",
+ "js-sys",
+ "lazy_static",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite 0.2.6",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio 1.5.0",
+ "tokio-native-tls",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg 0.7.0",
+]
+
+[[package]]
 name = "reqwest-retry"
 version = "0.1.0"
 dependencies = [
@@ -2375,8 +2481,8 @@ dependencies = [
  "backoff",
  "log",
  "onefuzz-telemetry",
- "reqwest",
- "tokio 0.2.25",
+ "reqwest 0.11.3",
+ "tokio 1.5.0",
 ]
 
 [[package]]
@@ -2663,10 +2769,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e3dfc207c526015c632472a77be09cf1b6e46866581aecae5cc38fb4235dea2"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "spinning_top"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bd0ab6b8c375d2d963503b90d3770010d95bc3b5f98036f948dee24bf4e8879"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "stacktrace-parser"
@@ -2698,16 +2823,17 @@ dependencies = [
  "base64",
  "bytes 0.5.6",
  "derivative",
+ "flume",
  "num_cpus",
  "queue-file",
  "regex",
- "reqwest",
+ "reqwest 0.11.3",
  "reqwest-retry",
  "serde",
  "serde-xml-rs",
  "serde_derive",
  "serde_json",
- "tokio 0.2.25",
+ "tokio 1.5.0",
  "uuid",
  "yaque",
 ]
@@ -2913,34 +3039,38 @@ dependencies = [
  "futures-core",
  "iovec",
  "lazy_static",
- "libc",
  "memchr",
  "mio 0.6.23",
- "mio-named-pipes",
- "mio-uds",
  "num_cpus",
  "pin-project-lite 0.1.12",
- "signal-hook-registry",
  "slab",
+]
+
+[[package]]
+name = "tokio"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83f0c8e7c0addab50b663055baf787d0af7f413a46e6e7fb9559a4e4db7137a5"
+dependencies = [
+ "autocfg",
+ "bytes 1.0.1",
+ "libc",
+ "memchr",
+ "mio 0.7.10",
+ "num_cpus",
+ "once_cell",
+ "parking_lot",
+ "pin-project-lite 0.2.6",
+ "signal-hook-registry",
  "tokio-macros",
  "winapi 0.3.9",
 ]
 
 [[package]]
-name = "tokio"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8190d04c665ea9e6b6a0dc45523ade572c088d2e6566244c1122671dbf4ae3a"
-dependencies = [
- "autocfg",
- "pin-project-lite 0.2.6",
-]
-
-[[package]]
 name = "tokio-macros"
-version = "0.2.6"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e44da00bfc73a25f814cd8d7e57a68a5c31b74b3152a0a1d1f590c97ed06265a"
+checksum = "caf7b11a536f46a809a8a9f0bb4237020f70ecbf115b842360afb127ea2fda57"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
@@ -2948,14 +3078,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-stream"
-version = "0.1.3"
+name = "tokio-native-tls"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1981ad97df782ab506a1f43bf82c967326960d278acf3bf8279809648c3ff3ea"
+checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+dependencies = [
+ "native-tls",
+ "tokio 1.5.0",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e177a5d8c3bf36de9ebe6d58537d8879e964332f93fb3339e43f618c81361af0"
 dependencies = [
  "futures-core",
  "pin-project-lite 0.2.6",
- "tokio 1.2.0",
+ "tokio 1.5.0",
+ "tokio-util 0.6.6",
 ]
 
 [[package]]
@@ -2976,11 +3117,26 @@ checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
 dependencies = [
  "bytes 0.5.6",
  "futures-core",
- "futures-io",
  "futures-sink",
  "log",
  "pin-project-lite 0.1.12",
  "tokio 0.2.25",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940a12c99365c31ea8dd9ba04ec1be183ffe4920102bb7122c2f515437601e8e"
+dependencies = [
+ "bytes 1.0.1",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "log",
+ "pin-project-lite 0.2.6",
+ "slab",
+ "tokio 1.5.0",
 ]
 
 [[package]]

--- a/src/agent/onefuzz-agent/Cargo.toml
+++ b/src/agent/onefuzz-agent/Cargo.toml
@@ -19,12 +19,13 @@ backoff = { version = "0.3", features = ["async-std"] }
 clap = "2.33"
 crossterm = "0.18"
 env_logger = "0.8"
-futures = "0.3"
+flume = "0.10.4"
+futures = "0.3.14"
 hex = "0.4"
 lazy_static = "1.4"
 log = "0.4"
 num_cpus = "1.13"
-reqwest = { version = "0.10", features = ["json", "stream"] }
+reqwest = { version = "0.11.3", features = ["json", "stream"] }
 serde = "1.0"
 serde_json = "1.0"
 onefuzz = { path = "../onefuzz" }
@@ -36,9 +37,9 @@ stacktrace-parser = { path = "../stacktrace-parser" }
 storage-queue = { path = "../storage-queue" }
 tempfile = "3.2"
 thiserror = "1.0"
-tokio = { version = "0.2", features = ["full"] }
-tokio-util = { version = "0.3", features = ["full"] }
-tokio-stream = "0.1.3"
+tokio = { version = "1.5.0", features = ["full"] }
+tokio-util = { version = "0.6.6", features = ["full"] }
+tokio-stream = "0.1.5"
 tui = { version = "0.14", default-features = false, features = ['crossterm'] }
 url = { version = "2.2", features = ["serde"] }
 uuid = { version = "0.8", features = ["serde", "v4"] }

--- a/src/agent/onefuzz-agent/src/local/common.rs
+++ b/src/agent/onefuzz-agent/src/local/common.rs
@@ -3,6 +3,7 @@ use crate::tasks::utils::parse_key_value;
 use anyhow::Result;
 use backoff::{future::retry, Error as BackoffError, ExponentialBackoff};
 use clap::{App, Arg, ArgMatches};
+use flume;
 use onefuzz::jitter::delay_with_jitter;
 use onefuzz::{blob::BlobContainerUrl, monitor::DirectoryMonitor, syncdir::SyncedDir};
 use path_absolutize::Absolutize;
@@ -15,7 +16,6 @@ use std::{
     path::{Path, PathBuf},
     time::Duration,
 };
-use tokio::sync::mpsc::UnboundedSender;
 use uuid::Uuid;
 
 pub const SETUP_DIR: &str = "setup_dir";
@@ -68,7 +68,7 @@ pub enum CmdType {
 pub struct LocalContext {
     pub job_path: PathBuf,
     pub common_config: CommonConfig,
-    pub event_sender: Option<UnboundedSender<UiEvent>>,
+    pub event_sender: Option<flume::Sender<UiEvent>>,
 }
 
 pub fn get_hash_map(args: &clap::ArgMatches<'_>, name: &str) -> Result<HashMap<String, String>> {
@@ -215,7 +215,7 @@ pub fn get_synced_dir(
 pub fn build_local_context(
     args: &ArgMatches<'_>,
     generate_task_id: bool,
-    event_sender: Option<UnboundedSender<UiEvent>>,
+    event_sender: Option<flume::Sender<UiEvent>>,
 ) -> Result<LocalContext> {
     let job_id = get_uuid("job_id", args).unwrap_or_else(|_| Uuid::nil());
     let task_id = get_uuid("task_id", args).unwrap_or_else(|_| {
@@ -328,11 +328,11 @@ pub enum UiEvent {
 }
 
 pub trait SyncCountDirMonitor<T: Sized> {
-    fn monitor_count(self, event_sender: &Option<UnboundedSender<UiEvent>>) -> Result<T>;
+    fn monitor_count(self, event_sender: &Option<flume::Sender<UiEvent>>) -> Result<T>;
 }
 
 impl SyncCountDirMonitor<SyncedDir> for SyncedDir {
-    fn monitor_count(self, event_sender: &Option<UnboundedSender<UiEvent>>) -> Result<Self> {
+    fn monitor_count(self, event_sender: &Option<flume::Sender<UiEvent>>) -> Result<Self> {
         if let (Some(event_sender), Some(p)) = (event_sender, self.url.as_file_path()) {
             event_sender.send(UiEvent::MonitorDir(p))?;
         }
@@ -341,7 +341,7 @@ impl SyncCountDirMonitor<SyncedDir> for SyncedDir {
 }
 
 impl SyncCountDirMonitor<Option<SyncedDir>> for Option<SyncedDir> {
-    fn monitor_count(self, event_sender: &Option<UnboundedSender<UiEvent>>) -> Result<Self> {
+    fn monitor_count(self, event_sender: &Option<flume::Sender<UiEvent>>) -> Result<Self> {
         if let Some(sd) = self {
             let sd = sd.monitor_count(event_sender)?;
             Ok(Some(sd))

--- a/src/agent/onefuzz-agent/src/local/common.rs
+++ b/src/agent/onefuzz-agent/src/local/common.rs
@@ -3,6 +3,7 @@ use crate::tasks::utils::parse_key_value;
 use anyhow::Result;
 use backoff::{future::retry, Error as BackoffError, ExponentialBackoff};
 use clap::{App, Arg, ArgMatches};
+use flume::Sender;
 use onefuzz::jitter::delay_with_jitter;
 use onefuzz::{blob::BlobContainerUrl, monitor::DirectoryMonitor, syncdir::SyncedDir};
 use path_absolutize::Absolutize;
@@ -67,7 +68,7 @@ pub enum CmdType {
 pub struct LocalContext {
     pub job_path: PathBuf,
     pub common_config: CommonConfig,
-    pub event_sender: Option<flume::Sender<UiEvent>>,
+    pub event_sender: Option<Sender<UiEvent>>,
 }
 
 pub fn get_hash_map(args: &clap::ArgMatches<'_>, name: &str) -> Result<HashMap<String, String>> {
@@ -214,7 +215,7 @@ pub fn get_synced_dir(
 pub fn build_local_context(
     args: &ArgMatches<'_>,
     generate_task_id: bool,
-    event_sender: Option<flume::Sender<UiEvent>>,
+    event_sender: Option<Sender<UiEvent>>,
 ) -> Result<LocalContext> {
     let job_id = get_uuid("job_id", args).unwrap_or_else(|_| Uuid::nil());
     let task_id = get_uuid("task_id", args).unwrap_or_else(|_| {
@@ -327,11 +328,11 @@ pub enum UiEvent {
 }
 
 pub trait SyncCountDirMonitor<T: Sized> {
-    fn monitor_count(self, event_sender: &Option<flume::Sender<UiEvent>>) -> Result<T>;
+    fn monitor_count(self, event_sender: &Option<Sender<UiEvent>>) -> Result<T>;
 }
 
 impl SyncCountDirMonitor<SyncedDir> for SyncedDir {
-    fn monitor_count(self, event_sender: &Option<flume::Sender<UiEvent>>) -> Result<Self> {
+    fn monitor_count(self, event_sender: &Option<Sender<UiEvent>>) -> Result<Self> {
         if let (Some(event_sender), Some(p)) = (event_sender, self.url.as_file_path()) {
             event_sender.send(UiEvent::MonitorDir(p))?;
         }
@@ -340,7 +341,7 @@ impl SyncCountDirMonitor<SyncedDir> for SyncedDir {
 }
 
 impl SyncCountDirMonitor<Option<SyncedDir>> for Option<SyncedDir> {
-    fn monitor_count(self, event_sender: &Option<flume::Sender<UiEvent>>) -> Result<Self> {
+    fn monitor_count(self, event_sender: &Option<Sender<UiEvent>>) -> Result<Self> {
         if let Some(sd) = self {
             let sd = sd.monitor_count(event_sender)?;
             Ok(Some(sd))

--- a/src/agent/onefuzz-agent/src/local/common.rs
+++ b/src/agent/onefuzz-agent/src/local/common.rs
@@ -3,7 +3,6 @@ use crate::tasks::utils::parse_key_value;
 use anyhow::Result;
 use backoff::{future::retry, Error as BackoffError, ExponentialBackoff};
 use clap::{App, Arg, ArgMatches};
-use flume;
 use onefuzz::jitter::delay_with_jitter;
 use onefuzz::{blob::BlobContainerUrl, monitor::DirectoryMonitor, syncdir::SyncedDir};
 use path_absolutize::Absolutize;

--- a/src/agent/onefuzz-agent/src/local/generic_analysis.rs
+++ b/src/agent/onefuzz-agent/src/local/generic_analysis.rs
@@ -15,13 +15,14 @@ use crate::{
 };
 use anyhow::Result;
 use clap::{App, Arg, SubCommand};
+use flume::Sender;
 use storage_queue::QueueClient;
 
 pub fn build_analysis_config(
     args: &clap::ArgMatches<'_>,
     input_queue: Option<QueueClient>,
     common: CommonConfig,
-    event_sender: Option<flume::Sender<UiEvent>>,
+    event_sender: Option<Sender<UiEvent>>,
 ) -> Result<Config> {
     let target_exe = get_cmd_exe(CmdType::Target, args)?.into();
     let target_options = get_cmd_arg(CmdType::Target, args);
@@ -68,10 +69,7 @@ pub fn build_analysis_config(
     Ok(config)
 }
 
-pub async fn run(
-    args: &clap::ArgMatches<'_>,
-    event_sender: Option<flume::Sender<UiEvent>>,
-) -> Result<()> {
+pub async fn run(args: &clap::ArgMatches<'_>, event_sender: Option<Sender<UiEvent>>) -> Result<()> {
     let context = build_local_context(args, true, event_sender.clone())?;
     let config = build_analysis_config(args, None, context.common_config.clone(), event_sender)?;
     run_analysis(config).await

--- a/src/agent/onefuzz-agent/src/local/generic_analysis.rs
+++ b/src/agent/onefuzz-agent/src/local/generic_analysis.rs
@@ -15,7 +15,6 @@ use crate::{
 };
 use anyhow::Result;
 use clap::{App, Arg, SubCommand};
-use flume;
 use storage_queue::QueueClient;
 
 pub fn build_analysis_config(

--- a/src/agent/onefuzz-agent/src/local/generic_analysis.rs
+++ b/src/agent/onefuzz-agent/src/local/generic_analysis.rs
@@ -15,14 +15,14 @@ use crate::{
 };
 use anyhow::Result;
 use clap::{App, Arg, SubCommand};
+use flume;
 use storage_queue::QueueClient;
-use tokio::sync::mpsc::UnboundedSender;
 
 pub fn build_analysis_config(
     args: &clap::ArgMatches<'_>,
     input_queue: Option<QueueClient>,
     common: CommonConfig,
-    event_sender: Option<UnboundedSender<UiEvent>>,
+    event_sender: Option<flume::Sender<UiEvent>>,
 ) -> Result<Config> {
     let target_exe = get_cmd_exe(CmdType::Target, args)?.into();
     let target_options = get_cmd_arg(CmdType::Target, args);
@@ -71,7 +71,7 @@ pub fn build_analysis_config(
 
 pub async fn run(
     args: &clap::ArgMatches<'_>,
-    event_sender: Option<UnboundedSender<UiEvent>>,
+    event_sender: Option<flume::Sender<UiEvent>>,
 ) -> Result<()> {
     let context = build_local_context(args, true, event_sender.clone())?;
     let config = build_analysis_config(args, None, context.common_config.clone(), event_sender)?;

--- a/src/agent/onefuzz-agent/src/local/generic_crash_report.rs
+++ b/src/agent/onefuzz-agent/src/local/generic_crash_report.rs
@@ -15,14 +15,14 @@ use crate::{
 };
 use anyhow::Result;
 use clap::{App, Arg, SubCommand};
+use flume;
 use storage_queue::QueueClient;
-use tokio::sync::mpsc::UnboundedSender;
 
 pub fn build_report_config(
     args: &clap::ArgMatches<'_>,
     input_queue: Option<QueueClient>,
     common: CommonConfig,
-    event_sender: Option<UnboundedSender<UiEvent>>,
+    event_sender: Option<flume::Sender<UiEvent>>,
 ) -> Result<Config> {
     let target_exe = get_cmd_exe(CmdType::Target, args)?.into();
     let target_env = get_cmd_env(CmdType::Target, args)?;
@@ -80,7 +80,7 @@ pub fn build_report_config(
 
 pub async fn run(
     args: &clap::ArgMatches<'_>,
-    event_sender: Option<UnboundedSender<UiEvent>>,
+    event_sender: Option<flume::Sender<UiEvent>>,
 ) -> Result<()> {
     let context = build_local_context(args, true, event_sender.clone())?;
     let config = build_report_config(args, None, context.common_config.clone(), event_sender)?;

--- a/src/agent/onefuzz-agent/src/local/generic_crash_report.rs
+++ b/src/agent/onefuzz-agent/src/local/generic_crash_report.rs
@@ -15,7 +15,6 @@ use crate::{
 };
 use anyhow::Result;
 use clap::{App, Arg, SubCommand};
-use flume;
 use storage_queue::QueueClient;
 
 pub fn build_report_config(

--- a/src/agent/onefuzz-agent/src/local/generic_crash_report.rs
+++ b/src/agent/onefuzz-agent/src/local/generic_crash_report.rs
@@ -15,13 +15,14 @@ use crate::{
 };
 use anyhow::Result;
 use clap::{App, Arg, SubCommand};
+use flume::Sender;
 use storage_queue::QueueClient;
 
 pub fn build_report_config(
     args: &clap::ArgMatches<'_>,
     input_queue: Option<QueueClient>,
     common: CommonConfig,
-    event_sender: Option<flume::Sender<UiEvent>>,
+    event_sender: Option<Sender<UiEvent>>,
 ) -> Result<Config> {
     let target_exe = get_cmd_exe(CmdType::Target, args)?.into();
     let target_env = get_cmd_env(CmdType::Target, args)?;
@@ -77,10 +78,7 @@ pub fn build_report_config(
     Ok(config)
 }
 
-pub async fn run(
-    args: &clap::ArgMatches<'_>,
-    event_sender: Option<flume::Sender<UiEvent>>,
-) -> Result<()> {
+pub async fn run(args: &clap::ArgMatches<'_>, event_sender: Option<Sender<UiEvent>>) -> Result<()> {
     let context = build_local_context(args, true, event_sender.clone())?;
     let config = build_report_config(args, None, context.common_config.clone(), event_sender)?;
     ReportTask::new(config).managed_run().await

--- a/src/agent/onefuzz-agent/src/local/generic_generator.rs
+++ b/src/agent/onefuzz-agent/src/local/generic_generator.rs
@@ -16,12 +16,12 @@ use crate::{
 };
 use anyhow::Result;
 use clap::{App, Arg, SubCommand};
-use tokio::sync::mpsc::UnboundedSender;
+use flume;
 
 pub fn build_fuzz_config(
     args: &clap::ArgMatches<'_>,
     common: CommonConfig,
-    event_sender: Option<UnboundedSender<UiEvent>>,
+    event_sender: Option<flume::Sender<UiEvent>>,
 ) -> Result<Config> {
     let crashes = get_synced_dir(CRASHES_DIR, common.job_id, common.task_id, args)?
         .monitor_count(&event_sender)?;
@@ -73,7 +73,7 @@ pub fn build_fuzz_config(
 
 pub async fn run(
     args: &clap::ArgMatches<'_>,
-    event_sender: Option<UnboundedSender<UiEvent>>,
+    event_sender: Option<flume::Sender<UiEvent>>,
 ) -> Result<()> {
     let context = build_local_context(args, true, event_sender.clone())?;
     let config = build_fuzz_config(args, context.common_config.clone(), event_sender)?;

--- a/src/agent/onefuzz-agent/src/local/generic_generator.rs
+++ b/src/agent/onefuzz-agent/src/local/generic_generator.rs
@@ -16,7 +16,6 @@ use crate::{
 };
 use anyhow::Result;
 use clap::{App, Arg, SubCommand};
-use flume;
 
 pub fn build_fuzz_config(
     args: &clap::ArgMatches<'_>,

--- a/src/agent/onefuzz-agent/src/local/generic_generator.rs
+++ b/src/agent/onefuzz-agent/src/local/generic_generator.rs
@@ -16,11 +16,12 @@ use crate::{
 };
 use anyhow::Result;
 use clap::{App, Arg, SubCommand};
+use flume::Sender;
 
 pub fn build_fuzz_config(
     args: &clap::ArgMatches<'_>,
     common: CommonConfig,
-    event_sender: Option<flume::Sender<UiEvent>>,
+    event_sender: Option<Sender<UiEvent>>,
 ) -> Result<Config> {
     let crashes = get_synced_dir(CRASHES_DIR, common.job_id, common.task_id, args)?
         .monitor_count(&event_sender)?;
@@ -70,10 +71,7 @@ pub fn build_fuzz_config(
     Ok(config)
 }
 
-pub async fn run(
-    args: &clap::ArgMatches<'_>,
-    event_sender: Option<flume::Sender<UiEvent>>,
-) -> Result<()> {
+pub async fn run(args: &clap::ArgMatches<'_>, event_sender: Option<Sender<UiEvent>>) -> Result<()> {
     let context = build_local_context(args, true, event_sender.clone())?;
     let config = build_fuzz_config(args, context.common_config.clone(), event_sender)?;
     GeneratorTask::new(config).run().await

--- a/src/agent/onefuzz-agent/src/local/libfuzzer.rs
+++ b/src/agent/onefuzz-agent/src/local/libfuzzer.rs
@@ -25,12 +25,12 @@ use anyhow::Result;
 use clap::{App, SubCommand};
 use onefuzz::utils::try_wait_all_join_handles;
 use std::collections::HashSet;
-use tokio::{sync::mpsc::UnboundedSender, task::spawn};
+use tokio::task::spawn;
 use uuid::Uuid;
 
 pub async fn run(
     args: &clap::ArgMatches<'_>,
-    event_sender: Option<UnboundedSender<UiEvent>>,
+    event_sender: Option<flume::Sender<UiEvent>>,
 ) -> Result<()> {
     let context = build_local_context(args, true, event_sender.clone())?;
     let fuzz_config = build_fuzz_config(args, context.common_config.clone(), event_sender.clone())?;

--- a/src/agent/onefuzz-agent/src/local/libfuzzer.rs
+++ b/src/agent/onefuzz-agent/src/local/libfuzzer.rs
@@ -23,15 +23,13 @@ use crate::{
 };
 use anyhow::Result;
 use clap::{App, SubCommand};
+use flume::Sender;
 use onefuzz::utils::try_wait_all_join_handles;
 use std::collections::HashSet;
 use tokio::task::spawn;
 use uuid::Uuid;
 
-pub async fn run(
-    args: &clap::ArgMatches<'_>,
-    event_sender: Option<flume::Sender<UiEvent>>,
-) -> Result<()> {
+pub async fn run(args: &clap::ArgMatches<'_>, event_sender: Option<Sender<UiEvent>>) -> Result<()> {
     let context = build_local_context(args, true, event_sender.clone())?;
     let fuzz_config = build_fuzz_config(args, context.common_config.clone(), event_sender.clone())?;
     let crash_dir = fuzz_config

--- a/src/agent/onefuzz-agent/src/local/libfuzzer_coverage.rs
+++ b/src/agent/onefuzz-agent/src/local/libfuzzer_coverage.rs
@@ -14,7 +14,6 @@ use crate::{
 };
 use anyhow::Result;
 use clap::{App, Arg, SubCommand};
-use flume;
 use storage_queue::QueueClient;
 
 use super::common::{SyncCountDirMonitor, UiEvent};

--- a/src/agent/onefuzz-agent/src/local/libfuzzer_coverage.rs
+++ b/src/agent/onefuzz-agent/src/local/libfuzzer_coverage.rs
@@ -14,6 +14,7 @@ use crate::{
 };
 use anyhow::Result;
 use clap::{App, Arg, SubCommand};
+use flume::Sender;
 use storage_queue::QueueClient;
 
 use super::common::{SyncCountDirMonitor, UiEvent};
@@ -23,7 +24,7 @@ pub fn build_coverage_config(
     local_job: bool,
     input_queue: Option<QueueClient>,
     common: CommonConfig,
-    event_sender: Option<flume::Sender<UiEvent>>,
+    event_sender: Option<Sender<UiEvent>>,
 ) -> Result<Config> {
     let target_exe = get_cmd_exe(CmdType::Target, args)?.into();
     let target_env = get_cmd_env(CmdType::Target, args)?;
@@ -60,10 +61,7 @@ pub fn build_coverage_config(
     Ok(config)
 }
 
-pub async fn run(
-    args: &clap::ArgMatches<'_>,
-    event_sender: Option<flume::Sender<UiEvent>>,
-) -> Result<()> {
+pub async fn run(args: &clap::ArgMatches<'_>, event_sender: Option<Sender<UiEvent>>) -> Result<()> {
     let context = build_local_context(args, true, event_sender.clone())?;
     let config = build_coverage_config(
         args,

--- a/src/agent/onefuzz-agent/src/local/libfuzzer_coverage.rs
+++ b/src/agent/onefuzz-agent/src/local/libfuzzer_coverage.rs
@@ -14,8 +14,8 @@ use crate::{
 };
 use anyhow::Result;
 use clap::{App, Arg, SubCommand};
+use flume;
 use storage_queue::QueueClient;
-use tokio::sync::mpsc::UnboundedSender;
 
 use super::common::{SyncCountDirMonitor, UiEvent};
 
@@ -24,7 +24,7 @@ pub fn build_coverage_config(
     local_job: bool,
     input_queue: Option<QueueClient>,
     common: CommonConfig,
-    event_sender: Option<UnboundedSender<UiEvent>>,
+    event_sender: Option<flume::Sender<UiEvent>>,
 ) -> Result<Config> {
     let target_exe = get_cmd_exe(CmdType::Target, args)?.into();
     let target_env = get_cmd_env(CmdType::Target, args)?;
@@ -63,7 +63,7 @@ pub fn build_coverage_config(
 
 pub async fn run(
     args: &clap::ArgMatches<'_>,
-    event_sender: Option<UnboundedSender<UiEvent>>,
+    event_sender: Option<flume::Sender<UiEvent>>,
 ) -> Result<()> {
     let context = build_local_context(args, true, event_sender.clone())?;
     let config = build_coverage_config(

--- a/src/agent/onefuzz-agent/src/local/libfuzzer_crash_report.rs
+++ b/src/agent/onefuzz-agent/src/local/libfuzzer_crash_report.rs
@@ -15,13 +15,14 @@ use crate::{
 };
 use anyhow::Result;
 use clap::{App, Arg, SubCommand};
+use flume::Sender;
 use storage_queue::QueueClient;
 
 pub fn build_report_config(
     args: &clap::ArgMatches<'_>,
     input_queue: Option<QueueClient>,
     common: CommonConfig,
-    event_sender: Option<flume::Sender<UiEvent>>,
+    event_sender: Option<Sender<UiEvent>>,
 ) -> Result<Config> {
     let target_exe = get_cmd_exe(CmdType::Target, args)?.into();
     let target_env = get_cmd_env(CmdType::Target, args)?;
@@ -72,10 +73,7 @@ pub fn build_report_config(
     Ok(config)
 }
 
-pub async fn run(
-    args: &clap::ArgMatches<'_>,
-    event_sender: Option<flume::Sender<UiEvent>>,
-) -> Result<()> {
+pub async fn run(args: &clap::ArgMatches<'_>, event_sender: Option<Sender<UiEvent>>) -> Result<()> {
     let context = build_local_context(args, true, event_sender.clone())?;
     let config = build_report_config(args, None, context.common_config.clone(), event_sender)?;
     ReportTask::new(config).managed_run().await

--- a/src/agent/onefuzz-agent/src/local/libfuzzer_crash_report.rs
+++ b/src/agent/onefuzz-agent/src/local/libfuzzer_crash_report.rs
@@ -15,7 +15,6 @@ use crate::{
 };
 use anyhow::Result;
 use clap::{App, Arg, SubCommand};
-use flume;
 use storage_queue::QueueClient;
 
 pub fn build_report_config(

--- a/src/agent/onefuzz-agent/src/local/libfuzzer_crash_report.rs
+++ b/src/agent/onefuzz-agent/src/local/libfuzzer_crash_report.rs
@@ -15,14 +15,14 @@ use crate::{
 };
 use anyhow::Result;
 use clap::{App, Arg, SubCommand};
+use flume;
 use storage_queue::QueueClient;
-use tokio::sync::mpsc::UnboundedSender;
 
 pub fn build_report_config(
     args: &clap::ArgMatches<'_>,
     input_queue: Option<QueueClient>,
     common: CommonConfig,
-    event_sender: Option<UnboundedSender<UiEvent>>,
+    event_sender: Option<flume::Sender<UiEvent>>,
 ) -> Result<Config> {
     let target_exe = get_cmd_exe(CmdType::Target, args)?.into();
     let target_env = get_cmd_env(CmdType::Target, args)?;
@@ -75,7 +75,7 @@ pub fn build_report_config(
 
 pub async fn run(
     args: &clap::ArgMatches<'_>,
-    event_sender: Option<UnboundedSender<UiEvent>>,
+    event_sender: Option<flume::Sender<UiEvent>>,
 ) -> Result<()> {
     let context = build_local_context(args, true, event_sender.clone())?;
     let config = build_report_config(args, None, context.common_config.clone(), event_sender)?;

--- a/src/agent/onefuzz-agent/src/local/libfuzzer_fuzz.rs
+++ b/src/agent/onefuzz-agent/src/local/libfuzzer_fuzz.rs
@@ -14,13 +14,14 @@ use crate::{
 };
 use anyhow::Result;
 use clap::{App, Arg, SubCommand};
+use flume::Sender;
 
 const EXPECT_CRASH_ON_FAILURE: &str = "expect_crash_on_failure";
 
 pub fn build_fuzz_config(
     args: &clap::ArgMatches<'_>,
     common: CommonConfig,
-    event_sender: Option<flume::Sender<UiEvent>>,
+    event_sender: Option<Sender<UiEvent>>,
 ) -> Result<Config> {
     let crashes = get_synced_dir(CRASHES_DIR, common.job_id, common.task_id, args)?
         .monitor_count(&event_sender)?;
@@ -55,10 +56,7 @@ pub fn build_fuzz_config(
     Ok(config)
 }
 
-pub async fn run(
-    args: &clap::ArgMatches<'_>,
-    event_sender: Option<flume::Sender<UiEvent>>,
-) -> Result<()> {
+pub async fn run(args: &clap::ArgMatches<'_>, event_sender: Option<Sender<UiEvent>>) -> Result<()> {
     let context = build_local_context(args, true, event_sender.clone())?;
     let config = build_fuzz_config(args, context.common_config.clone(), event_sender)?;
     LibFuzzerFuzzTask::new(config)?.run().await

--- a/src/agent/onefuzz-agent/src/local/libfuzzer_fuzz.rs
+++ b/src/agent/onefuzz-agent/src/local/libfuzzer_fuzz.rs
@@ -14,14 +14,14 @@ use crate::{
 };
 use anyhow::Result;
 use clap::{App, Arg, SubCommand};
-use tokio::sync::mpsc::UnboundedSender;
+use flume;
 
 const EXPECT_CRASH_ON_FAILURE: &str = "expect_crash_on_failure";
 
 pub fn build_fuzz_config(
     args: &clap::ArgMatches<'_>,
     common: CommonConfig,
-    event_sender: Option<UnboundedSender<UiEvent>>,
+    event_sender: Option<flume::Sender<UiEvent>>,
 ) -> Result<Config> {
     let crashes = get_synced_dir(CRASHES_DIR, common.job_id, common.task_id, args)?
         .monitor_count(&event_sender)?;
@@ -58,7 +58,7 @@ pub fn build_fuzz_config(
 
 pub async fn run(
     args: &clap::ArgMatches<'_>,
-    event_sender: Option<UnboundedSender<UiEvent>>,
+    event_sender: Option<flume::Sender<UiEvent>>,
 ) -> Result<()> {
     let context = build_local_context(args, true, event_sender.clone())?;
     let config = build_fuzz_config(args, context.common_config.clone(), event_sender)?;

--- a/src/agent/onefuzz-agent/src/local/libfuzzer_fuzz.rs
+++ b/src/agent/onefuzz-agent/src/local/libfuzzer_fuzz.rs
@@ -14,7 +14,6 @@ use crate::{
 };
 use anyhow::Result;
 use clap::{App, Arg, SubCommand};
-use flume;
 
 const EXPECT_CRASH_ON_FAILURE: &str = "expect_crash_on_failure";
 

--- a/src/agent/onefuzz-agent/src/local/libfuzzer_merge.rs
+++ b/src/agent/onefuzz-agent/src/local/libfuzzer_merge.rs
@@ -15,13 +15,14 @@ use crate::{
 };
 use anyhow::Result;
 use clap::{App, Arg, SubCommand};
+use flume::Sender;
 use storage_queue::QueueClient;
 
 pub fn build_merge_config(
     args: &clap::ArgMatches<'_>,
     input_queue: Option<QueueClient>,
     common: CommonConfig,
-    event_sender: Option<flume::Sender<UiEvent>>,
+    event_sender: Option<Sender<UiEvent>>,
 ) -> Result<Config> {
     let target_exe = get_cmd_exe(CmdType::Target, args)?.into();
     let target_env = get_cmd_env(CmdType::Target, args)?;
@@ -51,10 +52,7 @@ pub fn build_merge_config(
     Ok(config)
 }
 
-pub async fn run(
-    args: &clap::ArgMatches<'_>,
-    event_sender: Option<flume::Sender<UiEvent>>,
-) -> Result<()> {
+pub async fn run(args: &clap::ArgMatches<'_>, event_sender: Option<Sender<UiEvent>>) -> Result<()> {
     let context = build_local_context(args, true, event_sender.clone())?;
     let config = build_merge_config(args, None, context.common_config.clone(), event_sender)?;
     spawn(std::sync::Arc::new(config)).await

--- a/src/agent/onefuzz-agent/src/local/libfuzzer_merge.rs
+++ b/src/agent/onefuzz-agent/src/local/libfuzzer_merge.rs
@@ -15,14 +15,14 @@ use crate::{
 };
 use anyhow::Result;
 use clap::{App, Arg, SubCommand};
+use flume;
 use storage_queue::QueueClient;
-use tokio::sync::mpsc::UnboundedSender;
 
 pub fn build_merge_config(
     args: &clap::ArgMatches<'_>,
     input_queue: Option<QueueClient>,
     common: CommonConfig,
-    event_sender: Option<UnboundedSender<UiEvent>>,
+    event_sender: Option<flume::Sender<UiEvent>>,
 ) -> Result<Config> {
     let target_exe = get_cmd_exe(CmdType::Target, args)?.into();
     let target_env = get_cmd_env(CmdType::Target, args)?;
@@ -54,7 +54,7 @@ pub fn build_merge_config(
 
 pub async fn run(
     args: &clap::ArgMatches<'_>,
-    event_sender: Option<UnboundedSender<UiEvent>>,
+    event_sender: Option<flume::Sender<UiEvent>>,
 ) -> Result<()> {
     let context = build_local_context(args, true, event_sender.clone())?;
     let config = build_merge_config(args, None, context.common_config.clone(), event_sender)?;

--- a/src/agent/onefuzz-agent/src/local/libfuzzer_merge.rs
+++ b/src/agent/onefuzz-agent/src/local/libfuzzer_merge.rs
@@ -15,7 +15,6 @@ use crate::{
 };
 use anyhow::Result;
 use clap::{App, Arg, SubCommand};
-use flume;
 use storage_queue::QueueClient;
 
 pub fn build_merge_config(

--- a/src/agent/onefuzz-agent/src/local/libfuzzer_regression.rs
+++ b/src/agent/onefuzz-agent/src/local/libfuzzer_regression.rs
@@ -15,14 +15,14 @@ use crate::{
 };
 use anyhow::Result;
 use clap::{App, Arg, SubCommand};
-use tokio::sync::mpsc::UnboundedSender;
+use flume;
 
 const REPORT_NAMES: &str = "report_names";
 
 pub fn build_regression_config(
     args: &clap::ArgMatches<'_>,
     common: CommonConfig,
-    event_sender: Option<UnboundedSender<UiEvent>>,
+    event_sender: Option<flume::Sender<UiEvent>>,
 ) -> Result<Config> {
     let target_exe = get_cmd_exe(CmdType::Target, args)?.into();
     let target_env = get_cmd_env(CmdType::Target, args)?;
@@ -75,7 +75,7 @@ pub fn build_regression_config(
 
 pub async fn run(
     args: &clap::ArgMatches<'_>,
-    event_sender: Option<UnboundedSender<UiEvent>>,
+    event_sender: Option<flume::Sender<UiEvent>>,
 ) -> Result<()> {
     let context = build_local_context(args, true, event_sender.clone())?;
     let config = build_regression_config(args, context.common_config.clone(), event_sender)?;

--- a/src/agent/onefuzz-agent/src/local/libfuzzer_regression.rs
+++ b/src/agent/onefuzz-agent/src/local/libfuzzer_regression.rs
@@ -15,13 +15,14 @@ use crate::{
 };
 use anyhow::Result;
 use clap::{App, Arg, SubCommand};
+use flume::Sender;
 
 const REPORT_NAMES: &str = "report_names";
 
 pub fn build_regression_config(
     args: &clap::ArgMatches<'_>,
     common: CommonConfig,
-    event_sender: Option<flume::Sender<UiEvent>>,
+    event_sender: Option<Sender<UiEvent>>,
 ) -> Result<Config> {
     let target_exe = get_cmd_exe(CmdType::Target, args)?.into();
     let target_env = get_cmd_env(CmdType::Target, args)?;
@@ -72,10 +73,7 @@ pub fn build_regression_config(
     Ok(config)
 }
 
-pub async fn run(
-    args: &clap::ArgMatches<'_>,
-    event_sender: Option<flume::Sender<UiEvent>>,
-) -> Result<()> {
+pub async fn run(args: &clap::ArgMatches<'_>, event_sender: Option<Sender<UiEvent>>) -> Result<()> {
     let context = build_local_context(args, true, event_sender.clone())?;
     let config = build_regression_config(args, context.common_config.clone(), event_sender)?;
     LibFuzzerRegressionTask::new(config).run().await

--- a/src/agent/onefuzz-agent/src/local/libfuzzer_regression.rs
+++ b/src/agent/onefuzz-agent/src/local/libfuzzer_regression.rs
@@ -15,7 +15,6 @@ use crate::{
 };
 use anyhow::Result;
 use clap::{App, Arg, SubCommand};
-use flume;
 
 const REPORT_NAMES: &str = "report_names";
 

--- a/src/agent/onefuzz-agent/src/local/libfuzzer_test_input.rs
+++ b/src/agent/onefuzz-agent/src/local/libfuzzer_test_input.rs
@@ -10,12 +10,12 @@ use crate::{
 };
 use anyhow::Result;
 use clap::{App, Arg, SubCommand};
+use flume;
 use std::path::PathBuf;
-use tokio::sync::mpsc::UnboundedSender;
 
 pub async fn run(
     args: &clap::ArgMatches<'_>,
-    event_sender: Option<UnboundedSender<UiEvent>>,
+    event_sender: Option<flume::Sender<UiEvent>>,
 ) -> Result<()> {
     let context = build_local_context(args, true, event_sender)?;
 

--- a/src/agent/onefuzz-agent/src/local/libfuzzer_test_input.rs
+++ b/src/agent/onefuzz-agent/src/local/libfuzzer_test_input.rs
@@ -10,7 +10,6 @@ use crate::{
 };
 use anyhow::Result;
 use clap::{App, Arg, SubCommand};
-use flume;
 use std::path::PathBuf;
 
 pub async fn run(

--- a/src/agent/onefuzz-agent/src/local/libfuzzer_test_input.rs
+++ b/src/agent/onefuzz-agent/src/local/libfuzzer_test_input.rs
@@ -10,12 +10,10 @@ use crate::{
 };
 use anyhow::Result;
 use clap::{App, Arg, SubCommand};
+use flume::Sender;
 use std::path::PathBuf;
 
-pub async fn run(
-    args: &clap::ArgMatches<'_>,
-    event_sender: Option<flume::Sender<UiEvent>>,
-) -> Result<()> {
+pub async fn run(args: &clap::ArgMatches<'_>, event_sender: Option<Sender<UiEvent>>) -> Result<()> {
     let context = build_local_context(args, true, event_sender)?;
 
     let target_exe = value_t!(args, TARGET_EXE, PathBuf)?;

--- a/src/agent/onefuzz-agent/src/local/radamsa.rs
+++ b/src/agent/onefuzz-agent/src/local/radamsa.rs
@@ -11,7 +11,6 @@ use crate::{
 };
 use anyhow::Result;
 use clap::{App, SubCommand};
-use flume;
 use onefuzz::utils::try_wait_all_join_handles;
 use std::collections::HashSet;
 use tokio::task::spawn;

--- a/src/agent/onefuzz-agent/src/local/radamsa.rs
+++ b/src/agent/onefuzz-agent/src/local/radamsa.rs
@@ -11,15 +11,13 @@ use crate::{
 };
 use anyhow::Result;
 use clap::{App, SubCommand};
+use flume::Sender;
 use onefuzz::utils::try_wait_all_join_handles;
 use std::collections::HashSet;
 use tokio::task::spawn;
 use uuid::Uuid;
 
-pub async fn run(
-    args: &clap::ArgMatches<'_>,
-    event_sender: Option<flume::Sender<UiEvent>>,
-) -> Result<()> {
+pub async fn run(args: &clap::ArgMatches<'_>, event_sender: Option<Sender<UiEvent>>) -> Result<()> {
     let context = build_local_context(args, true, event_sender.clone())?;
     let fuzz_config = build_fuzz_config(args, context.common_config.clone(), event_sender.clone())?;
     let crash_dir = fuzz_config

--- a/src/agent/onefuzz-agent/src/local/radamsa.rs
+++ b/src/agent/onefuzz-agent/src/local/radamsa.rs
@@ -11,15 +11,15 @@ use crate::{
 };
 use anyhow::Result;
 use clap::{App, SubCommand};
+use flume;
 use onefuzz::utils::try_wait_all_join_handles;
 use std::collections::HashSet;
-use tokio::sync::mpsc::UnboundedSender;
 use tokio::task::spawn;
 use uuid::Uuid;
 
 pub async fn run(
     args: &clap::ArgMatches<'_>,
-    event_sender: Option<UnboundedSender<UiEvent>>,
+    event_sender: Option<flume::Sender<UiEvent>>,
 ) -> Result<()> {
     let context = build_local_context(args, true, event_sender.clone())?;
     let fuzz_config = build_fuzz_config(args, context.common_config.clone(), event_sender.clone())?;

--- a/src/agent/onefuzz-agent/src/local/test_input.rs
+++ b/src/agent/onefuzz-agent/src/local/test_input.rs
@@ -11,7 +11,6 @@ use crate::{
 };
 use anyhow::Result;
 use clap::{App, Arg, SubCommand};
-use flume;
 use std::path::PathBuf;
 
 pub async fn run(

--- a/src/agent/onefuzz-agent/src/local/test_input.rs
+++ b/src/agent/onefuzz-agent/src/local/test_input.rs
@@ -11,12 +11,12 @@ use crate::{
 };
 use anyhow::Result;
 use clap::{App, Arg, SubCommand};
+use flume;
 use std::path::PathBuf;
-use tokio::sync::mpsc::UnboundedSender;
 
 pub async fn run(
     args: &clap::ArgMatches<'_>,
-    event_sender: Option<UnboundedSender<UiEvent>>,
+    event_sender: Option<flume::Sender<UiEvent>>,
 ) -> Result<()> {
     let context = build_local_context(args, false, event_sender)?;
 

--- a/src/agent/onefuzz-agent/src/local/test_input.rs
+++ b/src/agent/onefuzz-agent/src/local/test_input.rs
@@ -11,12 +11,10 @@ use crate::{
 };
 use anyhow::Result;
 use clap::{App, Arg, SubCommand};
+use flume::Sender;
 use std::path::PathBuf;
 
-pub async fn run(
-    args: &clap::ArgMatches<'_>,
-    event_sender: Option<flume::Sender<UiEvent>>,
-) -> Result<()> {
+pub async fn run(args: &clap::ArgMatches<'_>, event_sender: Option<Sender<UiEvent>>) -> Result<()> {
     let context = build_local_context(args, false, event_sender)?;
 
     let target_exe = value_t!(args, TARGET_EXE, PathBuf)?;

--- a/src/agent/onefuzz-agent/src/local/tui.rs
+++ b/src/agent/onefuzz-agent/src/local/tui.rs
@@ -22,7 +22,6 @@ use std::{
     time::Duration,
 };
 
-use flume;
 use tokio::{
     sync::broadcast::{self, error::TryRecvError},
     time::sleep,

--- a/src/agent/onefuzz-agent/src/local/tui.rs
+++ b/src/agent/onefuzz-agent/src/local/tui.rs
@@ -21,12 +21,11 @@ use std::{
     thread::{self, JoinHandle},
     time::Duration,
 };
+
+use flume;
 use tokio::{
-    sync::{
-        broadcast::{self, TryRecvError},
-        mpsc::{self, UnboundedSender},
-    },
-    time::delay_for,
+    sync::broadcast::{self, error::TryRecvError},
+    time::sleep,
 };
 use tui::{
     backend::CrosstermBackend,
@@ -91,7 +90,7 @@ struct UiLoopState {
     pub file_count: HashMap<PathBuf, usize>,
     pub file_count_state: ListState,
     pub file_monitors: HashMap<PathBuf, tokio::task::JoinHandle<Result<()>>>,
-    pub log_event_receiver: mpsc::UnboundedReceiver<(Level, String)>,
+    pub log_event_receiver: flume::Receiver<(Level, String)>,
     pub terminal: Terminal<CrosstermBackend<Stdout>>,
     pub cancellation_tx: broadcast::Sender<()>,
     pub events: HashMap<Discriminant<EventData>, EventData>,
@@ -100,7 +99,7 @@ struct UiLoopState {
 impl UiLoopState {
     fn new(
         terminal: Terminal<CrosstermBackend<Stdout>>,
-        log_event_receiver: mpsc::UnboundedReceiver<(Level, String)>,
+        log_event_receiver: flume::Receiver<(Level, String)>,
     ) -> Self {
         let (cancellation_tx, _) = broadcast::channel(1);
         let events = HashMap::new();
@@ -118,16 +117,16 @@ impl UiLoopState {
 }
 
 pub struct TerminalUi {
-    pub task_events: mpsc::UnboundedSender<UiEvent>,
-    task_event_receiver: mpsc::UnboundedReceiver<UiEvent>,
-    ui_event_tx: mpsc::UnboundedSender<TerminalEvent>,
-    ui_event_rx: mpsc::UnboundedReceiver<TerminalEvent>,
+    pub task_events: flume::Sender<UiEvent>,
+    task_event_receiver: flume::Receiver<UiEvent>,
+    ui_event_tx: flume::Sender<TerminalEvent>,
+    ui_event_rx: flume::Receiver<TerminalEvent>,
 }
 
 impl TerminalUi {
     pub fn init() -> Result<Self> {
-        let (task_event_sender, task_event_receiver) = mpsc::unbounded_channel();
-        let (ui_event_tx, ui_event_rx) = mpsc::unbounded_channel();
+        let (task_event_sender, task_event_receiver) = flume::unbounded();
+        let (ui_event_tx, ui_event_rx) = flume::unbounded();
         Ok(Self {
             task_events: task_event_sender,
             task_event_receiver,
@@ -144,7 +143,7 @@ impl TerminalUi {
         let backend = CrosstermBackend::new(stdout);
         let mut terminal = Terminal::new(backend)?;
         terminal.clear()?;
-        let (log_event_sender, log_event_receiver) = mpsc::unbounded_channel();
+        let (log_event_sender, log_event_receiver) = flume::unbounded();
         let initial_state = UiLoopState::new(terminal, log_event_receiver);
 
         env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
@@ -196,7 +195,7 @@ impl TerminalUi {
         if let Some(timeout) = timeout {
             let ui_event_tx = self.ui_event_tx.clone();
             tokio::spawn(async move {
-                tokio::time::delay_for(timeout).await;
+                tokio::time::sleep(timeout).await;
                 let _ = ui_event_tx.send(TerminalEvent::Quit);
             });
         }
@@ -226,12 +225,12 @@ impl TerminalUi {
     }
 
     async fn listen_telemetry_event(
-        ui_event_tx: UnboundedSender<TerminalEvent>,
+        ui_event_tx: flume::Sender<TerminalEvent>,
         mut cancellation_rx: broadcast::Receiver<()>,
     ) -> Result<()> {
         let mut rx = onefuzz_telemetry::subscribe_to_events();
 
-        while cancellation_rx.try_recv() == Err(broadcast::TryRecvError::Empty) {
+        while cancellation_rx.try_recv() == Err(broadcast::error::TryRecvError::Empty) {
             match rx.try_recv() {
                 Ok((_event, data)) => {
                     let data = data
@@ -240,7 +239,7 @@ impl TerminalUi {
                         .collect::<Vec<_>>();
                     let _ = ui_event_tx.send(TerminalEvent::Telemetry(data));
                 }
-                Err(TryRecvError::Empty) => delay_for(EVENT_POLLING_PERIOD).await,
+                Err(TryRecvError::Empty) => sleep(EVENT_POLLING_PERIOD).await,
                 Err(TryRecvError::Lagged(_)) => continue,
                 Err(TryRecvError::Closed) => break,
             }
@@ -249,11 +248,11 @@ impl TerminalUi {
     }
 
     async fn ticking(
-        ui_event_tx: mpsc::UnboundedSender<TerminalEvent>,
+        ui_event_tx: flume::Sender<TerminalEvent>,
         mut cancellation_rx: broadcast::Receiver<()>,
     ) -> Result<()> {
         let mut interval = tokio::time::interval(TICK_RATE);
-        while Err(broadcast::TryRecvError::Empty) == cancellation_rx.try_recv() {
+        while Err(broadcast::error::TryRecvError::Empty) == cancellation_rx.try_recv() {
             interval.tick().await;
             if let Err(_err) = ui_event_tx.send(TerminalEvent::Tick) {
                 break;
@@ -263,11 +262,11 @@ impl TerminalUi {
     }
 
     fn read_keyboard_events(
-        ui_event_tx: mpsc::UnboundedSender<TerminalEvent>,
+        ui_event_tx: flume::Sender<TerminalEvent>,
         mut cancellation_rx: broadcast::Receiver<()>,
     ) -> JoinHandle<Result<()>> {
         thread::spawn(move || {
-            while Err(broadcast::TryRecvError::Empty) == cancellation_rx.try_recv() {
+            while Err(broadcast::error::TryRecvError::Empty) == cancellation_rx.try_recv() {
                 if event::poll(EVENT_POLLING_PERIOD)? {
                     let event = event::read()?;
                     if let Err(_err) = ui_event_tx.send(TerminalEvent::Input(event)) {
@@ -280,26 +279,26 @@ impl TerminalUi {
     }
 
     async fn read_commands(
-        ui_event_tx: mpsc::UnboundedSender<TerminalEvent>,
-        mut external_event_rx: mpsc::UnboundedReceiver<UiEvent>,
+        ui_event_tx: flume::Sender<TerminalEvent>,
+        external_event_rx: flume::Receiver<UiEvent>,
         mut cancellation_rx: broadcast::Receiver<()>,
     ) -> Result<()> {
-        while Err(broadcast::TryRecvError::Empty) == cancellation_rx.try_recv() {
+        while Err(broadcast::error::TryRecvError::Empty) == cancellation_rx.try_recv() {
             match external_event_rx.try_recv() {
                 Ok(UiEvent::MonitorDir(dir)) => {
                     if ui_event_tx.send(TerminalEvent::MonitorDir(dir)).is_err() {
                         break;
                     }
                 }
-                Err(mpsc::error::TryRecvError::Empty) => delay_for(EVENT_POLLING_PERIOD).await,
-                Err(mpsc::error::TryRecvError::Closed) => break,
+                Err(flume::TryRecvError::Empty) => sleep(EVENT_POLLING_PERIOD).await,
+                Err(flume::TryRecvError::Disconnected) => break,
             }
         }
         Ok(())
     }
 
     fn take_available_logs<T>(
-        receiver: &mut mpsc::UnboundedReceiver<T>,
+        receiver: &mut flume::Receiver<T>,
         size: usize,
         buffer: &mut ArrayDeque<[T; LOGS_BUFFER_SIZE], Wrapping>,
     ) {
@@ -565,7 +564,7 @@ impl TerminalUi {
     async fn on_monitor_dir(
         ui_state: UiLoopState,
         path: PathBuf,
-        ui_event_tx: mpsc::UnboundedSender<TerminalEvent>,
+        ui_event_tx: flume::Sender<TerminalEvent>,
         cancellation_rx: broadcast::Receiver<()>,
     ) -> Result<UiLoopState, UiLoopError> {
         let mut file_monitors = ui_state.file_monitors;
@@ -582,10 +581,11 @@ impl TerminalUi {
 
     async fn ui_loop(
         initial_state: UiLoopState,
-        ui_event_rx: mpsc::UnboundedReceiver<TerminalEvent>,
-        ui_event_tx: mpsc::UnboundedSender<TerminalEvent>,
+        ui_event_rx: flume::Receiver<TerminalEvent>,
+        ui_event_tx: flume::Sender<TerminalEvent>,
     ) -> Result<()> {
         let loop_result = ui_event_rx
+            .stream()
             .map(Ok)
             .try_fold(initial_state, |ui_state, event| async {
                 let ui_event_tx = ui_event_tx.clone();
@@ -632,16 +632,16 @@ impl TerminalUi {
 
     fn spawn_file_count_monitor(
         dir: PathBuf,
-        sender: mpsc::UnboundedSender<TerminalEvent>,
+        sender: flume::Sender<TerminalEvent>,
         mut cancellation_rx: broadcast::Receiver<()>,
     ) -> tokio::task::JoinHandle<Result<()>> {
         tokio::spawn(async move {
             wait_for_dir(&dir).await?;
-            while cancellation_rx.try_recv() == Err(broadcast::TryRecvError::Empty) {
+            while cancellation_rx.try_recv() == Err(broadcast::error::TryRecvError::Empty) {
                 let mut rd = tokio::fs::read_dir(&dir).await?;
                 let mut count: usize = 0;
 
-                while let Some(Ok(entry)) = rd.next().await {
+                while let Ok(Some(entry)) = rd.next_entry().await {
                     if entry.path().is_file() {
                         count += 1;
                     }
@@ -657,7 +657,7 @@ impl TerminalUi {
                     break;
                 }
 
-                delay_for(FILE_MONITOR_POLLING_PERIOD).await;
+                sleep(FILE_MONITOR_POLLING_PERIOD).await;
             }
             Ok(())
         })

--- a/src/agent/onefuzz-agent/src/main.rs
+++ b/src/agent/onefuzz-agent/src/main.rs
@@ -37,7 +37,7 @@ fn main() -> Result<()> {
 
     let matches = app.get_matches();
 
-    let mut rt = tokio::runtime::Runtime::new()?;
+    let rt = tokio::runtime::Runtime::new()?;
     let result = rt.block_on(run(matches));
     atexit::execute();
     result

--- a/src/agent/onefuzz-agent/src/tasks/analysis/generic.rs
+++ b/src/agent/onefuzz-agent/src/tasks/analysis/generic.rs
@@ -5,7 +5,6 @@ use crate::tasks::{
     config::CommonConfig, heartbeat::HeartbeatSender, report::crash_report::monitor_reports,
 };
 use anyhow::{Context, Result};
-use futures::stream::StreamExt;
 use onefuzz::{az_copy, blob::url::BlobUrl};
 use onefuzz::{
     expand::Expand,
@@ -116,9 +115,8 @@ async fn run_existing(config: &Config, reports_dir: &Option<PathBuf>) -> Result<
         crashes.init_pull().await?;
         let mut count: u64 = 0;
         let mut read_dir = fs::read_dir(&crashes.path).await?;
-        while let Some(file) = read_dir.next().await {
+        while let Some(file) = read_dir.next_entry().await? {
             debug!("Processing file {:?}", file);
-            let file = file?;
             run_tool(file.path(), &config, &reports_dir).await?;
             count += 1;
         }

--- a/src/agent/onefuzz-agent/src/tasks/coverage/libfuzzer_coverage.rs
+++ b/src/agent/onefuzz-agent/src/tasks/coverage/libfuzzer_coverage.rs
@@ -38,7 +38,6 @@ use crate::tasks::{
 };
 use anyhow::{Context, Result};
 use async_trait::async_trait;
-use futures::stream::StreamExt;
 use onefuzz::{fs::list_files, libfuzzer::LibFuzzer, syncdir::SyncedDir};
 use onefuzz_telemetry::{Event::coverage_data, EventData};
 use reqwest::Url;
@@ -159,9 +158,10 @@ impl CoverageTask {
         })?;
         let mut seen_inputs = false;
 
-        while let Some(input) = corpus.next().await {
-            let input = match input {
-                Ok(input) => input,
+        loop {
+            let input = match corpus.next_entry().await {
+                Ok(Some(input)) => input,
+                Ok(None) => break,
                 Err(err) => {
                     error!("{}", err);
                     continue;

--- a/src/agent/onefuzz-agent/src/tasks/fuzz/generator.rs
+++ b/src/agent/onefuzz-agent/src/tasks/fuzz/generator.rs
@@ -7,7 +7,6 @@ use crate::tasks::{
     utils::{self, default_bool_true},
 };
 use anyhow::{Context, Result};
-use futures::stream::StreamExt;
 use onefuzz::{
     expand::Expand,
     fs::set_executable,
@@ -122,9 +121,7 @@ impl GeneratorTask {
         tester: &Tester<'_>,
     ) -> Result<()> {
         let mut read_dir = fs::read_dir(generated_inputs).await?;
-        while let Some(file) = read_dir.next().await {
-            let file = file?;
-
+        while let Some(file) = read_dir.next_entry().await? {
             debug!("testing input: {:?}", file);
 
             let destination_file = if self.config.rename_output {

--- a/src/agent/onefuzz-agent/src/tasks/fuzz/supervisor.rs
+++ b/src/agent/onefuzz-agent/src/tasks/fuzz/supervisor.rs
@@ -357,7 +357,7 @@ mod tests {
                     MAX_FUZZ_TIME_SECONDS
                 );
             }
-            tokio::time::delay_for(std::time::Duration::from_secs(1)).await;
+            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
         }
     }
 }

--- a/src/agent/onefuzz-agent/src/tasks/generic/input_poller.rs
+++ b/src/agent/onefuzz-agent/src/tasks/generic/input_poller.rs
@@ -4,7 +4,6 @@
 use std::{fmt, path::PathBuf};
 
 use anyhow::Result;
-use futures::stream::StreamExt;
 use onefuzz::{blob::BlobUrl, jitter::delay_with_jitter, syncdir::SyncedDir};
 use reqwest::Url;
 use tempfile::{tempdir, TempDir};
@@ -133,8 +132,8 @@ impl<M> InputPoller<M> {
         );
 
         let mut read_dir = fs::read_dir(&to_process.path).await?;
-        while let Some(file) = read_dir.next().await {
-            let path = file?.path();
+        while let Some(file) = read_dir.next_entry().await? {
+            let path = file.path();
             info!(
                 "processing batch-downloaded input: {} - {}",
                 self.name,

--- a/src/agent/onefuzz-supervisor/Cargo.toml
+++ b/src/agent/onefuzz-supervisor/Cargo.toml
@@ -12,15 +12,15 @@ appinsights = "0.1"
 async-trait = "0.1"
 downcast-rs = "1.2"
 env_logger = "0.8"
-futures = "0.3"
+futures = "0.3.14"
 log = "0.4"
 onefuzz = { path = "../onefuzz" }
-reqwest = { version = "0.10", features = ["json", "stream"] }
+reqwest = { version = "0.11.3", features = ["json", "stream"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 storage-queue = { path = "../storage-queue" }
 structopt = "0.3"
-tokio = { version = "0.2", features = ["full"] }
+tokio = { version = "1.5.0", features = ["full"] }
 url = { version = "2.2", features = ["serde"] }
 uuid = { version = "0.8", features = ["serde", "v4"] }
 clap = "2.33"

--- a/src/agent/onefuzz-supervisor/src/agent.rs
+++ b/src/agent/onefuzz-supervisor/src/agent.rs
@@ -277,7 +277,7 @@ impl Agent {
 
     async fn sleep(&mut self) {
         let delay = time::Duration::from_secs(30);
-        time::delay_for(delay).await;
+        time::sleep(delay).await;
     }
 
     fn scheduler(&mut self) -> Result<&mut Scheduler> {
@@ -285,9 +285,9 @@ impl Agent {
     }
 }
 
-fn command_delay() -> time::Delay {
+fn command_delay() -> time::Sleep {
     let delay = time::Duration::from_secs(10);
-    time::delay_for(delay)
+    time::sleep(delay)
 }
 
 // The agent owns a `Scheduler`, which it must consume when driving its state

--- a/src/agent/onefuzz-supervisor/src/debug.rs
+++ b/src/agent/onefuzz-supervisor/src/debug.rs
@@ -163,7 +163,7 @@ fn debug_run_worker(opt: RunWorkerOpt) -> Result<()> {
         work_units: vec![work_unit],
     };
 
-    let mut rt = tokio::runtime::Runtime::new()?;
+    let rt = tokio::runtime::Runtime::new()?;
     let events = rt.block_on(run_worker(work_set))?;
 
     for event in events {

--- a/src/agent/onefuzz-supervisor/src/main.rs
+++ b/src/agent/onefuzz-supervisor/src/main.rs
@@ -104,7 +104,7 @@ fn run(opt: RunOpt) -> Result<()> {
 
     let config = config?;
 
-    let mut rt = tokio::runtime::Runtime::new()?;
+    let rt = tokio::runtime::Runtime::new()?;
     let result = rt.block_on(run_agent(config));
 
     if let Err(err) = &result {

--- a/src/agent/onefuzz-supervisor/src/setup.rs
+++ b/src/agent/onefuzz-supervisor/src/setup.rs
@@ -132,7 +132,7 @@ async fn create_setup_symlink(setup_dir: &Path, work_unit: &WorkUnit) -> Result<
 
 #[cfg(target_os = "linux")]
 async fn create_setup_symlink(setup_dir: &Path, work_unit: &WorkUnit) -> Result<()> {
-    use tokio::fs::os::unix::symlink;
+    use tokio::fs::symlink;
 
     let working_dir = work_unit.working_dir()?;
 

--- a/src/agent/onefuzz-telemetry/Cargo.toml
+++ b/src/agent/onefuzz-telemetry/Cargo.toml
@@ -17,7 +17,7 @@ uuid = { version = "0.8", features = ["serde", "v4"] }
 serde = { version = "1.0", features = ["derive"] }
 z3-sys = { version = "0.6", optional = true}
 iced-x86 = { version = "1.1", optional = true}
-tokio = { version = "0.2" }
+tokio = { version = "1.5.0", features = ["full"] }
 lazy_static = "1.4"
 
 

--- a/src/agent/onefuzz/Cargo.toml
+++ b/src/agent/onefuzz/Cargo.toml
@@ -11,15 +11,16 @@ anyhow = "1.0"
 appinsights = "0.1"
 async-trait = "0.1"
 base64 = "0.13"
-bytes = "0.5"
+bytes = "1.0.1"
 dunce = "1.0"
-futures = "0.3"
+futures = "0.3.14"
+futures-util = "0.3.14"
 hex = "0.4"
 lazy_static = "1.4"
 log = "0.4"
 notify = "4.0"
 regex = "1.4"
-reqwest = { version = "0.10", features = ["json", "stream"] }
+reqwest = { version = "0.11.3", features = ["json", "stream"] }
 sha2 = "0.9"
 url = { version = "2.2", features = ["serde"] }
 serde = "1.0"
@@ -27,8 +28,9 @@ serde_json = "1.0"
 rand = "0.7"
 serde_derive = "1.0"
 sysinfo = "0.16"
-tokio = { version = "0.2", features = ["full"] }
-tokio-util = { version = "0.3", features = ["full"] }
+tokio = { version = "1.5.0", features = ["full"] }
+tokio-stream = { version = "0.1.5", features = ["fs", "time", "tokio-util"] }
+tokio-util = { version = "0.6.6", features = ["full"] }
 uuid = { version = "0.8", features = ["serde", "v4"] }
 urlparse = "0.7"
 ring = "0.16"

--- a/src/agent/onefuzz/src/asan.rs
+++ b/src/agent/onefuzz/src/asan.rs
@@ -3,7 +3,7 @@
 
 use anyhow::{Context, Result};
 use std::{collections::HashMap, hash::BuildHasher, path::Path};
-use tokio::{fs, stream::StreamExt};
+use tokio::fs;
 
 pub use stacktrace_parser::CrashLog;
 const ASAN_LOG_TRUNCATE_SIZE: usize = 4096;
@@ -68,8 +68,7 @@ pub async fn check_asan_string(mut data: String) -> Result<Option<CrashLog>> {
 pub async fn check_asan_path(asan_dir: &Path) -> Result<Option<CrashLog>> {
     let mut entries = fs::read_dir(asan_dir).await?;
     // there should be only up to one file in asan_dir
-    if let Some(file) = entries.next().await {
-        let file = file?;
+    if let Some(file) = entries.next_entry().await? {
         let mut asan_text = fs::read_to_string(file.path()).await?;
 
         let asan = CrashLog::parse(asan_text.clone()).with_context(|| {

--- a/src/agent/onefuzz/src/blob/client.rs
+++ b/src/agent/onefuzz/src/blob/client.rs
@@ -11,6 +11,7 @@ use serde::Serialize;
 use tokio::{fs, io};
 use tokio_util::codec;
 
+
 #[derive(Clone)]
 pub struct BlobClient {
     client: reqwest::Client,

--- a/src/agent/onefuzz/src/blob/client.rs
+++ b/src/agent/onefuzz/src/blob/client.rs
@@ -11,7 +11,6 @@ use serde::Serialize;
 use tokio::{fs, io};
 use tokio_util::codec;
 
-
 #[derive(Clone)]
 pub struct BlobClient {
     client: reqwest::Client,

--- a/src/agent/onefuzz/src/fs.rs
+++ b/src/agent/onefuzz/src/fs.rs
@@ -7,6 +7,7 @@ use std::{
     ffi::OsStr,
     path::{Path, PathBuf},
 };
+use tokio_stream::wrappers::ReadDirStream;
 
 use std::process::Stdio;
 use tokio::fs;
@@ -41,7 +42,7 @@ pub async fn list_files(path: impl AsRef<Path>) -> Result<Vec<PathBuf>> {
         .await
         .with_context(|| format!("unable to list files: {}", path.display()))?;
 
-    let mut files = paths
+    let mut files = ReadDirStream::new(paths)
         .filter_map(|x| async {
             match x {
                 Ok(x) => {

--- a/src/agent/onefuzz/src/fs.rs
+++ b/src/agent/onefuzz/src/fs.rs
@@ -299,7 +299,7 @@ pub async fn copy(src: SyncPath, dst: SyncPath, recur: bool) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use tempfile::tempdir;
-    use tokio::{fs, stream::StreamExt};
+    use tokio::fs;
 
     use super::*;
 
@@ -307,7 +307,7 @@ mod tests {
         let mut len = 0;
         let mut entries = fs::read_dir(dir).await.unwrap();
 
-        while entries.next().await.is_some() {
+        while entries.next_entry().await.unwrap().is_some() {
             len += 1;
         }
 

--- a/src/agent/onefuzz/src/heartbeat.rs
+++ b/src/agent/onefuzz/src/heartbeat.rs
@@ -35,7 +35,7 @@ where
     T: Clone + Sync + Send,
 {
     fn drop(&mut self) {
-        self.context.cancelled.notify();
+        self.context.cancelled.notify_one();
     }
 }
 

--- a/src/agent/onefuzz/src/jitter.rs
+++ b/src/agent/onefuzz/src/jitter.rs
@@ -3,7 +3,7 @@
 
 use rand::prelude::*;
 use std::time::Duration;
-use tokio::time::delay_for;
+use tokio::time::sleep;
 
 pub fn jitter(value: Duration) -> Duration {
     let random: u64 = thread_rng().gen_range(0, 10);
@@ -11,11 +11,11 @@ pub fn jitter(value: Duration) -> Duration {
 }
 
 pub async fn delay_with_jitter(value: Duration) {
-    delay_for(jitter(value)).await
+    sleep(jitter(value)).await
 }
 
 pub async fn random_delay(value: Duration) {
     let random: u64 = thread_rng().gen_range(0, value.as_secs());
     let delay = Duration::new(random, 0);
-    delay_for(delay).await
+    sleep(delay).await
 }

--- a/src/agent/onefuzz/src/process.rs
+++ b/src/agent/onefuzz/src/process.rs
@@ -165,7 +165,7 @@ async fn wait_process(context: &str, process: Child, stopped: Option<&Notify>) -
 
     debug!("child exited. {}:{:?}", context, output.status);
     if let Some(stopped) = stopped {
-        stopped.notify();
+        stopped.notify_one();
     }
 
     if output.status.success() {

--- a/src/agent/onefuzz/src/uploader.rs
+++ b/src/agent/onefuzz/src/uploader.rs
@@ -67,7 +67,9 @@ impl BlobUploader {
             let file = fs::File::from_std(std::fs::File::open(file_path)?);
             let reader = io::BufReader::new(file);
             let codec = codec::BytesCodec::new();
-            let file_stream = codec::FramedRead::new(reader, codec).map_ok(bytes::BytesMut::freeze);
+            let file_stream = codec::FramedRead::new(reader, codec)
+                .map_ok(bytes::BytesMut::freeze)
+                .into_stream();
 
             let request_builder = self
                 .client

--- a/src/agent/onefuzz/src/utils.rs
+++ b/src/agent/onefuzz/src/utils.rs
@@ -46,7 +46,7 @@ mod test {
     use anyhow::Result;
     use futures::*;
     use std::sync::Arc;
-    use tokio::{spawn, sync::Notify, task::JoinHandle, time::delay_for};
+    use tokio::{spawn, sync::Notify, task::JoinHandle, time::sleep};
 
     fn spawn_ok() -> (Arc<Notify>, JoinHandle<Result<()>>) {
         let notify = Arc::new(Notify::new());
@@ -77,7 +77,7 @@ mod test {
         let (_notify3, handle3) = spawn_ok();
 
         let try_wait_handle = try_wait_all_join_handles(vec![handle1, handle2, handle3]);
-        delay_for(Duration::from_secs(1)).await;
+        sleep(Duration::from_secs(1)).await;
         assert!(
             try_wait_handle.now_or_never().is_none(),
             "expected no result"
@@ -94,7 +94,7 @@ mod test {
 
         notify1.notify();
         notify2.notify();
-        delay_for(Duration::from_secs(1)).await;
+        sleep(Duration::from_secs(1)).await;
         assert!(
             try_wait_handle.now_or_never().is_none(),
             "expected no result"
@@ -112,7 +112,7 @@ mod test {
         notify1.notify();
         notify2.notify();
         notify3.notify();
-        delay_for(Duration::from_secs(1)).await;
+        sleep(Duration::from_secs(1)).await;
         if let Some(result) = try_wait_handle.now_or_never() {
             assert!(result.is_ok(), "expected Ok")
         } else {
@@ -129,7 +129,7 @@ mod test {
         let try_wait_handle = try_wait_all_join_handles(vec![handle1, handle2, handle3]);
 
         notify1.notify();
-        delay_for(Duration::from_secs(1)).await;
+        sleep(Duration::from_secs(1)).await;
         assert!(
             try_wait_handle.now_or_never().is_none(),
             "expected no result"
@@ -146,7 +146,7 @@ mod test {
 
         notify2.notify();
 
-        delay_for(Duration::from_secs(1)).await;
+        sleep(Duration::from_secs(1)).await;
         if let Some(result) = try_wait_handle.now_or_never() {
             assert!(result.is_err(), "expected error")
         } else {

--- a/src/agent/onefuzz/src/utils.rs
+++ b/src/agent/onefuzz/src/utils.rs
@@ -92,8 +92,8 @@ mod test {
 
         let try_wait_handle = try_wait_all_join_handles(vec![handle1, handle2, handle3]);
 
-        notify1.notify();
-        notify2.notify();
+        notify1.notify_one();
+        notify2.notify_one();
         sleep(Duration::from_secs(1)).await;
         assert!(
             try_wait_handle.now_or_never().is_none(),
@@ -109,9 +109,9 @@ mod test {
 
         let try_wait_handle = try_wait_all_join_handles(vec![handle1, handle2, handle3]);
 
-        notify1.notify();
-        notify2.notify();
-        notify3.notify();
+        notify1.notify_one();
+        notify2.notify_one();
+        notify3.notify_one();
         sleep(Duration::from_secs(1)).await;
         if let Some(result) = try_wait_handle.now_or_never() {
             assert!(result.is_ok(), "expected Ok")
@@ -128,7 +128,7 @@ mod test {
 
         let try_wait_handle = try_wait_all_join_handles(vec![handle1, handle2, handle3]);
 
-        notify1.notify();
+        notify1.notify_one();
         sleep(Duration::from_secs(1)).await;
         assert!(
             try_wait_handle.now_or_never().is_none(),
@@ -144,7 +144,7 @@ mod test {
 
         let try_wait_handle = try_wait_all_join_handles(vec![handle1, handle2, handle3]);
 
-        notify2.notify();
+        notify2.notify_one();
 
         sleep(Duration::from_secs(1)).await;
         if let Some(result) = try_wait_handle.now_or_never() {

--- a/src/agent/reqwest-retry/Cargo.toml
+++ b/src/agent/reqwest-retry/Cargo.toml
@@ -8,10 +8,10 @@ license = "MIT"
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
-reqwest = { version = "0.10", features = ["json", "stream"] }
+reqwest = { version = "0.11.3", features = ["json", "stream"] }
 backoff = { version = "0.3", features = ["async-std"] }
 log = "0.4"
 onefuzz-telemetry = { path = "../onefuzz-telemetry" }
 
 [dev-dependencies]
-tokio = { version = "0.2" , features=["macros"] }
+tokio = { version = "1.5.0", features = ["macros"] }

--- a/src/agent/storage-queue/Cargo.toml
+++ b/src/agent/storage-queue/Cargo.toml
@@ -12,15 +12,16 @@ backoff = { version = "0.3", features = ["async-std"] }
 base64 = "0.13"
 bytes = "0.5"
 derivative = "2.2.0"
+flume = "0.10.4"
 num_cpus = "1.13"
 regex = "1.4"
-reqwest = { version = "0.10", features = ["json", "stream"] }
+reqwest = { version = "0.11.3", features = ["json", "stream"] }
 reqwest-retry = { path = "../reqwest-retry" }
 serde = { version = "1.0", features = ["derive"]}
 serde_derive = "1.0"
 serde_json = "1.0"
 serde-xml-rs = "0.4"
-tokio = { version = "0.2", features = ["full"] }
+tokio = { version = "1.5.0" , features=["full"] }
 queue-file = "1.1"
 uuid = { version = "0.8", features = ["serde", "v4"] }
 yaque = "0.5.1"

--- a/src/proxy-manager/Cargo.lock
+++ b/src/proxy-manager/Cargo.lock
@@ -42,7 +42,7 @@ dependencies = [
  "http",
  "log",
  "paste",
- "reqwest",
+ "reqwest 0.10.10",
  "serde",
  "serde_json",
  "sm",
@@ -479,6 +479,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11fce69af4d4582ea989e6adfc5c9b81fd2071ff89234e5c14675c82a85217df"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "nanorand",
+ "pin-project",
+ "spinning_top",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -546,9 +559,9 @@ checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "futures"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f55667319111d593ba876406af7c409c0ebb44dc4be6132a783ccf163ea14c1"
+checksum = "a9d5813545e459ad3ca1bff9915e9ad7f1a47dc6a91b627ce321d5863b7dd253"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -561,9 +574,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c2dd2df839b57db9ab69c2c9d8f3e8c81984781937fe2807dc6dcf3b2ad2939"
+checksum = "ce79c6a52a299137a6013061e0cf0e688fce5d7f1bc60125f520912fdb29ec25"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -571,15 +584,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15496a72fabf0e62bdc3df11a59a3787429221dd0710ba8ef163d6f7a9112c94"
+checksum = "098cd1c6dda6ca01650f1a37a794245eb73181d0d4d4e955e2f3c37db7af1815"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891a4b7b96d84d5940084b2a37632dd65deeae662c114ceaa2c879629c9c0ad1"
+checksum = "10f6cb7042eda00f0049b1d2080aa4b93442997ee507eb3828e8bd7577f94c9d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -588,9 +601,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71c2c65c57704c32f5241c1223167c2c3294fd34ac020c807ddbe6db287ba59"
+checksum = "365a1a1fb30ea1c03a830fdb2158f5236833ac81fa0ad12fe35b29cddc35cb04"
 
 [[package]]
 name = "futures-lite"
@@ -609,9 +622,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea405816a5139fb39af82c2beb921d52143f556038378d6db21183a5c37fbfb7"
+checksum = "668c6733a182cd7deb4f1de7ba3bf2120823835b3bcfbeacf7d2c4a773c1bb8b"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2 1.0.24",
@@ -621,21 +634,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85754d98985841b7d4f5e8e6fbfa4a4ac847916893ec511a2917ccd8525b8bb3"
+checksum = "5c5629433c555de3d82861a7a4e3794a4c40040390907cfbfd7143a92a426c23"
 
 [[package]]
 name = "futures-task"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa189ef211c15ee602667a6fcfe1c1fd9e07d42250d2156382820fba33c9df80"
+checksum = "ba7aa51095076f3ba6d9a1f702f74bd05ec65f555d70d2033d55ba8d69f581bc"
 
 [[package]]
 name = "futures-util"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1812c7ab8aedf8d6f2701a43e1243acdbcc2b36ab26e2ad421eb99ac963d96d1"
+checksum = "3c144ad54d60f23927f0a6b6d816e4271278b64f005ad65e4e35291d2de9c025"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -669,8 +682,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
 dependencies = [
  "cfg-if 1.0.0",
+ "js-sys",
  "libc",
  "wasi 0.10.2+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -700,10 +715,29 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio",
- "tokio-util",
+ "tokio 0.2.25",
+ "tokio-util 0.3.1",
  "tracing",
  "tracing-futures",
+]
+
+[[package]]
+name = "h2"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc018e188373e2777d0ef2467ebff62a08e66c3f5857b23c8fbec3018210dc00"
+dependencies = [
+ "bytes 1.0.1",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio 1.5.0",
+ "tokio-util 0.6.6",
+ "tracing",
 ]
 
 [[package]]
@@ -754,6 +788,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-body"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfb77c123b4e2f72a2069aeae0b4b4949cc7e966df277813fc16347e7549737"
+dependencies = [
+ "bytes 1.0.1",
+ "http",
+ "pin-project-lite 0.2.5",
+]
+
+[[package]]
 name = "httparse"
 version = "1.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -781,15 +826,39 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.2.7",
  "http",
- "http-body",
+ "http-body 0.3.1",
  "httparse",
  "httpdate",
  "itoa",
  "pin-project",
- "socket2",
- "tokio",
+ "socket2 0.3.19",
+ "tokio 0.2.25",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bf09f61b52cfcf4c00de50df88ae423d6c02354e385a86341133b5338630ad1"
+dependencies = [
+ "bytes 1.0.1",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.2",
+ "http",
+ "http-body 0.4.1",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project",
+ "socket2 0.4.0",
+ "tokio 1.5.0",
  "tower-service",
  "tracing",
  "want",
@@ -802,10 +871,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d979acc56dcb5b8dddba3917601745e877576475aa046df3226eabdecef78eed"
 dependencies = [
  "bytes 0.5.6",
- "hyper",
+ "hyper 0.13.10",
  "native-tls",
- "tokio",
+ "tokio 0.2.25",
  "tokio-tls",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes 1.0.1",
+ "hyper 0.14.5",
+ "native-tls",
+ "tokio 1.5.0",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -920,6 +1002,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "265d751d31d6780a3f956bb5b8022feba2d94eeee5a84ba64f4212eedca42213"
 
 [[package]]
+name = "lock_api"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3c91c24eae6777794bb1997ad98bbb87daf92890acab859f7eaa4320333176"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1011,29 +1102,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mio-named-pipes"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0840c1c50fd55e521b247f949c241c9997709f23bd7f023b9762cd561e935656"
-dependencies = [
- "log",
- "mio 0.6.23",
- "miow 0.3.6",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "mio-uds"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0"
-dependencies = [
- "iovec",
- "libc",
- "mio 0.6.23",
-]
-
-[[package]]
 name = "miow"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1051,8 +1119,17 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
 dependencies = [
- "socket2",
+ "socket2 0.3.19",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "nanorand"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac1378b66f7c93a1c0f8464a19bf47df8795083842e5090f4b7305973d5a22d0"
+dependencies = [
+ "getrandom 0.2.2",
 ]
 
 [[package]]
@@ -1080,7 +1157,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "670361df1bc2399ee1ff50406a0d422587dd3bb0da596e1978fe8e05dabddf4f"
 dependencies = [
  "libc",
- "socket2",
+ "socket2 0.3.19",
 ]
 
 [[package]]
@@ -1167,13 +1244,13 @@ dependencies = [
  "futures",
  "log",
  "onefuzz-telemetry",
- "reqwest",
+ "reqwest 0.11.3",
  "reqwest-retry",
  "serde",
  "serde_json",
  "storage-queue",
  "thiserror",
- "tokio",
+ "tokio 1.5.0",
  "url",
  "uuid",
 ]
@@ -1183,8 +1260,10 @@ name = "onefuzz-telemetry"
 version = "0.1.0"
 dependencies = [
  "appinsights",
+ "lazy_static",
  "log",
  "serde",
+ "tokio 1.5.0",
  "uuid",
 ]
 
@@ -1226,6 +1305,31 @@ name = "parking"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
+
+[[package]]
+name = "parking_lot"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018"
+dependencies = [
+ "cfg-if 1.0.0",
+ "instant",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "paste"
@@ -1527,9 +1631,9 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http",
- "http-body",
- "hyper",
- "hyper-tls",
+ "http-body 0.3.1",
+ "hyper 0.13.10",
+ "hyper-tls 0.4.3",
  "ipnet",
  "js-sys",
  "lazy_static",
@@ -1542,8 +1646,43 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "tokio",
+ "tokio 0.2.25",
  "tokio-tls",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2296f2fac53979e8ccbc4a1136b25dcefd37be9ed7e4a1f6b05a6029c84ff124"
+dependencies = [
+ "base64",
+ "bytes 1.0.1",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body 0.4.1",
+ "hyper 0.14.5",
+ "hyper-tls 0.5.0",
+ "ipnet",
+ "js-sys",
+ "lazy_static",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite 0.2.5",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio 1.5.0",
+ "tokio-native-tls",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -1560,7 +1699,7 @@ dependencies = [
  "backoff",
  "log",
  "onefuzz-telemetry",
- "reqwest",
+ "reqwest 0.11.3",
 ]
 
 [[package]]
@@ -1708,6 +1847,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallvec"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
+
+[[package]]
 name = "snafu"
 version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1740,6 +1885,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e3dfc207c526015c632472a77be09cf1b6e46866581aecae5cc38fb4235dea2"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "spinning_top"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bd0ab6b8c375d2d963503b90d3770010d95bc3b5f98036f948dee24bf4e8879"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "storage-queue"
 version = "0.1.0"
 dependencies = [
@@ -1749,15 +1913,17 @@ dependencies = [
  "base64",
  "bytes 0.5.6",
  "derivative",
+ "flume",
+ "num_cpus",
  "queue-file",
  "regex",
- "reqwest",
+ "reqwest 0.11.3",
  "reqwest-retry",
  "serde",
  "serde-xml-rs",
  "serde_derive",
  "serde_json",
- "tokio",
+ "tokio 1.5.0",
  "uuid",
  "yaque",
 ]
@@ -1902,28 +2068,52 @@ dependencies = [
  "futures-core",
  "iovec",
  "lazy_static",
- "libc",
  "memchr",
  "mio 0.6.23",
- "mio-named-pipes",
- "mio-uds",
  "num_cpus",
  "pin-project-lite 0.1.12",
- "signal-hook-registry",
  "slab",
+]
+
+[[package]]
+name = "tokio"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83f0c8e7c0addab50b663055baf787d0af7f413a46e6e7fb9559a4e4db7137a5"
+dependencies = [
+ "autocfg",
+ "bytes 1.0.1",
+ "libc",
+ "memchr",
+ "mio 0.7.9",
+ "num_cpus",
+ "once_cell",
+ "parking_lot",
+ "pin-project-lite 0.2.5",
+ "signal-hook-registry",
  "tokio-macros",
  "winapi 0.3.9",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "0.2.6"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e44da00bfc73a25f814cd8d7e57a68a5c31b74b3152a0a1d1f590c97ed06265a"
+checksum = "caf7b11a536f46a809a8a9f0bb4237020f70ecbf115b842360afb127ea2fda57"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
  "syn 1.0.60",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+dependencies = [
+ "native-tls",
+ "tokio 1.5.0",
 ]
 
 [[package]]
@@ -1933,7 +2123,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a70f4fcd7b3b24fb194f837560168208f669ca8cb70d0c4b862944452396343"
 dependencies = [
  "native-tls",
- "tokio",
+ "tokio 0.2.25",
 ]
 
 [[package]]
@@ -1947,7 +2137,21 @@ dependencies = [
  "futures-sink",
  "log",
  "pin-project-lite 0.1.12",
- "tokio",
+ "tokio 0.2.25",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940a12c99365c31ea8dd9ba04ec1be183ffe4920102bb7122c2f515437601e8e"
+dependencies = [
+ "bytes 1.0.1",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "pin-project-lite 0.2.5",
+ "tokio 1.5.0",
 ]
 
 [[package]]

--- a/src/proxy-manager/Cargo.toml
+++ b/src/proxy-manager/Cargo.toml
@@ -10,13 +10,13 @@ license = "MIT"
 anyhow = "1.0"
 clap = "2.33"
 env_logger = "0.8"
-futures = "0.3"
-reqwest = { version = "0.10", features = ["json", "stream"] }
+futures = "0.3.14"
+reqwest = { version = "0.11.3", features = ["json", "stream"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 storage-queue = { path = "../agent/storage-queue" }
 thiserror = "1.0"
-tokio = { version = "0.2", features = ["macros", "rt-threaded", "fs", "process"] }
+tokio = { version = "1.5.0", features = ["macros", "rt-threaded", "fs", "process"] }
 url = { version = "2.2", features = ["serde"] }
 reqwest-retry = { path = "../agent/reqwest-retry"}
 onefuzz-telemetry = { path = "../agent/onefuzz-telemetry" }

--- a/src/proxy-manager/Cargo.toml
+++ b/src/proxy-manager/Cargo.toml
@@ -16,7 +16,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 storage-queue = { path = "../agent/storage-queue" }
 thiserror = "1.0"
-tokio = { version = "1.5.0", features = ["macros", "rt-threaded", "fs", "process"] }
+tokio = { version = "1.5.0", features = ["macros", "rt-multi-thread", "fs", "process"] }
 url = { version = "2.2", features = ["serde"] }
 reqwest-retry = { path = "../agent/reqwest-retry"}
 onefuzz-telemetry = { path = "../agent/onefuzz-telemetry" }

--- a/src/proxy-manager/src/main.rs
+++ b/src/proxy-manager/src/main.rs
@@ -85,6 +85,6 @@ fn main() -> Result<()> {
     let proxy = Config::from_file(config_path)?;
 
     info!("parsed initial config");
-    let mut rt = Runtime::new()?;
+    let rt = Runtime::new()?;
     rt.block_on(run(proxy))
 }

--- a/src/proxy-manager/src/main.rs
+++ b/src/proxy-manager/src/main.rs
@@ -20,7 +20,7 @@ use std::{
 };
 use tokio::{
     runtime::Runtime,
-    time::{delay_for, Duration},
+    time::{sleep, Duration},
 };
 
 const MINIMUM_NOTIFY_INTERVAL: Duration = Duration::from_secs(120);
@@ -37,7 +37,7 @@ async fn run_loop(mut proxy_config: Config) -> Result<()> {
             last_notified = Instant::now();
         }
 
-        delay_for(POLL_INTERVAL).await;
+        sleep(POLL_INTERVAL).await;
     }
 }
 

--- a/src/proxy-manager/src/proxy.rs
+++ b/src/proxy-manager/src/proxy.rs
@@ -3,7 +3,6 @@
 
 use crate::config::ConfigData;
 use anyhow::Result;
-use futures::stream::StreamExt;
 use std::{collections::HashMap, path::Path};
 use tokio::process::Command;
 
@@ -76,9 +75,10 @@ pub async fn update(data: &ConfigData) -> Result<()> {
     let configs = build(data);
 
     let mut config_dir = tokio::fs::read_dir(SYSTEMD_CONFIG_DIR).await?;
-    while let Some(entry) = config_dir.next().await {
-        let entry = match entry {
-            Ok(entry) => entry,
+    loop {
+        let entry = match config_dir.next_entry().await {
+            Ok(Some(entry)) => entry,
+            Ok(None) => break,
             Err(err) => {
                 error!("error listing files {}", err);
                 continue;


### PR DESCRIPTION
Upgrade to tokio 1.5.0
replaced tokio::sync::mpsc:: with [flume ](https://crates.io/crates/flume) because try_recv was removed 