### PR TITLE
prevent object id collision in hide_secrets

### DIFF
--- a/src/api-service/__app__/onefuzzlib/orm.py
+++ b/src/api-service/__app__/onefuzzlib/orm.py
@@ -231,18 +231,18 @@ def hide_secrets(data: B, hider: Callable[[SecretData], SecretData]) -> B:
 
         if isinstance(field_data, SecretData):
             field_data = hider(field_data)
+        elif isinstance(field_data, BaseModel):
+            field_data = hide_secrets(field_data, hider)
         elif isinstance(field_data, list):
-            if len(field_data) > 0:
-                if not isinstance(field_data[0], BaseModel):
-                    continue
-            field_data = [hide_secrets(x, hider) for x in field_data]
+            field_data = [
+                hide_secrets(x, hider) if isinstance(x, BaseModel) else x
+                for x in field_data
+            ]
         elif isinstance(field_data, dict):
             for key in field_data:
                 if not isinstance(field_data[key], BaseModel):
                     continue
                 field_data[key] = hide_secrets(field_data[key], hider)
-        elif isinstance(field_data, BaseModel):
-            field_data = hide_secrets(field_data, hider)
 
         setattr(data, field, field_data)
 

--- a/src/api-service/__app__/onefuzzlib/secrets.py
+++ b/src/api-service/__app__/onefuzzlib/secrets.py
@@ -18,9 +18,9 @@ from .azure.creds import get_keyvault_client
 A = TypeVar("A", bound=BaseModel)
 
 
-def save_to_keyvault(secret_data: SecretData) -> None:
+def save_to_keyvault(secret_data: SecretData) -> SecretData:
     if isinstance(secret_data.secret, SecretAddress):
-        return
+        return secret_data
 
     secret_name = str(uuid4())
     if isinstance(secret_data.secret, str):
@@ -32,6 +32,7 @@ def save_to_keyvault(secret_data: SecretData) -> None:
 
     kv = store_in_keyvault(get_keyvault_address(), secret_name, secret_value)
     secret_data.secret = SecretAddress(url=kv.id)
+    return secret_data
 
 
 def get_secret_string_value(self: SecretData[str]) -> str:


### PR DESCRIPTION
This fixes an issue related to object id reuse that can occur making the object identification cache fail.  Instead, this simplifies `hide_secrets` to always recurse and use `setattr` to always set the value based on the recursion.

Note, the object id reuse issue was seen in the `events.filter_event_recurse` development and this was the fix for the id reuse there.

Python documentation states:

> id(object):
>     Return the “identity” of an object. This is an integer (or long integer)
>     which is guaranteed to be unique and constant for this object during its
>     lifetime. Two objects with non-overlapping lifetimes may have the same
>     id() value.