### PR TITLE
Catch argparse type errors

### DIFF
--- a/src/cli/onefuzz/cli.py
+++ b/src/cli/onefuzz/cli.py
@@ -524,7 +524,11 @@ def execute_api(api: Any, api_types: List[Any], version: str) -> int:
     builder = Builder(api_types)
     builder.add_version(version)
     builder.parse_api(api)
-    args = builder.parse_args()
+    try:
+        args = builder.parse_args()
+    except argparse.ArgumentTypeError as err:
+        LOGGER.error("unable to parse arguments: %s", err)
+        return 1
 
     if args.verbose == 0:
         logging.basicConfig(level=logging.WARNING)

--- a/src/cli/onefuzz/cli.py
+++ b/src/cli/onefuzz/cli.py
@@ -303,6 +303,13 @@ class Builder:
             ) -> None:
                 if values is None:
                     return
+
+                for arg in values:
+                    if "=" not in arg:
+                        raise argparse.ArgumentTypeError(
+                            "unable to parse value as a key=value pair: %s" % repr(arg)
+                        )
+
                 as_dict: Dict[str, str] = {
                     key_arg(k): val_arg(v) for k, v in (x.split("=", 1) for x in values)
                 }


### PR DESCRIPTION
Catch argparse argument type errors and display them in a simplified fashion.

As an example, this is how the output is rendered.
```
❯ onefuzz template libfuzzer basic --target_env  ASAN_OPTIONS=allocator_may_return_null=1 a a a linux
unable to parse arguments: unable to parse value as a key=value pair: 'a'   
❯
```

Note, this builds upon #910.  