### PR TITLE
Make field public for `CoverageReport` consumers

### DIFF
--- a/src/agent/coverage/src/block.rs
+++ b/src/agent/coverage/src/block.rs
@@ -142,7 +142,7 @@ pub type BlockCoverageReport = CoverageReport<Block, ()>;
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Block {
-    blocks: ModuleCov,
+    pub blocks: ModuleCov,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]


### PR DESCRIPTION
Allow consumers to stay consistent with the OneFuzz block coverage report format, but mutate reports if desired.