### PR TITLE
Add setup arguments to enable specifying alt tenants on the CLI

### DIFF
--- a/src/cli/onefuzz/api.py
+++ b/src/cli/onefuzz/api.py
@@ -1525,9 +1525,22 @@ class Onefuzz:
 
         self.__setup__()
 
-    def __setup__(self, endpoint: Optional[str] = None) -> None:
+    def __setup__(
+        self,
+        endpoint: Optional[str] = None,
+        client_id: Optional[str] = None,
+        authority: Optional[str] = None,
+        tenant_domain: Optional[str] = None,
+    ) -> None:
+
         if endpoint:
             self._backend.config.endpoint = endpoint
+        if authority is not None:
+            self._backend.config.authority = authority
+        if client_id is not None:
+            self._backend.config.client_id = client_id
+        if tenant_domain is not None:
+            self._backend.config.tenant_domain = tenant_domain
 
         if self._backend.is_feature_enabled(PreviewFeature.job_templates.name):
             self.job_templates._load_cache()


### PR DESCRIPTION
This enables specifying the endpoint configuration for alternate tenants purely on the command line.

Previously, on a single tenant you could use the following:
```
onefuzz --endpoint https://INSTANCE.azurewebsites.net info get
```

For multi-tenant installs, we need to expose more than just endpoint.

This enables:
```
onefuzz --endpoint https://INSTANCE.azurewebsites.net --client_id CLIENT_ID  --authority https://login.microsoftonline.com/common --tenant_domain TENANT_DOMAIN info get
```