### PR TITLE
add cooloff period for rapidly exiting libFuzzer targets

### DIFF
--- a/src/agent/onefuzz-agent/src/tasks/fuzz/libfuzzer_fuzz.rs
+++ b/src/agent/onefuzz-agent/src/tasks/fuzz/libfuzzer_fuzz.rs
@@ -37,7 +37,8 @@ const PROC_INFO_PERIOD: Duration = Duration::from_secs(30);
 // Period of reporting fuzzer-generated runtime stats.
 const RUNTIME_STATS_PERIOD: Duration = Duration::from_secs(60);
 
-const COOLOFF_PERIOD: Duration = Duration::from_secs(5);
+// Period for minimum duration between launches of libFuzzer
+const COOLOFF_PERIOD: Duration = Duration::from_secs(10);
 
 /// Maximum number of log message to safe in case of libFuzzer failing,
 /// arbitrarily chosen
@@ -187,8 +188,9 @@ impl LibFuzzerFuzzTask {
 
             // if libFuzzer is exiting rapidly, give some breathing room to allow the
             // handles to be reaped.
-            if instant.elapsed() < COOLOFF_PERIOD {
-                sleep(COOLOFF_PERIOD).await;
+            let runtime = instant.elapsed();
+            if runtime < COOLOFF_PERIOD {
+                sleep(COOLOFF_PERIOD - runtime).await;
             }
         }
     }


### PR DESCRIPTION
For rapidly exiting libFuzzer targets, the agent can get into a state where it never has a chance for the handles to get reaped.  This eventually causes an OOM error in the system.

This enforces that within a given worker, at least 5 seconds have occurred between each execution of the target.

Note, we effectively had a sleep before, but the performance improvements in #941 removed the effective sleep.