### PR TITLE
remove timestamp from WebhookMessageLog model

### DIFF
--- a/src/api-service/__app__/onefuzzlib/webhooks.py
+++ b/src/api-service/__app__/onefuzzlib/webhooks.py
@@ -18,13 +18,13 @@ from onefuzztypes.models import Error, Result
 from onefuzztypes.webhooks import Webhook as BASE_WEBHOOK
 from onefuzztypes.webhooks import WebhookMessage
 from onefuzztypes.webhooks import WebhookMessageLog as BASE_WEBHOOK_MESSAGE_LOG
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from .__version__ import __version__
 from .azure.creds import get_instance_id, get_instance_name
 from .azure.queue import queue_object
 from .azure.storage import StorageType
-from .orm import ORMMixin
+from .orm import MappingIntStrAny, ORMMixin
 
 MAX_TRIES = 5
 EXPIRE_DAYS = 7
@@ -37,9 +37,14 @@ class WebhookMessageQueueObj(BaseModel):
 
 
 class WebhookMessageLog(BASE_WEBHOOK_MESSAGE_LOG, ORMMixin):
+    timestamp: Optional[datetime.datetime] = Field(alias="Timestamp")
+
     @classmethod
     def key_fields(cls) -> Tuple[str, Optional[str]]:
         return ("webhook_id", "event_id")
+
+    def export_exclude(self) -> Optional[MappingIntStrAny]:
+        return {"etag": ..., "timestamp": ...}
 
     @classmethod
     def search_expired(cls) -> List["WebhookMessageLog"]:

--- a/src/pytypes/onefuzztypes/webhooks.py
+++ b/src/pytypes/onefuzztypes/webhooks.py
@@ -3,7 +3,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-from datetime import datetime
 from typing import List, Optional
 from uuid import UUID, uuid4
 
@@ -18,7 +17,6 @@ class WebhookMessage(EventMessage):
 
 
 class WebhookMessageLog(WebhookMessage):
-    timestamp: Optional[datetime] = Field(alias="Timestamp")
     state: WebhookMessageState = Field(default=WebhookMessageState.queued)
     try_count: int = Field(default=0)
 


### PR DESCRIPTION
Due to BaseEvent denying extra fields (see below), the addition of timestamp to WebhookMessageLog in #796 creates a backwards compatibility issue.

https://github.com/microsoft/onefuzz/blob/e413aec03dcd682c049855b77cf0b0042407ddc1/src/pytypes/onefuzztypes/events.py#L27-L29