### PR TITLE
explain key=value argument parsing failures

### DIFF
--- a/src/cli/onefuzz/cli.py
+++ b/src/cli/onefuzz/cli.py
@@ -303,6 +303,13 @@ class Builder:
             ) -> None:
                 if values is None:
                     return
+
+                for arg in values:
+                    if "=" not in arg:
+                        raise argparse.ArgumentTypeError(
+                            "unable to parse value as a key=value pair: %s" % repr(arg)
+                        )
+
                 as_dict: Dict[str, str] = {
                     key_arg(k): val_arg(v) for k, v in (x.split("=", 1) for x in values)
                 }


### PR DESCRIPTION
As demonstrated in #906, failures in parsing key-value options is not obvious.  This explains the failure in a slightly less obtuse fashion.