### PR TITLE
Add timeout when recording Linux coverage

### DIFF
--- a/src/agent/coverage/src/block/linux.rs
+++ b/src/agent/coverage/src/block/linux.rs
@@ -40,7 +40,7 @@ impl<'c> Recorder<'c> {
         let mut tracer = Ptracer::new();
         let mut child = tracer.spawn(cmd)?;
 
-        let timer = Timer::new(timeout, move || child.kill());
+        let _timer = Timer::new(timeout, move || child.kill());
 
         let recorder = Recorder {
             breakpoints: Breakpoints::default(),
@@ -53,8 +53,6 @@ impl<'c> Recorder<'c> {
         };
 
         let coverage = recorder.wait()?;
-
-        timer.cancel();
 
         Ok(coverage)
     }
@@ -409,7 +407,7 @@ fn continue_to_init_execve(tracer: &mut Ptracer) -> Result<Tracee> {
 
 const MAX_POLL_PERIOD: Duration = Duration::from_millis(100);
 
-struct Timer {
+pub struct Timer {
     sender: mpsc::Sender<()>,
     _handle: thread::JoinHandle<()>,
 }

--- a/src/agent/coverage/src/block/linux.rs
+++ b/src/agent/coverage/src/block/linux.rs
@@ -5,6 +5,9 @@ use std::collections::BTreeMap;
 use std::convert::TryInto;
 use std::ffi::OsStr;
 use std::process::Command;
+use std::sync::mpsc;
+use std::thread;
+use std::time::{Duration, Instant};
 
 use anyhow::{format_err, Context, Result};
 use pete::{Ptracer, Restart, Signal, Stop, Tracee};
@@ -16,14 +19,6 @@ use crate::code::{CmdFilter, ModulePath};
 use crate::demangle::Demangler;
 use crate::region::Region;
 
-pub fn record(cmd: Command) -> Result<CommandBlockCov> {
-    let mut cache = ModuleCache::default();
-    let filter = CmdFilter::default();
-    let mut recorder = Recorder::new(&mut cache, filter);
-    recorder.record(cmd)?;
-    Ok(recorder.into_coverage())
-}
-
 #[derive(Debug)]
 pub struct Recorder<'c> {
     breakpoints: Breakpoints,
@@ -32,40 +27,47 @@ pub struct Recorder<'c> {
     demangler: Demangler,
     filter: CmdFilter,
     images: Option<Images>,
+    tracer: Ptracer,
+    tracee: Tracee,
 }
 
 impl<'c> Recorder<'c> {
-    pub fn new(cache: &'c mut ModuleCache, filter: CmdFilter) -> Self {
-        Self {
+    pub fn record(
+        cmd: Command,
+        timeout: Duration,
+        cache: &'c mut ModuleCache,
+        filter: CmdFilter,
+    ) -> Result<CommandBlockCov> {
+        let mut tracer = Ptracer::new();
+        let mut child = tracer.spawn(cmd)?;
+
+        let timer = Timer::new(timeout, move || child.kill());
+
+        // Continue the tracee process until the return from its initial `execve()`.
+        let tracee = continue_to_init_execve(&mut tracer)?;
+
+        let recorder = Recorder {
             breakpoints: Breakpoints::default(),
             cache,
             coverage: CommandBlockCov::default(),
             demangler: Demangler::default(),
             filter,
             images: None,
-        }
+            tracer,
+            tracee,
+        };
+
+        let coverage = recorder.wait()?;
+
+        timer.cancel();
+
+        Ok(coverage)
     }
 
-    pub fn coverage(&self) -> &CommandBlockCov {
-        &self.coverage
-    }
-
-    pub fn into_coverage(self) -> CommandBlockCov {
-        self.coverage
-    }
-
-    pub fn module_cache(&self) -> &ModuleCache {
-        self.cache
-    }
-
-    pub fn record(&mut self, cmd: Command) -> Result<()> {
+    fn wait(mut self) -> Result<CommandBlockCov> {
         use pete::ptracer::Options;
 
-        let mut tracer = Ptracer::new();
-        let _child = tracer.spawn(cmd)?;
-
-        // Continue the tracee process until the return from its initial `execve()`.
-        let mut tracee = continue_to_init_execve(&mut tracer)?;
+        let mut tracee = self.tracee;
 
         // Do not follow forks.
         //
@@ -80,9 +82,9 @@ impl<'c> Recorder<'c> {
         self.images = Some(Images::new(tracee.pid.as_raw()));
         self.update_images(&mut tracee)?;
 
-        tracer.restart(tracee, Restart::Syscall)?;
+        self.tracer.restart(tracee, Restart::Syscall)?;
 
-        while let Some(mut tracee) = tracer.wait()? {
+        while let Some(mut tracee) = self.tracer.wait()? {
             match tracee.stop {
                 Stop::SyscallEnterStop(..) => log::trace!("syscall-enter: {:?}", tracee.stop),
                 Stop::SyscallExitStop(..) => {
@@ -100,12 +102,12 @@ impl<'c> Recorder<'c> {
                 }
             }
 
-            if let Err(err) = tracer.restart(tracee, Restart::Syscall) {
+            if let Err(err) = self.tracer.restart(tracee, Restart::Syscall) {
                 log::error!("unable to restart tracee: {}", err);
             }
         }
 
-        Ok(())
+        Ok(self.coverage)
     }
 
     fn update_images(&mut self, tracee: &mut Tracee) -> Result<()> {
@@ -407,4 +409,53 @@ fn continue_to_init_execve(tracer: &mut Ptracer) -> Result<Tracee> {
     }
 
     anyhow::bail!("did not see initial execve() in tracee while recording coverage");
+}
+
+const MAX_POLL_PERIOD: Duration = Duration::from_millis(100);
+
+struct Timer {
+    sender: mpsc::Sender<()>,
+    _handle: thread::JoinHandle<()>,
+}
+
+impl Timer {
+    pub fn new<F, T>(timeout: Duration, on_timeout: F) -> Self
+    where
+        F: FnOnce() -> T + Send + 'static,
+    {
+        let (sender, receiver) = std::sync::mpsc::channel();
+
+        let _handle = thread::spawn(move || {
+            let poll_period = Duration::min(timeout, MAX_POLL_PERIOD);
+            let start = Instant::now();
+
+            while start.elapsed() < timeout {
+                thread::sleep(poll_period);
+
+                // Check if the timer has been cancelled.
+                if let Err(mpsc::TryRecvError::Empty) = receiver.try_recv() {
+                    continue;
+                } else {
+                    // We were cancelled or dropped, so return early and don't call back.
+                    return;
+                }
+            }
+
+            // Timed out, so call back.
+            on_timeout();
+        });
+
+        Self { sender, _handle }
+    }
+
+    pub fn cancel(self) {
+        // Drop `self`.
+    }
+}
+
+impl Drop for Timer {
+    fn drop(&mut self) {
+        // Ignore errors, because they just mean the receiver has been dropped.
+        let _ = self.sender.send(());
+    }
 }

--- a/src/agent/coverage/src/block/linux.rs
+++ b/src/agent/coverage/src/block/linux.rs
@@ -405,7 +405,7 @@ fn continue_to_init_execve(tracer: &mut Ptracer) -> Result<Tracee> {
     anyhow::bail!("did not see initial execve() in tracee while recording coverage");
 }
 
-const MAX_POLL_PERIOD: Duration = Duration::from_millis(100);
+const MAX_POLL_PERIOD: Duration = Duration::from_millis(500);
 
 pub struct Timer {
     sender: mpsc::Sender<()>,


### PR DESCRIPTION
- Simplify the Linux block coverage `Recorder` API 
- Add a (mandatory) timeout to recording runs

Closes #923.