### PR TITLE
add an optional initial delay for heartbeats

### DIFF
--- a/src/agent/onefuzz-agent/src/tasks/analysis/generic.rs
+++ b/src/agent/onefuzz-agent/src/tasks/analysis/generic.rs
@@ -143,7 +143,7 @@ async fn poll_inputs(
     tmp_dir: OwnedDir,
     reports_dir: &Option<PathBuf>,
 ) -> Result<()> {
-    let heartbeat = config.common.init_heartbeat().await?;
+    let heartbeat = config.common.init_heartbeat(None).await?;
     if let Some(input_queue) = &config.input_queue {
         loop {
             heartbeat.alive();

--- a/src/agent/onefuzz-agent/src/tasks/config.rs
+++ b/src/agent/onefuzz-agent/src/tasks/config.rs
@@ -15,8 +15,7 @@ use onefuzz_telemetry::{
 };
 use reqwest::Url;
 use serde::{self, Deserialize};
-use std::path::PathBuf;
-use std::sync::Arc;
+use std::{path::PathBuf, sync::Arc, time::Duration};
 use uuid::Uuid;
 
 #[derive(Debug, Deserialize, PartialEq, Clone)]
@@ -44,10 +43,14 @@ pub struct CommonConfig {
 }
 
 impl CommonConfig {
-    pub async fn init_heartbeat(&self) -> Result<Option<TaskHeartbeatClient>> {
+    pub async fn init_heartbeat(
+        &self,
+        initial_delay: Option<Duration>,
+    ) -> Result<Option<TaskHeartbeatClient>> {
         match &self.heartbeat_queue {
             Some(url) => {
-                let hb = init_task_heartbeat(url.clone(), self.task_id, self.job_id).await?;
+                let hb = init_task_heartbeat(url.clone(), self.task_id, self.job_id, initial_delay)
+                    .await?;
                 Ok(Some(hb))
             }
             None => Ok(None),

--- a/src/agent/onefuzz-agent/src/tasks/coverage/libfuzzer_coverage.rs
+++ b/src/agent/onefuzz-agent/src/tasks/coverage/libfuzzer_coverage.rs
@@ -188,7 +188,7 @@ pub struct CoverageProcessor {
 
 impl CoverageProcessor {
     pub async fn new(config: Arc<Config>) -> Result<Self> {
-        let heartbeat_client = config.common.init_heartbeat().await?;
+        let heartbeat_client = config.common.init_heartbeat(None).await?;
         let total = TotalCoverage::new(config.coverage.local_path.join(TOTAL_COVERAGE));
         let recorder = CoverageRecorder::new(config.clone()).await?;
         let module_totals = BTreeMap::default();

--- a/src/agent/onefuzz-agent/src/tasks/fuzz/generator.rs
+++ b/src/agent/onefuzz-agent/src/tasks/fuzz/generator.rs
@@ -67,7 +67,7 @@ impl GeneratorTask {
             set_executable(&tools.local_path).await?;
         }
 
-        let hb_client = self.config.common.init_heartbeat().await?;
+        let hb_client = self.config.common.init_heartbeat(None).await?;
 
         for dir in &self.config.readonly_inputs {
             dir.init_pull().await?;

--- a/src/agent/onefuzz-agent/src/tasks/fuzz/libfuzzer_fuzz.rs
+++ b/src/agent/onefuzz-agent/src/tasks/fuzz/libfuzzer_fuzz.rs
@@ -88,7 +88,7 @@ impl LibFuzzerFuzzTask {
         self.init_directories().await?;
         self.verify().await?;
 
-        let hb_client = self.config.common.init_heartbeat().await?;
+        let hb_client = self.config.common.init_heartbeat(None).await?;
 
         // To be scheduled.
         let resync = self.continuous_sync_inputs();

--- a/src/agent/onefuzz-agent/src/tasks/fuzz/supervisor.rs
+++ b/src/agent/onefuzz-agent/src/tasks/fuzz/supervisor.rs
@@ -126,7 +126,7 @@ pub async fn spawn(config: SupervisorConfig) -> Result<(), Error> {
     let stopped = Notify::new();
     let monitor_supervisor =
         monitor_process(process, "supervisor".to_string(), true, Some(&stopped));
-    let hb = config.common.init_heartbeat().await?;
+    let hb = config.common.init_heartbeat(None).await?;
 
     let heartbeat_process = heartbeat_process(&stopped, hb);
 

--- a/src/agent/onefuzz-agent/src/tasks/heartbeat.rs
+++ b/src/agent/onefuzz-agent/src/tasks/heartbeat.rs
@@ -6,6 +6,7 @@ use crate::onefuzz::machine_id::{get_machine_id, get_machine_name};
 use anyhow::Result;
 use reqwest::Url;
 use serde::{self, Deserialize, Serialize};
+use std::time::Duration;
 use uuid::Uuid;
 
 #[derive(Debug, Deserialize, Serialize, Hash, Eq, PartialEq, Clone)]
@@ -38,6 +39,7 @@ pub async fn init_task_heartbeat(
     queue_url: Url,
     task_id: Uuid,
     job_id: Uuid,
+    initial_delay: Option<Duration>,
 ) -> Result<TaskHeartbeatClient> {
     let machine_id = get_machine_id().await?;
     let machine_name = get_machine_name().await?;
@@ -49,6 +51,7 @@ pub async fn init_task_heartbeat(
             machine_name,
         },
         queue_url,
+        initial_delay,
         None,
         |context| async move {
             let task_id = context.state.task_id;

--- a/src/agent/onefuzz-agent/src/tasks/merge/generic.rs
+++ b/src/agent/onefuzz-agent/src/tasks/merge/generic.rs
@@ -49,7 +49,7 @@ pub async fn spawn(config: Arc<Config>) -> Result<()> {
     set_executable(&config.tools.local_path).await?;
 
     config.unique_inputs.init().await?;
-    let hb_client = config.common.init_heartbeat().await?;
+    let hb_client = config.common.init_heartbeat(None).await?;
     loop {
         hb_client.alive();
         let tmp_dir = PathBuf::from("./tmp");

--- a/src/agent/onefuzz-agent/src/tasks/merge/libfuzzer_merge.rs
+++ b/src/agent/onefuzz-agent/src/tasks/merge/libfuzzer_merge.rs
@@ -83,7 +83,7 @@ pub async fn spawn(config: Arc<Config>) -> Result<()> {
 }
 
 async fn process_message(config: Arc<Config>, input_queue: QueueClient) -> Result<()> {
-    let hb_client = config.common.init_heartbeat().await?;
+    let hb_client = config.common.init_heartbeat(None).await?;
     hb_client.alive();
     let tmp_dir = "./tmp";
     debug!("tmp dir reset");

--- a/src/agent/onefuzz-agent/src/tasks/regression/generic.rs
+++ b/src/agent/onefuzz-agent/src/tasks/regression/generic.rs
@@ -82,7 +82,7 @@ impl GenericRegressionTask {
 
     pub async fn run(&self) -> Result<()> {
         info!("Starting generic regression task");
-        let heartbeat_client = self.config.common.init_heartbeat().await?;
+        let heartbeat_client = self.config.common.init_heartbeat(None).await?;
 
         let mut report_dirs = vec![];
         for dir in vec![

--- a/src/agent/onefuzz-agent/src/tasks/regression/libfuzzer.rs
+++ b/src/agent/onefuzz-agent/src/tasks/regression/libfuzzer.rs
@@ -90,7 +90,7 @@ impl LibFuzzerRegressionTask {
             report_dirs.push(dir);
         }
 
-        let heartbeat_client = self.config.common.init_heartbeat().await?;
+        let heartbeat_client = self.config.common.init_heartbeat(None).await?;
         common::run(
             heartbeat_client,
             &self.config.regression_reports,

--- a/src/agent/onefuzz-agent/src/tasks/report/generic.rs
+++ b/src/agent/onefuzz-agent/src/tasks/report/generic.rs
@@ -68,7 +68,7 @@ impl ReportTask {
 
     pub async fn managed_run(&mut self) -> Result<()> {
         info!("Starting generic crash report task");
-        let heartbeat_client = self.config.common.init_heartbeat().await?;
+        let heartbeat_client = self.config.common.init_heartbeat(None).await?;
         let mut processor = GenericReportProcessor::new(&self.config, heartbeat_client);
 
         info!("processing existing crashes");

--- a/src/agent/onefuzz-agent/src/tasks/report/libfuzzer_report.rs
+++ b/src/agent/onefuzz-agent/src/tasks/report/libfuzzer_report.rs
@@ -175,7 +175,7 @@ pub struct AsanProcessor {
 
 impl AsanProcessor {
     pub async fn new(config: Arc<Config>) -> Result<Self> {
-        let heartbeat_client = config.common.init_heartbeat().await?;
+        let heartbeat_client = config.common.init_heartbeat(None).await?;
 
         Ok(Self {
             config,

--- a/src/agent/onefuzz-supervisor/src/heartbeat.rs
+++ b/src/agent/onefuzz-supervisor/src/heartbeat.rs
@@ -39,6 +39,7 @@ pub async fn init_agent_heartbeat(queue_url: Url) -> Result<AgentHeartbeatClient
         },
         queue_url,
         None,
+        None,
         |context| async move {
             let data = HeartbeatClient::drain_current_messages(context.clone());
             let _ = context

--- a/src/agent/onefuzz/src/heartbeat.rs
+++ b/src/agent/onefuzz/src/heartbeat.rs
@@ -84,7 +84,6 @@ where
         TContext: Send + Sync + 'static,
     {
         let heartbeat_period = heartbeat_period.unwrap_or(DEFAULT_HEARTBEAT_PERIOD);
-        let initial_delay = initial_delay.unwrap_or(DEFAULT_HEARTBEAT_PERIOD);
 
         let context = Arc::new(HeartbeatContext {
             state: context,


### PR DESCRIPTION
One of the difficulties in crash repro as task is a race condition where we the client tries to connect before the cdb is running.

This makes it such that we can use the heartbeat to identify if the task has started before connecting in.

NOTE:  In this PR, it's always set to None.  See #830 for it's actual usage.  However, I split out the PR for easier review.