### PR TITLE
reduce log retention duration to 30 days

### DIFF
--- a/src/deployment/azuredeploy.json
+++ b/src/deployment/azuredeploy.json
@@ -48,7 +48,7 @@
     },
     "variables": {
         "autoscale_name": "[concat('onefuzz-autoscale-', uniquestring(resourceGroup().id))]",
-        "diagnosticsLogsRetentionInDays": 90,
+        "diagnosticsLogsRetentionInDays": 30,
         "monitorAccountName": "[concat('logs-wb-', uniquestring(resourceGroup().id))]",
         "scaleset_identity": "[concat(parameters('name'), '-scalesetid')]",
         "signalr-name": "[concat('onefuzz-', uniquestring(resourceGroup().id))]",


### PR DESCRIPTION
Internal policies by some of our teams require log durations to be shorter than our previous defaults of 90 days.  This reduces the log retention duration to 30 days.