### PR TITLE
Add NoNewWork node command to tell free nodes to stop asking for new work

### DIFF
--- a/src/agent/onefuzz-supervisor/src/coordinator.rs
+++ b/src/agent/onefuzz-supervisor/src/coordinator.rs
@@ -25,7 +25,7 @@ pub enum NodeCommand {
     AddSshKey(SshKeyInfo),
     StopTask(StopTask),
     Stop {},
-    NoNewWork {},
+    StopIfFree {},
 }
 
 #[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]

--- a/src/agent/onefuzz-supervisor/src/coordinator.rs
+++ b/src/agent/onefuzz-supervisor/src/coordinator.rs
@@ -25,6 +25,7 @@ pub enum NodeCommand {
     AddSshKey(SshKeyInfo),
     StopTask(StopTask),
     Stop {},
+    NoNewWork {},
 }
 
 #[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]

--- a/src/agent/onefuzz-supervisor/src/scheduler.rs
+++ b/src/agent/onefuzz-supervisor/src/scheduler.rs
@@ -71,7 +71,7 @@ impl Scheduler {
                 };
                 *self = state.into();
             }
-            NodeCommand::NoNewWork {} => {
+            NodeCommand::StopIfFree {} => {
                 if let Scheduler::Free(_) = self {
                     let cause = DoneCause::Stopped;
                     let state = State {

--- a/src/agent/onefuzz-supervisor/src/scheduler.rs
+++ b/src/agent/onefuzz-supervisor/src/scheduler.rs
@@ -71,6 +71,15 @@ impl Scheduler {
                 };
                 *self = state.into();
             }
+            NodeCommand::NoNewWork {} => {
+                if let Scheduler::Free(_) = self {
+                    let cause = DoneCause::Stopped;
+                    let state = State {
+                        ctx: Done { cause },
+                    };
+                    *self = state.into();
+                }
+            }
         }
 
         Ok(())

--- a/src/api-service/__app__/onefuzzlib/versions.py
+++ b/src/api-service/__app__/onefuzzlib/versions.py
@@ -6,6 +6,7 @@
 import os
 from typing import Dict
 
+import semver
 from memoization import cached
 from onefuzztypes.responses import Version
 
@@ -29,3 +30,14 @@ def versions() -> Dict[str, Version]:
         version=__version__,
     )
     return {"onefuzz": entry}
+
+
+def is_minimum_version(*, version: str, minimum: str) -> bool:
+    # >>> is_minimum_version(version="1.0.0", minimum="1.0.0")
+    # True
+    # >>> is_minimum_version(version="1.0.1", minimum="1.0.0")
+    # True
+    # >>> is_minimum_version(version="1.0.0", minimum="1.0.1")
+    # False
+    # >>>
+    return bool(semver.compare(version, minimum) >= 0)

--- a/src/api-service/__app__/onefuzzlib/versions.py
+++ b/src/api-service/__app__/onefuzzlib/versions.py
@@ -33,11 +33,5 @@ def versions() -> Dict[str, Version]:
 
 
 def is_minimum_version(*, version: str, minimum: str) -> bool:
-    # >>> is_minimum_version(version="1.0.0", minimum="1.0.0")
-    # True
-    # >>> is_minimum_version(version="1.0.1", minimum="1.0.0")
-    # True
-    # >>> is_minimum_version(version="1.0.0", minimum="1.0.1")
-    # False
-    # >>>
-    return bool(semver.compare(version, minimum) >= 0)
+    # check if version is at least (or higher) than minimum
+    return bool(semver.VersionInfo.parse(version).compare(minimum) >= 0)

--- a/src/api-service/__app__/onefuzzlib/workers/nodes.py
+++ b/src/api-service/__app__/onefuzzlib/workers/nodes.py
@@ -20,7 +20,7 @@ from onefuzztypes.models import (
     NodeAssignment,
     NodeCommand,
     NodeCommandAddSshKey,
-    NodeCommandNoNewWork,
+    NodeCommandStopIfFree,
 )
 from onefuzztypes.models import NodeTasks as BASE_NODE_TASK
 from onefuzztypes.models import Result, StopNodeCommand, StopTaskNodeCommand
@@ -347,7 +347,7 @@ class Node(BASE_NODE, ORMMixin):
 
         # if we're going to reimage, make sure the node doesn't pick up new work
         # too.
-        self.send_no_new_work()
+        self.send_stop_if_free()
 
         self.save()
 
@@ -366,9 +366,9 @@ class Node(BASE_NODE, ORMMixin):
         )
         return None
 
-    def send_no_new_work(self) -> None:
+    def send_stop_if_free(self) -> None:
         if is_minimum_version(version=self.version, minimum="2.16.1"):
-            self.send_message(NodeCommand(no_new_work=NodeCommandNoNewWork()))
+            self.send_message(NodeCommand(stop_if_free=NodeCommandStopIfFree()))
 
     def stop(self, done: bool = False) -> None:
         self.to_reimage(done=done)

--- a/src/api-service/__app__/onefuzzlib/workers/nodes.py
+++ b/src/api-service/__app__/onefuzzlib/workers/nodes.py
@@ -364,7 +364,7 @@ class Node(BASE_NODE, ORMMixin):
         return None
 
     def send_no_new_work(self) -> None:
-        if is_minimum_version(version=self.version, minimum="2.15.0"):
+        if is_minimum_version(version=self.version, minimum="2.16.1"):
             self.send_message(NodeCommand(no_new_work=NodeCommandNoNewWork()))
 
     def stop(self, done: bool = False) -> None:

--- a/src/api-service/__app__/onefuzzlib/workers/nodes.py
+++ b/src/api-service/__app__/onefuzzlib/workers/nodes.py
@@ -345,7 +345,10 @@ class Node(BASE_NODE, ORMMixin):
             logging.info("setting reimage_requested: %s", self.machine_id)
             self.reimage_requested = True
 
+        # if we're going to reimage, make sure the node doesn't pick up new work
+        # too.
         self.send_no_new_work()
+
         self.save()
 
     def add_ssh_public_key(self, public_key: str) -> Result[None]:

--- a/src/api-service/__app__/onefuzzlib/workers/nodes.py
+++ b/src/api-service/__app__/onefuzzlib/workers/nodes.py
@@ -364,7 +364,7 @@ class Node(BASE_NODE, ORMMixin):
         return None
 
     def send_no_new_work(self) -> None:
-        if is_minimum_version(version=self.version, minimum="2.17.0"):
+        if is_minimum_version(version=self.version, minimum="2.15.0"):
             self.send_message(NodeCommand(no_new_work=NodeCommandNoNewWork()))
 
     def stop(self, done: bool = False) -> None:

--- a/src/api-service/__app__/onefuzzlib/workers/scalesets.py
+++ b/src/api-service/__app__/onefuzzlib/workers/scalesets.py
@@ -451,7 +451,7 @@ class Scaleset(BASE_SCALESET, ORMMixin):
 
         nodes = Node.search_states(scaleset_id=self.scaleset_id)
         for node in nodes:
-            node.send_no_new_work()
+            node.send_stop_if_free()
 
     def resize(self) -> None:
         # no longer needing to resize

--- a/src/api-service/__app__/onefuzzlib/workers/scalesets.py
+++ b/src/api-service/__app__/onefuzzlib/workers/scalesets.py
@@ -440,9 +440,18 @@ class Scaleset(BASE_SCALESET, ORMMixin):
         return
 
     def _resize_shrink(self, to_remove: int) -> None:
+        logging.info(
+            SCALESET_LOG_PREFIX + "shrinking scaleset. scaleset_id:%s to_remove:%d",
+            self.scaleset_id,
+            to_remove,
+        )
         queue = ScalesetShrinkQueue(self.scaleset_id)
         for _ in range(to_remove):
             queue.add_entry()
+
+        nodes = Node.search_states(scaleset_id=self.scaleset_id)
+        for node in nodes:
+            node.send_no_new_work()
 
     def resize(self) -> None:
         # no longer needing to resize

--- a/src/api-service/__app__/requirements.txt
+++ b/src/api-service/__app__/requirements.txt
@@ -30,5 +30,6 @@ memoization~=0.3.1
 github3.py~=1.3.0
 typing-extensions~=3.7.4.3
 jsonpatch==1.28
+semver==2.13.0
 # onefuzz types version is set during build
 onefuzztypes==0.0.0

--- a/src/api-service/mypy.ini
+++ b/src/api-service/mypy.ini
@@ -37,3 +37,6 @@ ignore_missing_imports = True
 
 [mypy-jsonpatch.*]
 ignore_missing_imports = True
+
+[mypy-semver.*]
+ignore_missing_imports = True

--- a/src/api-service/tests/test_version_check.py
+++ b/src/api-service/tests/test_version_check.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+#
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+import unittest
+
+from __app__.onefuzzlib.versions import is_minimum_version
+
+
+class TestMinVersion(unittest.TestCase):
+    def test_basic(self) -> None:
+        self.assertEqual(is_minimum_version(version="1.0.0", minimum="1.0.0"), True)
+        self.assertEqual(is_minimum_version(version="2.0.0", minimum="1.0.0"), True)
+        self.assertEqual(is_minimum_version(version="2.0.0", minimum="3.0.0"), False)
+        self.assertEqual(is_minimum_version(version="1.0.0", minimum="1.6.0"), False)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/pytypes/onefuzztypes/models.py
+++ b/src/pytypes/onefuzztypes/models.py
@@ -557,6 +557,10 @@ class NodeHeartbeatEntry(BaseModel):
     data: List[Dict[str, HeartbeatType]]
 
 
+class NodeCommandNoNewWork(BaseModel):
+    pass
+
+
 class StopNodeCommand(BaseModel):
     pass
 
@@ -573,6 +577,7 @@ class NodeCommand(EnumModel):
     stop: Optional[StopNodeCommand]
     stop_task: Optional[StopTaskNodeCommand]
     add_ssh_key: Optional[NodeCommandAddSshKey]
+    no_new_work: Optional[NodeCommandNoNewWork]
 
 
 class NodeCommandEnvelope(BaseModel):

--- a/src/pytypes/onefuzztypes/models.py
+++ b/src/pytypes/onefuzztypes/models.py
@@ -557,7 +557,7 @@ class NodeHeartbeatEntry(BaseModel):
     data: List[Dict[str, HeartbeatType]]
 
 
-class NodeCommandNoNewWork(BaseModel):
+class NodeCommandStopIfFree(BaseModel):
     pass
 
 
@@ -577,7 +577,7 @@ class NodeCommand(EnumModel):
     stop: Optional[StopNodeCommand]
     stop_task: Optional[StopTaskNodeCommand]
     add_ssh_key: Optional[NodeCommandAddSshKey]
-    no_new_work: Optional[NodeCommandNoNewWork]
+    stop_if_free: Optional[NodeCommandStopIfFree]
 
 
 class NodeCommandEnvelope(BaseModel):


### PR DESCRIPTION
Currently, there are two states that are non-obvious as to what happens next.

1. A free node is "out of date".  Right now, it will stay on the old version until it tries to launch a task, at which point the node will check "can I run this work".  When the node asks "can I run this work", the node is rejected and then moves into the reimage/delete state.
2. A free node is part of a shrinking scaleset.  Right now, it will wait until a task launch similar to the "out of date" node to start the shrinking.

This PR adds sending "no_new_work" command to Nodes which basically allows us to tell free nodes to stop.

NOTE:  The node command infra in the supervisor will fail badly if it receives an unsupported command.  As such, this includes "minimum supported version" support that gate sending the message such that we don't accidentally break nodes that are actively doing work.