### PR TITLE
Use `u32` to represent module offsets

### DIFF
--- a/src/agent/coverage/src/block/linux.rs
+++ b/src/agent/coverage/src/block/linux.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 use std::collections::BTreeMap;
+use std::convert::TryInto;
 use std::ffi::OsStr;
 use std::process::Command;
 
@@ -140,7 +141,7 @@ impl<'c> Recorder<'c> {
                 .find_va_image(pc)
                 .ok_or_else(|| format_err!("unable to find image for va = {:x}", pc))?;
 
-            let offset = image.va_to_offset(pc);
+            let offset = image.va_to_offset(pc)?;
             self.coverage.increment(image.path(), offset);
 
             // Execute clobbered instruction on restart.
@@ -182,7 +183,15 @@ impl<'c> Recorder<'c> {
 
             // Check the maybe-demangled against the coverage filter.
             if self.filter.includes_symbol(&info.module.path, symbol_name) {
-                for offset in info.blocks.range(symbol.range()) {
+                // Convert range bounds to an `offset`-sized type.
+                let range = {
+                    let range = symbol.range();
+                    let lo: u32 = range.start.try_into()?;
+                    let hi: u32 = range.end.try_into()?;
+                    lo..hi
+                };
+
+                for offset in info.blocks.range(range) {
                     allowed_blocks.push(*offset);
                 }
             }
@@ -307,12 +316,16 @@ impl ModuleImage {
         (self.map.address.0)..(self.map.address.1)
     }
 
-    pub fn va_to_offset(&self, va: u64) -> u64 {
-        va - self.base()
+    pub fn va_to_offset(&self, va: u64) -> Result<u32> {
+        if let Some(offset) = va.checked_sub(self.base()) {
+            Ok(offset.try_into()?)
+        } else {
+            anyhow::bail!("underflow converting VA to image offset")
+        }
     }
 
-    pub fn offset_to_va(&self, offset: u64) -> u64 {
-        self.base() + offset
+    pub fn offset_to_va(&self, offset: u32) -> u64 {
+        self.base() + (offset as u64)
     }
 }
 

--- a/src/agent/coverage/src/block/linux.rs
+++ b/src/agent/coverage/src/block/linux.rs
@@ -6,7 +6,7 @@ use std::convert::TryInto;
 use std::ffi::OsStr;
 use std::process::Command;
 
-use anyhow::{format_err, Result};
+use anyhow::{format_err, Context, Result};
 use pete::{Ptracer, Restart, Signal, Stop, Tracee};
 use procfs::process::{MMapPath, MemoryMap, Process};
 
@@ -318,7 +318,7 @@ impl ModuleImage {
 
     pub fn va_to_offset(&self, va: u64) -> Result<u32> {
         if let Some(offset) = va.checked_sub(self.base()) {
-            Ok(offset.try_into()?)
+            Ok(offset.try_into().context("ELF offset overflowed `u32`")?)
         } else {
             anyhow::bail!("underflow converting VA to image offset")
         }

--- a/src/agent/coverage/src/block/windows.rs
+++ b/src/agent/coverage/src/block/windows.rs
@@ -231,7 +231,7 @@ struct Breakpoints {
     // Map of breakpoint IDs to data which pick out an code location. For a
     // value `(module, offset)`, `module` is an index into `self.modules`, and
     // `offset` is a VA offset relative to the module base.
-    registered: BTreeMap<BreakpointId, (usize, u64)>,
+    registered: BTreeMap<BreakpointId, (usize, u32)>,
 }
 
 impl Breakpoints {
@@ -245,7 +245,7 @@ impl Breakpoints {
         &mut self,
         dbg: &mut Debugger,
         module: &Module,
-        offsets: impl Iterator<Item = u64>,
+        offsets: impl Iterator<Item = u32>,
     ) -> Result<()> {
         // From the `target::Module`, create and save a `ModulePath`.
         let module_path = ModulePath::new(module.path().to_owned())?;
@@ -254,7 +254,7 @@ impl Breakpoints {
 
         for offset in offsets {
             // Register the breakpoint in the running target address space.
-            let id = dbg.register_breakpoint(module.name(), offset, BreakpointType::OneTime);
+            let id = dbg.register_breakpoint(module.name(), offset as u64, BreakpointType::OneTime);
 
             // Associate the opaque `BreakpointId` with the module and offset.
             self.registered.insert(id, (module_index, offset));
@@ -271,5 +271,5 @@ impl Breakpoints {
 #[derive(Clone, Copy, Debug)]
 pub struct BreakpointData<'a> {
     pub module: &'a ModulePath,
-    pub offset: u64,
+    pub offset: u32,
 }

--- a/src/agent/coverage/src/cache.rs
+++ b/src/agent/coverage/src/cache.rs
@@ -66,7 +66,7 @@ pub struct ModuleInfo {
     pub module: ModuleIndex,
 
     /// Set of image offsets of basic blocks.
-    pub blocks: BTreeSet<u64>,
+    pub blocks: BTreeSet<u32>,
 }
 
 impl ModuleInfo {
@@ -89,7 +89,7 @@ impl ModuleInfo {
         let pe = goblin::pe::PE::parse(&data)?;
         let module = ModuleIndex::index_pe(path.clone(), &pe);
         let offsets = crate::pe::process_module(path, &data, &pe, false, handle.into())?;
-        let blocks = offsets.ones().map(|off| off as u64).collect();
+        let blocks = offsets.ones().map(|off| off as u32).collect();
 
         Ok(Self { module, blocks })
     }

--- a/src/agent/coverage/src/disasm.rs
+++ b/src/agent/coverage/src/disasm.rs
@@ -53,7 +53,7 @@ impl<'a> ModuleDisassembler<'a> {
             .module
             .base_va
             .checked_add(symbol.image_offset)
-            .ok_or_else(|| format_err!("symbol image offset overflows base VA"))?;
+            .ok_or_else(|| format_err!("symbol image offset overflowed base VA"))?;
         decoder.set_ip(va);
 
         // Function entry is a leader.
@@ -68,7 +68,7 @@ impl<'a> ModuleDisassembler<'a> {
 
                 // The branch target is a leader, if it is intra-procedural.
                 if symbol.contains_image_offset(offset) {
-                    blocks.insert(offset.try_into().context("ELF offset overflows `u32`")?);
+                    blocks.insert(offset.try_into().context("ELF offset overflowed `u32`")?);
                 }
 
                 // Only mark the fallthrough instruction as a leader if the branch is conditional.
@@ -87,7 +87,7 @@ impl<'a> ModuleDisassembler<'a> {
                         let next = decoder.ip() as u64;
                         let next_offset =
                             if let Some(offset) = next.checked_sub(self.module.base_va) {
-                                offset.try_into().context("ELF offset overflows `u32`")?
+                                offset.try_into().context("ELF offset overflowed `u32`")?
                             } else {
                                 anyhow::bail!("underflow converting ELF VA to offset")
                             };

--- a/src/agent/coverage/src/disasm.rs
+++ b/src/agent/coverage/src/disasm.rs
@@ -2,8 +2,9 @@
 // Licensed under the MIT License.
 
 use std::collections::BTreeSet;
+use std::convert::TryInto;
 
-use anyhow::{bail, format_err, Result};
+use anyhow::{bail, format_err, Context, Result};
 use iced_x86::{Decoder, DecoderOptions, Instruction};
 
 use crate::code::{ModuleIndex, Symbol};
@@ -19,7 +20,7 @@ impl<'a> ModuleDisassembler<'a> {
     }
 
     /// Find block entry points for every symbol in the module.
-    pub fn find_blocks(&self) -> BTreeSet<u64> {
+    pub fn find_blocks(&self) -> BTreeSet<u32> {
         let mut blocks = BTreeSet::new();
 
         for symbol in self.module.symbols.iter() {
@@ -36,7 +37,7 @@ impl<'a> ModuleDisassembler<'a> {
     }
 
     /// Find all entry points for blocks contained within the region of `symbol`.
-    fn insert_symbol_blocks(&self, blocks: &mut BTreeSet<u64>, symbol: &Symbol) -> Result<()> {
+    fn insert_symbol_blocks(&self, blocks: &mut BTreeSet<u32>, symbol: &Symbol) -> Result<()> {
         // Slice the symbol's instruction data from the module file data.
         let data = if let Some(data) = self.data.get(symbol.file_range_usize()) {
             data
@@ -56,7 +57,7 @@ impl<'a> ModuleDisassembler<'a> {
         decoder.set_ip(va);
 
         // Function entry is a leader.
-        blocks.insert(symbol.image_offset);
+        blocks.insert(symbol.image_offset.try_into()?);
 
         let mut inst = Instruction::default();
         while decoder.can_decode() {
@@ -67,7 +68,7 @@ impl<'a> ModuleDisassembler<'a> {
 
                 // The branch target is a leader, if it is intra-procedural.
                 if symbol.contains_image_offset(offset) {
-                    blocks.insert(offset);
+                    blocks.insert(offset.try_into().context("ELF offset overflows `u32`")?);
                 }
 
                 // Only mark the fallthrough instruction as a leader if the branch is conditional.
@@ -84,7 +85,13 @@ impl<'a> ModuleDisassembler<'a> {
                         // We decoded the current instruction, so the decoder offset is
                         // set to the next instruction.
                         let next = decoder.ip() as u64;
-                        let next_offset = next - self.module.base_va;
+                        let next_offset =
+                            if let Some(offset) = next.checked_sub(self.module.base_va) {
+                                offset.try_into().context("ELF offset overflows `u32`")?
+                            } else {
+                                anyhow::bail!("underflow converting ELF VA to offset")
+                            };
+
                         blocks.insert(next_offset);
                     }
                 }


### PR DESCRIPTION
In #765, we introduced an assumption that all module-relative instruction offsets are representable by a `u32`. Move to an explicit `u32` repr for offsets, and add validation to check for overflow at conversion sites.