### PR TITLE
Separate report serialization from runtime struct

### DIFF
--- a/src/agent/coverage/src/block.rs
+++ b/src/agent/coverage/src/block.rs
@@ -296,6 +296,8 @@ mod tests {
     use anyhow::Result;
     use serde_json::json;
 
+    use crate::test::module_path;
+
     use super::*;
 
     // Builds a `ModuleCov` from a vec of `(offset, count)` tuples.
@@ -361,28 +363,6 @@ mod tests {
             to_vec(&total),
             vec![(1, 0), (2, 0), (3, 1), (5, 0), (8, 1), (13, 1),]
         );
-    }
-
-    // Given a POSIX-style path as a string, construct a valid absolute path for
-    // the target OS and return it as a checked `ModulePath`.
-    fn module_path(posix_path: &str) -> Result<ModulePath> {
-        let mut p = std::path::PathBuf::default();
-
-        // Ensure that the new path is absolute.
-        if cfg!(target_os = "windows") {
-            p.push("c:\\");
-        } else {
-            p.push("/");
-        }
-
-        // Remove any affixed POSIX path separators, then split on any internal
-        // separators and add each component to our accumulator path in an
-        // OS-specific way.
-        for c in posix_path.trim_matches('/').split('/') {
-            p.push(c);
-        }
-
-        ModulePath::new(p)
     }
 
     fn cmd_cov_from_vec(data: Vec<(&ModulePath, Vec<(u32, u32)>)>) -> CommandBlockCov {

--- a/src/agent/coverage/src/block.rs
+++ b/src/agent/coverage/src/block.rs
@@ -550,24 +550,33 @@ mod tests {
         assert_eq!(total.covered_blocks(), total.difference(&empty));
         assert_eq!(total.difference(&total), 0);
 
-        let new: BlockCoverageReport = serde_json::from_value(json!({
-            some_dll.to_string(): [
-                { "offset": 2, "count": 0 },
-                { "offset": 22, "count": 4 },
-                { "offset": 30, "count": 5 },
-                { "offset": 400, "count": 6 },
-            ],
-            main_exe.to_string(): [
-                { "offset": 1, "count": 0 },
-                { "offset": 300, "count": 1 },
-                { "offset": 5000, "count": 0 },
-            ],
-            other_dll.to_string(): [
-                { "offset": 123, "count": 0 },
-                { "offset": 456, "count": 10 },
-            ],
-        }))?;
-        let new = CommandBlockCov::try_from(new)?;
+        let new: BlockCoverageReport = serde_json::from_value(json!([
+            {
+                "module": some_dll,
+                "blocks": [
+                    { "offset": 2, "count": 0 },
+                    { "offset": 22, "count": 4 },
+                    { "offset": 30, "count": 5 },
+                    { "offset": 400, "count": 6 },
+                ],
+            },
+            {
+                "module": main_exe,
+                "blocks": [
+                    { "offset": 1, "count": 0 },
+                    { "offset": 300, "count": 1 },
+                    { "offset": 5000, "count": 0 },
+                ],
+            },
+            {
+                "module": other_dll,
+                "blocks": [
+                    { "offset": 123, "count": 0 },
+                    { "offset": 456, "count": 10 },
+                ],
+            },
+        ]))?;
+        let new = CommandBlockCov::try_from_report(new)?;
 
         assert_eq!(new.known_blocks(), 9);
         assert_eq!(new.covered_blocks(), 5);

--- a/src/agent/coverage/src/block.rs
+++ b/src/agent/coverage/src/block.rs
@@ -493,17 +493,17 @@ mod tests {
             {
                 "module": some_dll,
                 "blocks": [
-                    {"offset": 2,"count": 0},
-                    {"offset": 30,"count": 1},
-                    {"offset": 400,"count": 0},
+                    { "offset": 2, "count": 0 },
+                    { "offset": 30, "count": 1 },
+                    { "offset": 400, "count": 0 },
                 ],
             },
             {
                 "module": main_exe,
                 "blocks": [
-                    {"offset": 1, "count": 1},
-                    {"offset": 20,"count": 0},
-                    {"offset": 300, "count": 1},
+                    { "offset": 1, "count": 1 },
+                    { "offset": 20, "count": 0 },
+                    { "offset": 300, "count": 1 },
                 ],
             },
         ]))?;

--- a/src/agent/coverage/src/lib.rs
+++ b/src/agent/coverage/src/lib.rs
@@ -20,3 +20,6 @@ pub mod disasm;
 
 pub mod filter;
 mod region;
+
+#[cfg(test)]
+mod test;

--- a/src/agent/coverage/src/lib.rs
+++ b/src/agent/coverage/src/lib.rs
@@ -13,6 +13,7 @@ pub mod block;
 pub mod cache;
 pub mod code;
 pub mod demangle;
+pub mod report;
 
 #[cfg(target_os = "linux")]
 pub mod disasm;

--- a/src/agent/coverage/src/report.rs
+++ b/src/agent/coverage/src/report.rs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+#[serde(transparent)]
+pub struct CoverageReport<C, M> {
+    pub(crate) entries: Vec<CoverageReportEntry<C, M>>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+pub struct CoverageReportEntry<C, M> {
+    pub(crate) module: String,
+
+    #[serde(flatten)]
+    pub(crate) metadata: M,
+
+    #[serde(flatten)]
+    pub(crate) coverage: C,
+}

--- a/src/agent/coverage/src/report.rs
+++ b/src/agent/coverage/src/report.rs
@@ -3,19 +3,42 @@
 
 use serde::{Deserialize, Serialize};
 
+/// Generic container for a code coverage report.
+///
+/// Coverage is reported as a sequence of module coverage entries, which are
+/// generic in a coverage type `C` and a metadata type `M`.
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
 #[serde(transparent)]
 pub struct CoverageReport<C, M> {
+    /// Coverage data for each module.
     pub(crate) entries: Vec<CoverageReportEntry<C, M>>,
 }
 
+/// A generic entry in a code coverage report.
+///
+/// `C` is the coverage type. It should have a field whose value is a map or
+/// sequence of instrumented sites and associated counters.
+///
+/// `M` is the metadata type. It should include additional data about the module
+/// itself. It enables tracking provenance and disambiguating modules when the
+/// `module` field is insufficient. Examples: module file checksums, process
+/// identifiers. If not desired, it may be set to `()`.
+///
+/// The types `C` and `M` must be structs with named fields, and should at least
+/// implement `Serialize` and `Deserialize`.
+///
+/// Warning: `serde` allows duplicate keys. If `M` and `C` share field names as
+/// structs, then the serialized entry will have duplicate keys.
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
 pub struct CoverageReportEntry<C, M> {
+    /// Path or name of the module.
     pub(crate) module: String,
 
+    /// Metadata to identify or contextualize the module.
     #[serde(flatten)]
     pub(crate) metadata: M,
 
+    /// Coverage data for the module.
     #[serde(flatten)]
     pub(crate) coverage: C,
 }

--- a/src/agent/coverage/src/report.rs
+++ b/src/agent/coverage/src/report.rs
@@ -42,3 +42,158 @@ pub struct CoverageReportEntry<C, M> {
     #[serde(flatten)]
     pub(crate) coverage: C,
 }
+
+#[cfg(test)]
+mod tests {
+    use anyhow::Result;
+    use serde_json::json;
+
+    use crate::test::module_path;
+
+    use super::*;
+
+    #[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+    struct Metadata {
+        checksum: String,
+        pid: u64,
+    }
+
+    #[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+    struct Edge {
+        edges: Vec<EdgeCov>,
+    }
+
+    #[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+    struct EdgeCov {
+        src: u32,
+        dst: u32,
+        count: u32,
+    }
+
+    // Example of using `CoverageReport` for alternative coverage types.
+    type EdgeCoverageReport = CoverageReport<Edge, Metadata>;
+
+    #[test]
+    fn test_coverage_report() -> Result<()> {
+        let main_exe = module_path("/onefuzz/main.exe")?;
+        let some_dll = module_path("/common/some.dll")?;
+
+        let text = serde_json::to_string(&json!([
+            {
+                "module": some_dll,
+                "checksum": "5feceb66",
+                "pid": 123,
+                "edges": [
+                    { "src": 10, "dst": 20, "count": 0 },
+                    { "src": 10, "dst": 30, "count": 1 },
+                    { "src": 30, "dst": 40, "count": 1 },
+                ],
+            },
+            {
+                "module": some_dll,
+                "checksum": "ffc86f38",
+                "pid": 456,
+                "edges": [
+                    { "src": 100, "dst": 200, "count": 1 },
+                    { "src": 200, "dst": 300, "count": 0 },
+                    { "src": 300, "dst": 400, "count": 0 },
+                ],
+            },
+            {
+                "module": main_exe,
+                "checksum": "d952786c",
+                "pid": 123,
+                "edges": [
+                    { "src": 1000, "dst": 2000, "count": 1 },
+                    { "src": 2000, "dst": 3000, "count": 0 },
+                ],
+            },
+        ]))?;
+
+        let report = EdgeCoverageReport {
+            entries: vec![
+                CoverageReportEntry {
+                    module: some_dll.to_string(),
+                    metadata: Metadata {
+                        checksum: "5feceb66".into(),
+                        pid: 123,
+                    },
+                    coverage: Edge {
+                        edges: vec![
+                            EdgeCov {
+                                src: 10,
+                                dst: 20,
+                                count: 0,
+                            },
+                            EdgeCov {
+                                src: 10,
+                                dst: 30,
+                                count: 1,
+                            },
+                            EdgeCov {
+                                src: 30,
+                                dst: 40,
+                                count: 1,
+                            },
+                        ],
+                    },
+                },
+                CoverageReportEntry {
+                    module: some_dll.to_string(),
+                    metadata: Metadata {
+                        checksum: "ffc86f38".into(),
+                        pid: 456,
+                    },
+                    coverage: Edge {
+                        edges: vec![
+                            EdgeCov {
+                                src: 100,
+                                dst: 200,
+                                count: 1,
+                            },
+                            EdgeCov {
+                                src: 200,
+                                dst: 300,
+                                count: 0,
+                            },
+                            EdgeCov {
+                                src: 300,
+                                dst: 400,
+                                count: 0,
+                            },
+                        ],
+                    },
+                },
+                CoverageReportEntry {
+                    module: main_exe.to_string(),
+                    metadata: Metadata {
+                        checksum: "d952786c".into(),
+                        pid: 123,
+                    },
+                    coverage: Edge {
+                        edges: vec![
+                            EdgeCov {
+                                src: 1000,
+                                dst: 2000,
+                                count: 1,
+                            },
+                            EdgeCov {
+                                src: 2000,
+                                dst: 3000,
+                                count: 0,
+                            },
+                        ],
+                    },
+                },
+            ],
+        };
+
+        let ser = serde_json::to_string(&report)?;
+        assert_eq!(ser, text);
+
+        let de: EdgeCoverageReport = serde_json::from_str(&text)?;
+        assert_eq!(de, report);
+
+        Ok(())
+    }
+}

--- a/src/agent/coverage/src/test.rs
+++ b/src/agent/coverage/src/test.rs
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use anyhow::Result;
+
+use crate::code::ModulePath;
+
+/// Given a POSIX-style path as a string, construct a valid absolute path for
+/// the target OS and return it as a checked `ModulePath`.
+pub fn module_path(posix_path: &str) -> Result<ModulePath> {
+    let mut p = std::path::PathBuf::default();
+
+    // Ensure that the new path is absolute.
+    if cfg!(target_os = "windows") {
+        p.push("c:\\");
+    } else {
+        p.push("/");
+    }
+
+    // Remove any affixed POSIX path separators, then split on any internal
+    // separators and add each component to our accumulator path in an
+    // OS-specific way.
+    for c in posix_path.trim_matches('/').split('/') {
+        p.push(c);
+    }
+
+    ModulePath::new(p)
+}


### PR DESCRIPTION
### Changes
- Redefine the coverage report format to be easily extensible
- Introduce a generic `CoverageReport` struct for coverage report serialization
- Implement runtime-recorded block coverage serialization via conversion into the former

Note: we internally maintain strong requirements on the `module` fields that OneFuzz will generate, but we have relaxed the serialization-level types. So, the type-encoded constraints we leverage at runtime (modules are named by `ModulePaths`, which are OS-specific absolute paths with filenames) must be checked when converting from a report to a runtime coverage map.

### Future work
The slight generalization here supports eventually defining custom coverage report formats like so:
```rust
#[derive(Serialize)]
struct Metadata {
    sha256: String,
    thread_name: String,
}
#[derive(Serialize)]
struct Edge {
    edges: Vec<EdgeCov>,
}
type EdgeCoverageReport = CoverageReport<Edge, Metadata>;
```
A serialized `EdgeCoverageReport` might then look like:
```json
[
    {
        "module": "/home/dev/fuzz.exe",
        "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
        "thread_name": "parser",
        "edges": [
            {
                "src": "0x6a0",
                "dst": "0x671",                
                "count": 1
            },
            {
                "src": "0xf0a",
                "dst": "0xf12",                
                "count": 0
            }
        ]
    }
]
```