### PR TITLE
handle serialization of secrets sent from the CLI

### DIFF
--- a/src/cli/onefuzz/backend.py
+++ b/src/cli/onefuzz/backend.py
@@ -379,7 +379,6 @@ def serialize(data: Any) -> Any:
     if data is None:
         return data
     if isinstance(data, SecretData) and not isinstance(data.secret, SecretAddress):
-        print(type(data.secret))
         return serialize(data.secret)
     if isinstance(data, BaseModel):
         return {serialize(a): serialize(b) for (a, b) in data.dict().items()}

--- a/src/cli/onefuzz/backend.py
+++ b/src/cli/onefuzz/backend.py
@@ -30,6 +30,7 @@ from uuid import UUID
 import msal
 import requests
 from azure.storage.blob import ContainerClient
+from onefuzztypes.models import SecretAddress, SecretData
 from pydantic import BaseModel, Field
 from tenacity import Future as tenacity_future
 from tenacity import Retrying, retry
@@ -377,6 +378,9 @@ def container_file_path(container_url: str, blob_name: str) -> str:
 def serialize(data: Any) -> Any:
     if data is None:
         return data
+    if isinstance(data, SecretData) and not isinstance(data.secret, SecretAddress):
+        print(type(data.secret))
+        return serialize(data.secret)
     if isinstance(data, BaseModel):
         return {serialize(a): serialize(b) for (a, b) in data.dict().items()}
     if isinstance(data, dict):

--- a/src/cli/tests/test_serialize.py
+++ b/src/cli/tests/test_serialize.py
@@ -6,6 +6,7 @@
 import unittest
 
 from onefuzztypes.models import TeamsTemplate
+
 from onefuzz.backend import serialize
 
 
@@ -14,6 +15,7 @@ class TestSerialize(unittest.TestCase):
         base = TeamsTemplate(url="https://contoso.com")
         converted = serialize(base)
         self.assertEqual(converted, {"url": "https://contoso.com"})
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/cli/tests/test_serialize.py
+++ b/src/cli/tests/test_serialize.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+#
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+import unittest
+
+from onefuzztypes.models import TeamsTemplate
+from onefuzz.backend import serialize
+
+
+class TestSerialize(unittest.TestCase):
+    def test_cli_backend_secret_data_serialize(self) -> None:
+        base = TeamsTemplate(url="https://contoso.com")
+        converted = serialize(base)
+        self.assertEqual(converted, {"url": "https://contoso.com"})
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This normalizes the SecretData serialization from the client to address #981.

When serializing objects sent to the service with secrets, we would turn it into a SecretData

We use SecretData to convert this:
`{"auth": {"user": "A", "personal_access_token": "B"}}`
to this:
`"auth": { "secret": { "url": "https://KEYVAULT-URL" }}`

Currently, in the case we have a SecretData we've not yet saved, the serialized form looks like this:
`{"auth": { "secret": {"user": "A", "personal_access_token": "B"}}}`

This PR simplifies the client side serialization to this:
`{"auth": {"user": "A", "personal_access_token": "B"}}`