### PR TITLE
simplify long-life proxy cleanup

### DIFF
--- a/docs/webhook_events.md
+++ b/docs/webhook_events.md
@@ -37,6 +37,7 @@ Each event will be submitted via HTTP POST to the user provided URL.
 * [proxy_created](#proxy_created)
 * [proxy_deleted](#proxy_deleted)
 * [proxy_failed](#proxy_failed)
+* [proxy_state_updated](#proxy_state_updated)
 * [regression_reported](#regression_reported)
 * [scaleset_created](#scaleset_created)
 * [scaleset_deleted](#scaleset_deleted)
@@ -1407,6 +1408,61 @@ Each event will be submitted via HTTP POST to the user provided URL.
         "error"
     ],
     "title": "EventProxyFailed",
+    "type": "object"
+}
+```
+
+### proxy_state_updated
+
+#### Example
+
+```json
+{
+    "proxy_id": "00000000-0000-0000-0000-000000000000",
+    "region": "eastus",
+    "state": "init"
+}
+```
+
+#### Schema
+
+```json
+{
+    "definitions": {
+        "VmState": {
+            "description": "An enumeration.",
+            "enum": [
+                "init",
+                "extensions_launch",
+                "extensions_failed",
+                "vm_allocation_failed",
+                "running",
+                "stopping",
+                "stopped"
+            ],
+            "title": "VmState"
+        }
+    },
+    "properties": {
+        "proxy_id": {
+            "format": "uuid",
+            "title": "Proxy Id",
+            "type": "string"
+        },
+        "region": {
+            "title": "Region",
+            "type": "string"
+        },
+        "state": {
+            "$ref": "#/definitions/VmState"
+        }
+    },
+    "required": [
+        "region",
+        "proxy_id",
+        "state"
+    ],
+    "title": "EventProxyStateUpdated",
     "type": "object"
 }
 ```
@@ -4963,6 +5019,29 @@ Each event will be submitted via HTTP POST to the user provided URL.
             "title": "EventProxyFailed",
             "type": "object"
         },
+        "EventProxyStateUpdated": {
+            "properties": {
+                "proxy_id": {
+                    "format": "uuid",
+                    "title": "Proxy Id",
+                    "type": "string"
+                },
+                "region": {
+                    "title": "Region",
+                    "type": "string"
+                },
+                "state": {
+                    "$ref": "#/definitions/VmState"
+                }
+            },
+            "required": [
+                "region",
+                "proxy_id",
+                "state"
+            ],
+            "title": "EventProxyStateUpdated",
+            "type": "object"
+        },
         "EventRegressionReported": {
             "properties": {
                 "container": {
@@ -5248,6 +5327,7 @@ Each event will be submitted via HTTP POST to the user provided URL.
                 "proxy_created",
                 "proxy_deleted",
                 "proxy_failed",
+                "proxy_state_updated",
                 "scaleset_created",
                 "scaleset_deleted",
                 "scaleset_failed",
@@ -5858,6 +5938,19 @@ Each event will be submitted via HTTP POST to the user provided URL.
             },
             "title": "UserInfo",
             "type": "object"
+        },
+        "VmState": {
+            "description": "An enumeration.",
+            "enum": [
+                "init",
+                "extensions_launch",
+                "extensions_failed",
+                "vm_allocation_failed",
+                "running",
+                "stopping",
+                "stopped"
+            ],
+            "title": "VmState"
         }
     },
     "properties": {
@@ -5898,6 +5991,9 @@ Each event will be submitted via HTTP POST to the user provided URL.
                 },
                 {
                     "$ref": "#/definitions/EventProxyDeleted"
+                },
+                {
+                    "$ref": "#/definitions/EventProxyStateUpdated"
                 },
                 {
                     "$ref": "#/definitions/EventScalesetFailed"

--- a/src/api-service/__app__/onefuzzlib/proxy.py
+++ b/src/api-service/__app__/onefuzzlib/proxy.py
@@ -9,6 +9,7 @@ import os
 from typing import List, Optional, Tuple
 from uuid import UUID, uuid4
 
+import base58
 from azure.mgmt.compute.models import VirtualMachine
 from onefuzztypes.enums import ErrorCode, VmState
 from onefuzztypes.events import (
@@ -69,7 +70,7 @@ class Proxy(ORMMixin):
 
     def get_vm(self) -> VM:
         vm = VM(
-            name="proxy-%s-%s" % (self.region, self.proxy_id),
+            name="proxy-%s" % base58.b58encode(self.proxy_id.bytes).decode(),
             region=self.region,
             sku=PROXY_SKU,
             image=PROXY_IMAGE,

--- a/src/api-service/__app__/onefuzzlib/proxy.py
+++ b/src/api-service/__app__/onefuzzlib/proxy.py
@@ -11,7 +11,12 @@ from uuid import UUID, uuid4
 
 from azure.mgmt.compute.models import VirtualMachine
 from onefuzztypes.enums import ErrorCode, VmState
-from onefuzztypes.events import EventProxyCreated, EventProxyDeleted, EventProxyFailed
+from onefuzztypes.events import (
+    EventProxyCreated,
+    EventProxyDeleted,
+    EventProxyFailed,
+    EventProxyStateUpdated,
+)
 from onefuzztypes.models import (
     Authentication,
     Error,
@@ -81,7 +86,7 @@ class Proxy(ORMMixin):
                 return
             else:
                 self.save_proxy_config()
-                self.state = VmState.extensions_launch
+                self.set_state(VmState.extensions_launch)
         else:
             result = vm.create()
             if isinstance(result, Error):
@@ -115,8 +120,7 @@ class Proxy(ORMMixin):
             EventProxyFailed(region=self.region, proxy_id=self.proxy_id, error=error)
         )
         self.error = error
-        self.state = VmState.stopping
-        self.save()
+        self.set_state(VmState.stopping)
 
     def extensions_launch(self) -> None:
         vm = self.get_vm()
@@ -146,7 +150,7 @@ class Proxy(ORMMixin):
             self.set_failed(result)
             return
         elif result:
-            self.state = VmState.running
+            self.set_state(VmState.running)
 
         self.save()
 
@@ -164,6 +168,9 @@ class Proxy(ORMMixin):
         self.delete()
 
     def is_outdated(self) -> bool:
+        if self.state not in VmState.available():
+            return True
+
         if self.version != __version__:
             logging.info(
                 PROXY_LOG_PREFIX + "mismatch version: proxy:%s service:%s state:%s",
@@ -298,3 +305,16 @@ class Proxy(ORMMixin):
     def delete(self) -> None:
         super().delete()
         send_event(EventProxyDeleted(region=self.region, proxy_id=self.proxy_id))
+
+    def set_state(self, state: VmState) -> None:
+        if self.state == state:
+            return
+
+        self.state = state
+        self.save()
+
+        send_event(
+            EventProxyStateUpdated(
+                region=self.region, proxy_id=self.proxy_id, state=self.state
+            )
+        )

--- a/src/api-service/__app__/proxy/__init__.py
+++ b/src/api-service/__app__/proxy/__init__.py
@@ -92,8 +92,7 @@ def patch(req: func.HttpRequest) -> func.HttpResponse:
 
     proxy = Proxy.get(request.region)
     if proxy is not None:
-        proxy.state = VmState.stopping
-        proxy.save()
+        proxy.set_state(VmState.stopping)
         return ok(BoolResult(result=True))
 
     return ok(BoolResult(result=False))

--- a/src/api-service/__app__/requirements.txt
+++ b/src/api-service/__app__/requirements.txt
@@ -33,3 +33,4 @@ jsonpatch==1.28
 semver==2.13.0
 # onefuzz types version is set during build
 onefuzztypes==0.0.0
+base58==2.1.0

--- a/src/api-service/__app__/timer_daily/__init__.py
+++ b/src/api-service/__app__/timer_daily/__init__.py
@@ -6,44 +6,13 @@
 import logging
 
 import azure.functions as func
-from onefuzztypes.enums import VmState
-from onefuzztypes.events import EventProxyCreated
 
-from ..onefuzzlib.events import get_events, send_event
-from ..onefuzzlib.proxy import Proxy
+from ..onefuzzlib.events import get_events
 from ..onefuzzlib.webhooks import WebhookMessageLog
 from ..onefuzzlib.workers.scalesets import Scaleset
 
 
 def main(mytimer: func.TimerRequest, dashboard: func.Out[str]) -> None:  # noqa: F841
-    proxy_list = Proxy.search()
-    # Marking Outdated Proxies. Subsequently, shutting down Outdated & Unused Proxies.
-    for proxy in proxy_list:
-        if proxy.is_outdated():
-            logging.info("marking proxy in %s as outdated.", proxy.region)
-            proxy.outdated = True
-            proxy.save()
-    # Creating a new proxy if no proxy exists for a given region.
-    for proxy in proxy_list:
-        if proxy.outdated:
-            region_list = list(
-                filter(
-                    lambda x: (x.region == proxy.region and not x.outdated),
-                    proxy_list,
-                )
-            )
-            if not len(region_list):
-                logging.info("outdated proxy in %s, creating new one.", proxy.region)
-                new_proxy = Proxy(region=proxy.region)
-                new_proxy.save()
-                send_event(
-                    EventProxyCreated(region=proxy.region, proxy_id=proxy.proxy_id)
-                )
-            if not proxy.is_used():
-                logging.info("stopping one proxy in %s.", proxy.region)
-                proxy.state = VmState.stopping
-                proxy.save()
-
     scalesets = Scaleset.search()
     for scaleset in scalesets:
         logging.info("updating scaleset configs: %s", scaleset.scaleset_id)

--- a/src/api-service/__app__/timer_proxy/__init__.py
+++ b/src/api-service/__app__/timer_proxy/__init__.py
@@ -11,18 +11,25 @@ from onefuzztypes.enums import VmState
 from ..onefuzzlib.events import get_events
 from ..onefuzzlib.orm import process_state_updates
 from ..onefuzzlib.proxy import PROXY_LOG_PREFIX, Proxy
+from ..onefuzzlib.workers.scalesets import Scaleset
 
 
 def main(mytimer: func.TimerRequest, dashboard: func.Out[str]) -> None:  # noqa: F841
-    # Reminder, proxies are created on-demand.  If something is "wrong" with
-    # a proxy, the plan is: delete and recreate it.
-    for proxy in Proxy.search():
+    proxies = Proxy.search()
+    for proxy in proxies:
+        # Note, outdated checked at the start, but set at the end of this loop.
+        # As this function is called via a timer, this works around a user
+        # requesting to use the proxy while this function is checking if it's
+        # out of date
+        if proxy.outdated and not proxy.is_used():
+            proxy.set_state(VmState.stopping)
+
+        # If something is "wrong" with a proxy, delete & recreate it
         if not proxy.is_alive():
             logging.error(
                 PROXY_LOG_PREFIX + "alive check failed, stopping: %s", proxy.region
             )
-            proxy.state = VmState.stopping
-            proxy.save()
+            proxy.set_state(VmState.stopping)
         else:
             proxy.save_proxy_config()
 
@@ -33,6 +40,17 @@ def main(mytimer: func.TimerRequest, dashboard: func.Out[str]) -> None:  # noqa:
                 proxy.state,
             )
             process_state_updates(proxy)
+
+        if proxy.is_outdated():
+            proxy.outdated = True
+            proxy.save()
+
+    # make sure there is a proxy for every currently active region
+    scalesets = Scaleset.search()
+    regions = set(x.region for x in scalesets)
+    for region in regions:
+        if not any(not x.outdated for x in proxies if x.region == region):
+            Proxy.get_or_create(region)
 
     events = get_events()
     if events:

--- a/src/pytypes/extra/generate-docs.py
+++ b/src/pytypes/extra/generate-docs.py
@@ -16,6 +16,7 @@ from onefuzztypes.enums import (
     ScalesetState,
     TaskState,
     TaskType,
+    VmState,
 )
 from onefuzztypes.events import (
     Event,
@@ -33,6 +34,7 @@ from onefuzztypes.events import (
     EventProxyCreated,
     EventProxyDeleted,
     EventProxyFailed,
+    EventProxyStateUpdated,
     EventRegressionReported,
     EventScalesetCreated,
     EventScalesetDeleted,
@@ -162,6 +164,11 @@ def main() -> None:
             region=Region("eastus"),
             proxy_id=UUID(int=0),
             error=Error(code=ErrorCode.PROXY_FAILED, errors=["example error message"]),
+        ),
+        EventProxyStateUpdated(
+            region=Region("eastus"),
+            proxy_id=UUID(int=0),
+            state=VmState.init,
         ),
         EventPoolCreated(
             pool_name=PoolName("example"),

--- a/src/pytypes/onefuzztypes/events.py
+++ b/src/pytypes/onefuzztypes/events.py
@@ -10,7 +10,15 @@ from uuid import UUID, uuid4
 
 from pydantic import BaseModel, Field
 
-from .enums import OS, Architecture, NodeState, ScalesetState, TaskState, TaskType
+from .enums import (
+    OS,
+    Architecture,
+    NodeState,
+    ScalesetState,
+    TaskState,
+    TaskType,
+    VmState,
+)
 from .models import (
     AutoScaleConfig,
     Error,
@@ -124,6 +132,12 @@ class EventProxyCreated(BaseEvent):
     proxy_id: Optional[UUID]
 
 
+class EventProxyStateUpdated(BaseEvent):
+    region: Region
+    proxy_id: UUID
+    state: VmState
+
+
 class EventProxyDeleted(BaseEvent):
     region: Region
     proxy_id: Optional[UUID]
@@ -198,6 +212,7 @@ Event = Union[
     EventProxyFailed,
     EventProxyCreated,
     EventProxyDeleted,
+    EventProxyStateUpdated,
     EventScalesetFailed,
     EventScalesetCreated,
     EventScalesetDeleted,
@@ -225,6 +240,7 @@ class EventType(Enum):
     proxy_created = "proxy_created"
     proxy_deleted = "proxy_deleted"
     proxy_failed = "proxy_failed"
+    proxy_state_updated = "proxy_state_updated"
     scaleset_created = "scaleset_created"
     scaleset_deleted = "scaleset_deleted"
     scaleset_failed = "scaleset_failed"
@@ -251,6 +267,7 @@ EventTypeMap = {
     EventType.pool_created: EventPoolCreated,
     EventType.pool_deleted: EventPoolDeleted,
     EventType.proxy_created: EventProxyCreated,
+    EventType.proxy_state_updated: EventProxyStateUpdated,
     EventType.proxy_deleted: EventProxyDeleted,
     EventType.proxy_failed: EventProxyFailed,
     EventType.scaleset_created: EventScalesetCreated,


### PR DESCRIPTION
After merging #839 , I hit a race condition where I created proxy session while the proxy was being shut down.

This PR addresses this race condition by
1. unifies all of the proxy state actuation into timer_proxy rather than two distinct timer functions.
2. sets outdated at the end of the timer_proxy function, and checks during the next iteration (30s later).

Additionally, this works addresses another issue I had not seen during the review of #839 but noticed upon handling the above issue.  Currently, an up-to-date proxy is always maintained for any region a proxy has been created.  If the worker VMs all move from eastus to eastus2, we don't need to continue to manage proxies in eastus.

This PR also includes EventProxyStateUpdated, which adds in debugging this aforementioned issue.

This PR also changes the VM names for proxies to be `proxy-<base58(proxy_id)>` to handle the automatic disk name generation limits.  Otherwise, disk names are truncated from the VM names and never get deleted.