### PR TITLE
only run CodeQL on `main`

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -3,9 +3,6 @@ name: "CodeQL"
 on:
   push:
     branches: [ main ]
-  pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ main ]
   schedule:
     - cron: '29 3 * * 0'
 


### PR DESCRIPTION
Right now, we're running CodeQL analysis on every PR.  Since the alerts get fed into the `Security` pane in GitHub rather than breaking builds, we don't need to tie this to every build.