### PR TITLE
when processing node updates, don't wait on the node in cases it should be stopped

### DIFF
--- a/src/api-service/__app__/onefuzzlib/workers/nodes.py
+++ b/src/api-service/__app__/onefuzzlib/workers/nodes.py
@@ -217,7 +217,7 @@ class Node(BASE_NODE, ORMMixin):
             "node: stopping busy node with all tasks complete: %s",
             self.machine_id,
         )
-        self.stop()
+        self.stop(done=True)
         return True
 
     def mark_tasks_stopped_early(self, error: Optional[Error] = None) -> None:
@@ -253,7 +253,7 @@ class Node(BASE_NODE, ORMMixin):
                 self.version,
                 __version__,
             )
-            self.stop()
+            self.stop(done=True)
             return False
 
         if self.state in NodeState.ready_for_reset():
@@ -267,7 +267,7 @@ class Node(BASE_NODE, ORMMixin):
                 "can_schedule is set to be deleted.  machine_id:%s",
                 self.machine_id,
             )
-            self.stop()
+            self.stop(done=True)
             return False
 
         if self.reimage_requested:
@@ -275,7 +275,7 @@ class Node(BASE_NODE, ORMMixin):
                 "can_schedule is set to be reimaged.  machine_id:%s",
                 self.machine_id,
             )
-            self.stop()
+            self.stop(done=True)
             return False
 
         if self.could_shrink_scaleset():


### PR DESCRIPTION

In situations when the node should be done, mark it as done without
waiting for the node to respond to the Done command.
