### PR TITLE
fix SyncedDir.remote_url issue with relative paths

### DIFF
--- a/src/agent/onefuzz/src/blob/url.rs
+++ b/src/agent/onefuzz/src/blob/url.rs
@@ -151,7 +151,8 @@ impl BlobContainerUrl {
     pub fn url(&self) -> Result<Url> {
         match self {
             Self::BlobContainer(url) => Ok(url.clone()),
-            Self::Path(p) => Ok(Url::from_file_path(p).map_err(|_| anyhow!("invalid path"))?),
+            Self::Path(p) => Ok(Url::from_file_path(p)
+                .map_err(|err| anyhow!("invalid path.  path:{} error:{:?}", p.display(), err))?),
         }
     }
 

--- a/src/agent/onefuzz/src/syncdir.rs
+++ b/src/agent/onefuzz/src/syncdir.rs
@@ -356,3 +356,28 @@ pub async fn continuous_sync(
         delay_with_jitter(delay).await;
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::SyncedDir;
+    use anyhow::{anyhow, Result};
+    use dunce::canonicalize;
+    use std::env::current_dir;
+    use std::path::PathBuf;
+
+    #[test]
+    fn test_synceddir_relative_remote_url() -> Result<()> {
+        let path = PathBuf::from("Cargo.toml");
+        let expected = canonicalize(current_dir()?.join(&path))?;
+        let dir = SyncedDir {
+            local_path: path.clone(),
+            remote_path: None,
+        };
+        let blob_path = dir
+            .remote_url()?
+            .as_file_path()
+            .ok_or(anyhow!("as_file_path failed"))?;
+        assert_eq!(expected, blob_path);
+        Ok(())
+    }
+}

--- a/src/agent/onefuzz/src/syncdir.rs
+++ b/src/agent/onefuzz/src/syncdir.rs
@@ -10,12 +10,13 @@ use crate::{
     uploader::BlobUploader,
 };
 use anyhow::{Context, Result};
+use dunce::canonicalize;
 use futures::stream::StreamExt;
 use onefuzz_telemetry::{Event, EventData};
 use reqwest::{StatusCode, Url};
 use reqwest_retry::{RetryCheck, SendRetry, DEFAULT_RETRY_PERIOD, MAX_RETRY_ATTEMPTS};
 use serde::{Deserialize, Serialize};
-use std::{path::PathBuf, str, time::Duration};
+use std::{env::current_dir, path::PathBuf, str, time::Duration};
 use tokio::fs;
 
 #[derive(Debug, Clone, Copy)]
@@ -37,15 +38,32 @@ pub struct SyncedDir {
 
 impl SyncedDir {
     pub fn remote_url(&self) -> Result<BlobContainerUrl> {
-        let url = self.remote_path.clone().unwrap_or(BlobContainerUrl::new(
-            Url::from_file_path(self.local_path.clone()).map_err(|err| {
-                anyhow!(
-                    "invalid path: {} error:{:?}",
-                    self.local_path.display(),
-                    err
-                )
-            })?,
-        )?);
+        let url = match &self.remote_path {
+            Some(url) => url.clone(),
+            None => {
+                let url = if self.local_path.is_absolute() {
+                    Url::from_file_path(self.local_path.clone()).map_err(|err| {
+                        anyhow!(
+                            "invalid path: {} error: {:?}",
+                            self.local_path.display(),
+                            err
+                        )
+                    })?
+                } else {
+                    let absolute = current_dir()
+                        .context("unable to get current directory")?
+                        .join(&self.local_path);
+                    let canonicalized = canonicalize(&absolute).with_context(|| {
+                        format!("unable to canonicalize path: {}", absolute.display())
+                    })?;
+                    Url::from_file_path(&canonicalized).map_err(|err| {
+                        anyhow!("invalid path: {} error: {:?}", canonicalized.display(), err)
+                    })?
+                };
+                BlobContainerUrl::new(url.clone())
+                    .with_context(|| format!("unable to create BlobContainerUrl: {}", url))?
+            }
+        };
         Ok(url)
     }
 


### PR DESCRIPTION
Url::from_file_path does not support creating `Url` with a relative
path.  This change converts relative paths to canonicalized absolute
paths based on CWD.