### PR TITLE
send NodeCommandStopIfFree on node shutdown

### DIFF
--- a/src/api-service/__app__/onefuzzlib/workers/nodes.py
+++ b/src/api-service/__app__/onefuzzlib/workers/nodes.py
@@ -381,6 +381,7 @@ class Node(BASE_NODE, ORMMixin):
         logging.info("setting delete_requested: %s", self.machine_id)
         self.delete_requested = True
         self.save()
+        self.send_stop_if_free()
 
     def set_halt(self) -> None:
         """Tell the node to stop everything."""


### PR DESCRIPTION
If we move to shutdown a single node but it's not doing work, it will
wait until it picks up work to shutdown.  This shortcuts that.
