### PR TITLE
save more context in the failure log

### DIFF
--- a/src/agent/onefuzz-supervisor/src/failure.rs
+++ b/src/agent/onefuzz-supervisor/src/failure.rs
@@ -10,8 +10,9 @@ pub fn failure_path() -> Result<PathBuf> {
 }
 
 pub fn save_failure(err: &Error) -> Result<()> {
+    error!("saving failure: {:?}", err);
     let path = failure_path()?;
-    let message = format!("{}", err);
+    let message = format!("{:?}", err);
     fs::write(&path, message)
         .with_context(|| format!("unable to write failure log: {}", path.display()))
 }


### PR DESCRIPTION
When the supervisor fails, we log the error context to a file, which is used to inform tasks as what caused the supervisor to fail.

This update logs more details in the error context sent to the task failures.