### PR TITLE
Add optional coverage to `input-tester` API

### DIFF
--- a/src/agent/input-tester/src/crash_detector.rs
+++ b/src/agent/input-tester/src/crash_detector.rs
@@ -14,7 +14,10 @@ use std::{
 };
 
 use anyhow::Result;
-use coverage::{block::windows::Recorder as BlockCoverageRecorder, cache::ModuleCache};
+use coverage::{
+    block::{windows::Recorder as BlockCoverageRecorder, CommandBlockCov},
+    cache::ModuleCache,
+};
 use debugger::{BreakpointId, DebugEventHandler, Debugger, ModuleLoadInfo};
 use log::{debug, error, trace};
 use win_util::{
@@ -45,6 +48,7 @@ pub struct DebuggerResult {
     pub stdout: String,
     pub stderr: String,
     pub debugger_output: String,
+    pub coverage: Option<CommandBlockCov>,
 }
 
 impl DebuggerResult {
@@ -54,6 +58,7 @@ impl DebuggerResult {
         stdout: String,
         stderr: String,
         debugger_output: String,
+        coverage: Option<CommandBlockCov>,
     ) -> Self {
         DebuggerResult {
             exceptions,
@@ -61,6 +66,7 @@ impl DebuggerResult {
             stdout,
             stderr,
             debugger_output,
+            coverage,
         }
     }
 
@@ -359,6 +365,7 @@ pub fn test_process<'a>(
         String::from_utf8_lossy(&output.stdout).to_string(),
         String::from_utf8_lossy(&output.stderr).to_string(),
         event_handler.debugger_output,
+        event_handler.coverage.map(|r| r.into_coverage()),
     ))
 }
 

--- a/src/agent/input-tester/src/lib.rs
+++ b/src/agent/input-tester/src/lib.rs
@@ -44,6 +44,7 @@ pub fn run(
         max_run_s,
         ignore_first_chance_exceptions,
         app_verifier_tests,
+        coverage::cache::ModuleCache::default(),
     )?;
 
     tester.set_appverifier(AppVerifierState::Enabled)?;

--- a/src/agent/input-tester/src/tester.rs
+++ b/src/agent/input-tester/src/tester.rs
@@ -14,11 +14,12 @@ use std::{
     fs,
     io::Write,
     path::{Path, PathBuf},
-    sync::Arc,
+    sync::{Arc, RwLock},
     time::Duration,
 };
 
 use anyhow::{Context, Result};
+use coverage::cache::ModuleCache;
 use log::{error, info, trace, warn};
 use num_cpus;
 use rayon::{prelude::*, ThreadPoolBuilder};
@@ -70,6 +71,7 @@ pub struct Tester {
     ignore_first_chance_exceptions: bool,
     appverif_controller: Option<AppVerifierController>,
     bugs_found_dir: PathBuf,
+    module_cache: RwLock<ModuleCache>,
 }
 
 impl Tester {
@@ -81,6 +83,7 @@ impl Tester {
         max_run_s: u64,
         ignore_first_chance_exceptions: bool,
         app_verifier_tests: Option<Vec<String>>,
+        module_cache: ModuleCache,
     ) -> Result<Arc<Self>> {
         let mut bugs_found_dir = output_dir.to_path_buf();
         bugs_found_dir.push("bugs_found");
@@ -115,6 +118,7 @@ impl Tester {
             max_run_s,
             ignore_first_chance_exceptions,
             bugs_found_dir,
+            module_cache: RwLock::new(module_cache),
         }))
     }
 
@@ -122,13 +126,18 @@ impl Tester {
     pub fn test_application(&self, input_path: impl AsRef<Path>) -> Result<InputTestResult> {
         let app_args = args_with_input_file_applied(&self.driver_args, &input_path)?;
 
+        let mut module_cache = self
+            .module_cache
+            .write()
+            .map_err(|err| anyhow::format_err!("{:?}", err))?;
+
         crash_detector::test_process(
             &self.driver,
             &app_args,
             &self.driver_env,
             Duration::from_secs(self.max_run_s),
             self.ignore_first_chance_exceptions,
-            None,
+            Some(&mut *module_cache),
         )
         .and_then(|result| {
             let result = InputTestResult::new(result, PathBuf::from(input_path.as_ref()));


### PR DESCRIPTION
Add a `module_cache` field to the `Tester` struct and ctor (which is not used by OneFuzz). This enables coverage collection when using it to test inputs. Add an optional `coverage` field to the `DebuggerResult` in the `input-tester` crate. This lets users retrieve per-input coverage after testing an input.