### PR TITLE
fix build, remove unused reference to yaque

### DIFF
--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -40,12 +40,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b"
 
 [[package]]
-name = "anymap"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33954243bd79057c2de7338850b85983a44588021f8a5fee574a8888c6de4344"
-
-[[package]]
 name = "appinsights"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -796,17 +790,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ab7d1bd1bd33cc98b0889831b72da23c0aa4df9cec7e0702f46ecea04b35db6"
 dependencies = [
  "bitflags",
- "fsevent-sys 2.0.1",
-]
-
-[[package]]
-name = "fsevent"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97f347202c95c98805c216f9e1df210e8ebaec9fdb2365700a43c10797a35e63"
-dependencies = [
- "bitflags",
- "fsevent-sys 3.0.2",
+ "fsevent-sys",
 ]
 
 [[package]]
@@ -814,15 +798,6 @@ name = "fsevent-sys"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f41b048a94555da0f42f1d632e2e19510084fb8e303b0daa2816e733fb3644a0"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "fsevent-sys"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a29c77f1ca394c3e73a9a5d24cfcabb734682d9634fc398f2204a63c994120"
 dependencies = [
  "libc",
 ]
@@ -1273,17 +1248,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "inotify"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d19f57db1baad9d09e43a3cd76dcf82ebdafd37d75c9498b87762dba77c93f15"
-dependencies = [
- "bitflags",
- "inotify-sys",
- "libc",
-]
-
-[[package]]
 name = "inotify-sys"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1645,31 +1609,12 @@ checksum = "2599080e87c9bd051ddb11b10074f4da7b1223298df65d4c2ec5bcf309af1533"
 dependencies = [
  "bitflags",
  "filetime",
- "fsevent 0.4.0",
- "fsevent-sys 2.0.1",
- "inotify 0.7.1",
+ "fsevent",
+ "fsevent-sys",
+ "inotify",
  "libc",
  "mio 0.6.23",
  "mio-extras",
- "walkdir",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "notify"
-version = "5.0.0-pre.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebe7699a0f8c5759450716ee03d231685c22b4fe8f406c42c22e0ad94d40ce7"
-dependencies = [
- "anymap",
- "bitflags",
- "crossbeam-channel 0.5.1",
- "filetime",
- "fsevent 2.0.2",
- "fsevent-sys 3.0.2",
- "inotify 0.9.2",
- "libc",
- "mio 0.7.11",
  "walkdir",
  "winapi 0.3.9",
 ]
@@ -1738,7 +1683,7 @@ dependencies = [
  "lazy_static",
  "log",
  "nix 0.19.1",
- "notify 4.0.16",
+ "notify",
  "onefuzz-telemetry",
  "pete",
  "proc-maps",
@@ -1757,7 +1702,7 @@ dependencies = [
  "storage-queue",
  "strum",
  "strum_macros",
- "sysinfo 0.16.5",
+ "sysinfo",
  "tempfile",
  "tokio 1.5.0",
  "tokio-stream",
@@ -2753,7 +2698,6 @@ dependencies = [
  "serde_json",
  "tokio 1.5.0",
  "uuid",
- "yaque",
 ]
 
 [[package]]
@@ -2824,21 +2768,6 @@ dependencies = [
  "proc-macro2 1.0.26",
  "quote 1.0.9",
  "unicode-xid 0.2.1",
-]
-
-[[package]]
-name = "sysinfo"
-version = "0.14.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2983daff11a197c7c406b130579bc362177aa54cf2cc1f34d6ac88fccaa6a5e1"
-dependencies = [
- "cfg-if 0.1.10",
- "doc-comment",
- "libc",
- "ntapi",
- "once_cell",
- "rayon",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3472,20 +3401,6 @@ name = "xml-rs"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b07db065a5cf61a7e4ba64f29e67db906fb1787316516c4e6e5ff0fea1efcd8a"
-
-[[package]]
-name = "yaque"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "543707de19373df21757dc231c46407701d0b05a8067542584ea5c6fa8602725"
-dependencies = [
- "futures",
- "lazy_static",
- "log",
- "notify 5.0.0-pre.7",
- "rand 0.7.3",
- "sysinfo 0.14.15",
-]
 
 [[package]]
 name = "z3-sys"

--- a/src/agent/onefuzz-agent/Cargo.toml
+++ b/src/agent/onefuzz-agent/Cargo.toml
@@ -30,7 +30,7 @@ serde = "1.0"
 serde_json = "1.0"
 onefuzz = { path = "../onefuzz" }
 onefuzz-telemetry = { path = "../onefuzz-telemetry" }
-path-absolutize = "3.0.6"
+path-absolutize = "3.0.10"
 reqwest-retry = { path = "../reqwest-retry" }
 stacktrace-parser = { path = "../stacktrace-parser" }
 storage-queue = { path = "../storage-queue" }

--- a/src/agent/storage-queue/Cargo.toml
+++ b/src/agent/storage-queue/Cargo.toml
@@ -24,4 +24,3 @@ serde-xml-rs = "0.4"
 tokio = { version = "1.5.0" , features=["full"] }
 queue-file = "1.1"
 uuid = { version = "0.8", features = ["serde", "v4"] }
-yaque = "0.5.1"


### PR DESCRIPTION
yaque is causing a cargo audit failure. The PR removes the dependency because it is not needed