### PR TITLE
encode proxy name as base58 to allow full deletion of resources

### DIFF
--- a/src/api-service/__app__/onefuzzlib/azure/vm.py
+++ b/src/api-service/__app__/onefuzzlib/azure/vm.py
@@ -220,6 +220,8 @@ class VM(BaseModel):
     def check_name(cls, value: Union[UUID, str]) -> Union[UUID, str]:
         if isinstance(value, str):
             if len(value) > 40:
+                # Azure truncates resources if the names are longer than 40
+                # bytes
                 raise ValueError("VM name too long")
         return value
 

--- a/src/api-service/__app__/onefuzzlib/azure/vm.py
+++ b/src/api-service/__app__/onefuzzlib/azure/vm.py
@@ -14,7 +14,7 @@ from msrestazure.azure_exceptions import CloudError
 from onefuzztypes.enums import OS, ErrorCode
 from onefuzztypes.models import Authentication, Error
 from onefuzztypes.primitives import Extension, Region
-from pydantic import BaseModel
+from pydantic import BaseModel, validator
 
 from .compute import get_compute_client
 from .creds import get_base_resource_group
@@ -215,6 +215,13 @@ class VM(BaseModel):
     sku: str
     image: str
     auth: Authentication
+
+    @validator("name", allow_reuse=True)
+    def check_name(cls, value: Union[UUID, str]) -> Union[UUID, str]:
+        if isinstance(value, str):
+            if len(value) > 40:
+                raise ValueError("VM name too long")
+        return value
 
     def is_deleted(self) -> bool:
         # A VM is considered deleted once all of it's resources including disks,

--- a/src/api-service/__app__/onefuzzlib/proxy.py
+++ b/src/api-service/__app__/onefuzzlib/proxy.py
@@ -65,7 +65,7 @@ class Proxy(ORMMixin):
 
     def get_vm(self) -> VM:
         vm = VM(
-            name="proxy-%s" % base58.b58encode(self.proxy_id).decode(),
+            name="proxy-%s" % base58.b58encode(self.proxy_id.bytes).decode(),
             region=self.region,
             sku=PROXY_SKU,
             image=PROXY_IMAGE,

--- a/src/api-service/__app__/onefuzzlib/proxy.py
+++ b/src/api-service/__app__/onefuzzlib/proxy.py
@@ -9,6 +9,7 @@ import os
 from typing import List, Optional, Tuple
 from uuid import UUID, uuid4
 
+import base58
 from azure.mgmt.compute.models import VirtualMachine
 from onefuzztypes.enums import ErrorCode, VmState
 from onefuzztypes.events import EventProxyCreated, EventProxyDeleted, EventProxyFailed
@@ -64,7 +65,7 @@ class Proxy(ORMMixin):
 
     def get_vm(self) -> VM:
         vm = VM(
-            name="proxy-%s-%s" % (self.region, self.proxy_id),
+            name="proxy-%s" % base58.b58encode(self.proxy_id).decode(),
             region=self.region,
             sku=PROXY_SKU,
             image=PROXY_IMAGE,

--- a/src/api-service/__app__/requirements.txt
+++ b/src/api-service/__app__/requirements.txt
@@ -31,5 +31,6 @@ github3.py~=1.3.0
 typing-extensions~=3.7.4.3
 jsonpatch==1.28
 semver==2.13.0
+base58==2.1.0
 # onefuzz types version is set during build
 onefuzztypes==0.0.0


### PR DESCRIPTION
As is, the proxy name gets truncated when turned into the disk name.
This prevents the resource cleanup from completion.