### PR TITLE
Updating default VM_SKU on request. 

### DIFF
--- a/src/cli/onefuzz/api.py
+++ b/src/cli/onefuzz/api.py
@@ -1276,7 +1276,7 @@ class Scaleset(Endpoint):
         size: int,
         *,
         image: Optional[str] = None,
-        vm_sku: Optional[str] = "Standard_D2s_v3",
+        vm_sku: Optional[str] = "Standard_D4s_v3",
         region: Optional[primitives.Region] = None,
         spot_instances: bool = False,
         ephemeral_os_disks: bool = False,

--- a/src/cli/onefuzz/templates/ossfuzz.py
+++ b/src/cli/onefuzz/templates/ossfuzz.py
@@ -18,7 +18,7 @@ from onefuzz.backend import container_file_path
 
 from . import JobHelper
 
-VM_SKU = "Standard_D2s_v3"
+VM_SKU = "Standard_D4s_v3"
 VM_COUNT = 1
 
 


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_
A developer requested we update the default CLI value for VM_SKU to Standard_D4s_v3, as this SKU can more efficiently use 4 cores to run standard jobs - esp. libfuzzer jobs. 

## PR Checklist
* [ ] Applies to work item: #xxx
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/onefuzz) and sign the CLI.
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_
Changed files:
- modified:   src/cli/onefuzz/api.py
- modified:   src/cli/onefuzz/templates/ossfuzz.py
Updating default value to new Standard. 

## Validation Steps Performed

_How does someone test & validate?_
Integration tests. 