### PR TITLE
handle issue from azure-mgmt-resource 17.0.0 upgrade

### DIFF
--- a/src/api-service/__app__/onefuzzlib/azure/creds.py
+++ b/src/api-service/__app__/onefuzzlib/azure/creds.py
@@ -3,6 +3,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+import json
 import os
 from typing import Any, List
 from uuid import UUID
@@ -130,7 +131,19 @@ def get_scaleset_principal_id() -> UUID:
         credential=get_identity(), subscription_id=get_subscription()
     )
     uid = client.resources.get_by_id(get_scaleset_identity_resource_path(), api_version)
-    return UUID(uid.properties["principalId"])
+
+    # workaround issue from azure-mgmt-resource, where properties is now a str
+    # instead of an obj.
+    # https://github.com/Azure/azure-sdk-for-python/pull/18686/files
+    if isinstance(uid.properties, str):
+        as_str = uid.properties
+        if as_str.startswith("{'"):
+            as_str = as_str.replace("'", '"')
+        prop = json.loads(as_str)
+    else:
+        prop = uid.properties
+
+    return UUID(prop["principalId"])
 
 
 @cached


### PR DESCRIPTION
In azure-mgmt-resource 17.0.0, the resources.get_by_id().properties is now a string, rather than a dict.

In practice, it's not a json string (uses single quotes rather than double quotes).  This converts the quotes & uses json to decode it.

For example, in practice, the value is: "{'tenantId': 'GUID', 'principalId': 'GUID', 'clientId': 'GUID'}