### PR TITLE
work around issue with discriminated typed unions

### DIFF
--- a/src/api-service/__app__/onefuzzlib/events.py
+++ b/src/api-service/__app__/onefuzzlib/events.py
@@ -81,7 +81,7 @@ def send_event(event: Event) -> None:
         instance_name=get_instance_name(),
     )
 
-    # work around odd bug with Event Message creation
+    # work around odd bug with Event Message creation.  See PR 939
     if event_message.event != event:
         event_message.event = event.copy(deep=True)
 

--- a/src/api-service/__app__/onefuzzlib/events.py
+++ b/src/api-service/__app__/onefuzzlib/events.py
@@ -24,7 +24,7 @@ def get_events() -> Optional[str]:
     for _ in range(5):
         try:
             event = EVENTS.get(block=False)
-            events.append(json.loads(event.json(exclude_none=True)))
+            events.append(json.loads(event))
             EVENTS.task_done()
         except Empty:
             break
@@ -36,13 +36,13 @@ def get_events() -> Optional[str]:
 
 
 def log_event(event: Event, event_type: EventType) -> None:
-    scrubbed_event = filter_event(event, event_type)
+    scrubbed_event = filter_event(event)
     logging.info(
         "sending event: %s - %s", event_type, scrubbed_event.json(exclude_none=True)
     )
 
 
-def filter_event(event: Event, event_type: EventType) -> BaseModel:
+def filter_event(event: Event) -> BaseModel:
     clone_event = event.copy(deep=True)
     filtered_event = filter_event_recurse(clone_event)
     return filtered_event
@@ -73,12 +73,18 @@ def filter_event_recurse(entry: BaseModel) -> BaseModel:
 
 def send_event(event: Event) -> None:
     event_type = get_event_type(event)
-    log_event(event, event_type)
+
     event_message = EventMessage(
         event_type=event_type,
-        event=event,
+        event=event.copy(deep=True),
         instance_id=get_instance_id(),
         instance_name=get_instance_name(),
     )
-    EVENTS.put(event_message)
+
+    # work around odd bug with Event Message creation
+    if event_message.event != event:
+        event_message.event = event.copy(deep=True)
+
+    EVENTS.put(event_message.json())
     Webhook.send_event(event_message)
+    log_event(event, event_type)

--- a/src/api-service/__app__/requirements.txt
+++ b/src/api-service/__app__/requirements.txt
@@ -23,7 +23,7 @@ azure-storage-queue==12.1.6
 jinja2~=2.11.3
 msrestazure~=0.6.3
 opencensus-ext-azure~=1.0.2
-pydantic~=1.8.1 --no-binary=pydantic
+pydantic==1.8.2 --no-binary=pydantic
 PyJWT~=1.7.1
 requests~=2.25.1
 memoization~=0.3.1

--- a/src/api-service/tests/test_userinfo_filter.py
+++ b/src/api-service/tests/test_userinfo_filter.py
@@ -8,7 +8,7 @@ import unittest
 from uuid import uuid4
 
 from onefuzztypes.enums import ContainerType, TaskType
-from onefuzztypes.events import EventTaskCreated, get_event_type
+from onefuzztypes.events import EventTaskCreated
 from onefuzztypes.models import (
     TaskConfig,
     TaskContainers,
@@ -65,9 +65,7 @@ class TestUserInfoFilter(unittest.TestCase):
             user_info=None,
         )
 
-        test_event_type = get_event_type(test_event)
-
-        scrubbed_test_event = filter_event(test_event, test_event_type)
+        scrubbed_test_event = filter_event(test_event)
 
         self.assertEqual(scrubbed_test_event, control_test_event)
 

--- a/src/cli/onefuzz/status/top.py
+++ b/src/cli/onefuzz/status/top.py
@@ -9,8 +9,6 @@ from queue import PriorityQueue
 from threading import Thread
 from typing import Any, Optional
 
-from onefuzztypes.events import EventMessage
-
 from .cache import JobFilter, TopCache
 from .signalr import Stream
 from .top_view import render
@@ -50,8 +48,7 @@ class Top:
 
     def handler(self, message: Any) -> None:
         for event_raw in message:
-            message = EventMessage.parse_obj(event_raw)
-            self.cache.add_message(message)
+            self.cache.add_message(event_raw)
 
     def setup(self) -> Stream:
         client = Stream(self.onefuzz, self.logger)

--- a/src/pytypes/requirements.txt
+++ b/src/pytypes/requirements.txt
@@ -1,1 +1,1 @@
-pydantic~=1.8.1 --no-binary=pydantic
+pydantic==1.8.2 --no-binary=pydantic


### PR DESCRIPTION
We're experiencing a bug where Unions of sub-models are getting downcast, which causes a loss of information.  

As an example, EventScalesetCreated was getting downcast to EventScalesetDeleted.  I have not figured out why, nor can I replicate it locally to minimize the bug send upstream, but I was able to reliably replicate it on the service.

While working through this issue, I noticed that deserialization of SignalR events was frequently wrong, leaving things like tasks as "init" in `status top`.

Both of these issues are Unions of models with a type field, so it's likely these are related.