### PR TITLE
fix debug report

### DIFF
--- a/src/agent/onefuzz-agent/src/tasks/report/crash_report.rs
+++ b/src/agent/onefuzz-agent/src/tasks/report/crash_report.rs
@@ -280,3 +280,57 @@ pub async fn monitor_reports(
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+
+    use std::io::Write;
+
+    use super::{parse_report_file, CrashTestResult};
+    use anyhow::Result;
+    use tempfile::NamedTempFile;
+
+    #[tokio::test]
+    async fn test_parse_debug_report() -> Result<()> {
+        let json_str = br###"
+            {
+                "input_url": null,
+                "input_blob": {
+                    "account": "fuzz27ee6imdmr5gy",
+                    "container": "oft-crashes-cecbd958a1f257688f9768edaaf6c94d",
+                    "name": "fake-crash-sample"
+                },
+                "executable": "fuzz.exe",
+                "crash_type": "fake crash report",
+                "crash_site": "fake crash site",
+                "call_stack": ["#0 fake", "#1 call", "#2 stack"],
+                "call_stack_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+                "input_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "asan_log": "fake asan log",
+                "task_id": "91fb6329-0aa2-4c09-afaf-26340286a9c6",
+                "job_id": "447c2a03-5216-42ea-88e5-16cbb5dc6fc0",
+                "scariness_score": null,
+                "scariness_description": null,
+                "minimized_stack": null,
+                "minimized_stack_sha256": null,
+                "minimized_stack_function_names": null,
+                "minimized_stack_function_names_sha256": null
+            }"###;
+
+        let json_file = NamedTempFile::new()?;
+
+        json_file.as_file().write_all(json_str)?;
+
+        let report = parse_report_file(json_file.path().to_path_buf()).await?;
+
+        match report {
+            CrashTestResult::CrashReport(report) => {
+                assert_eq!(report.minimized_stack_function_names.len(), 0);
+                assert_eq!(report.minimized_stack.len(), 0);
+            }
+            CrashTestResult::NoRepro(norepro) => assert!(false, "invalid report type"),
+        }
+
+        Ok(())
+    }
+}

--- a/src/agent/onefuzz-agent/src/tasks/report/crash_report.rs
+++ b/src/agent/onefuzz-agent/src/tasks/report/crash_report.rs
@@ -11,7 +11,7 @@ use onefuzz_telemetry::{
     },
     EventData,
 };
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Serialize};
 use stacktrace_parser::CrashLog;
 use std::path::{Path, PathBuf};
 use uuid::Uuid;

--- a/src/agent/onefuzz-agent/src/tasks/report/crash_report.rs
+++ b/src/agent/onefuzz-agent/src/tasks/report/crash_report.rs
@@ -11,7 +11,7 @@ use onefuzz_telemetry::{
     },
     EventData,
 };
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use stacktrace_parser::CrashLog;
 use std::path::{Path, PathBuf};
 use uuid::Uuid;
@@ -33,11 +33,13 @@ pub struct CrashReport {
     pub call_stack_sha256: String,
 
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(deserialize_with = "deserialize_null_default")]
     pub minimized_stack: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub minimized_stack_sha256: Option<String>,
 
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(deserialize_with = "deserialize_null_default")]
     pub minimized_stack_function_names: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub minimized_stack_function_names_sha256: Option<String>,
@@ -54,6 +56,15 @@ pub struct CrashReport {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub scariness_description: Option<String>,
+}
+
+fn deserialize_null_default<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+where
+    T: Default + Deserialize<'de>,
+    D: Deserializer<'de>,
+{
+    let value = Option::deserialize(deserializer)?;
+    Ok(value.unwrap_or_default())
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/src/cli/onefuzz/debug.py
+++ b/src/cli/onefuzz/debug.py
@@ -695,6 +695,8 @@ class DebugNotification(Command):
             asan_log="fake asan log",
             task_id=task_id,
             job_id=task.job_id,
+            minimized_stack=[],
+            minimized_stack_function_names=[]
         )
 
         with tempfile.TemporaryDirectory() as tempdir:

--- a/src/cli/onefuzz/debug.py
+++ b/src/cli/onefuzz/debug.py
@@ -696,7 +696,7 @@ class DebugNotification(Command):
             task_id=task_id,
             job_id=task.job_id,
             minimized_stack=[],
-            minimized_stack_function_names=[]
+            minimized_stack_function_names=[],
         )
 
         with tempfile.TemporaryDirectory() as tempdir:


### PR DESCRIPTION
The debug report created by the command `onefuzz debug  notification job <job id>`  is causing a crash in the regression task 
```
error running task: libfuzzer regression

Caused by:
    0: handling crash reports
    1: unable to parse crash report: fake-crash-sample.json
    2: unable to parse report: task_unique_reports_2/fake-crash-sample.json - "{\"input_url\": null, \"input_blob\": {\"account\": \"fuzz27ee6imdmr5gy\", \"container\": \"oft-crashes-cecbd958a1f257688f9768edaaf6c94d\", \"name\": \"fake-crash-sample\"}, \"executable\": \"fuzz.exe\", \"crash_type\": \"fake crash report\", \"crash_site\": \"fake crash site\", \"call_stack\": [\"#0 fake\", \"#1 call\", \"#2 stack\"], \"call_stack_sha256\": \"0000000000000000000000000000000000000000000000000000000000000000\", \"input_sha256\": \"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\", \"asan_log\": \"fake asan log\", \"task_id\": \"b1107de0-c3cb-43ff-ab68-5accc579f4d4\", \"job_id\": \"afa45e3e-9a75-4a47-8d59-ef3154599fc7\", \"scariness_score\": null, \"scariness_description\": null, \"minimized_stack\": null, \"minimized_stack_sha256\": null, \"minimized_stack_function_names\": null, \"minimized_stack_function_names_sha256\": null}"
```