### PR TITLE
ensure VM IDs are unique before calling Azure reimage/delete APIs

### DIFF
--- a/src/api-service/__app__/onefuzzlib/azure/vmss.py
+++ b/src/api-service/__app__/onefuzzlib/azure/vmss.py
@@ -153,6 +153,7 @@ def check_can_update(name: UUID) -> Any:
 
 def reimage_vmss_nodes(name: UUID, vm_ids: List[UUID]) -> Optional[Error]:
     check_can_update(name)
+    # Azure requires VM IDs be unique
     vm_ids = list(set(vm_ids))
 
     resource_group = get_base_resource_group()
@@ -178,6 +179,7 @@ def reimage_vmss_nodes(name: UUID, vm_ids: List[UUID]) -> Optional[Error]:
 
 def delete_vmss_nodes(name: UUID, vm_ids: List[UUID]) -> Optional[Error]:
     check_can_update(name)
+    # Azure requires VM IDs to be unique
     vm_ids = list(set(vm_ids))
 
     resource_group = get_base_resource_group()

--- a/src/api-service/__app__/onefuzzlib/azure/vmss.py
+++ b/src/api-service/__app__/onefuzzlib/azure/vmss.py
@@ -5,7 +5,7 @@
 
 import logging
 import os
-from typing import Any, Dict, List, Optional, Union, cast
+from typing import Any, Dict, List, Optional, Set, Union, cast
 from uuid import UUID
 
 from azure.core.exceptions import (
@@ -151,20 +151,18 @@ def check_can_update(name: UUID) -> Any:
     return vmss
 
 
-def reimage_vmss_nodes(name: UUID, vm_ids: List[UUID]) -> Optional[Error]:
+def reimage_vmss_nodes(name: UUID, vm_ids: Set[UUID]) -> Optional[Error]:
     check_can_update(name)
-    # Azure requires VM IDs be unique
-    vm_ids = list(set(vm_ids))
 
     resource_group = get_base_resource_group()
     logging.info("reimaging scaleset VM - name: %s vm_ids:%s", name, vm_ids)
     compute_client = get_compute_client()
 
-    instance_ids = []
+    instance_ids = set()
     machine_to_id = list_instance_ids(name)
     for vm_id in vm_ids:
         if vm_id in machine_to_id:
-            instance_ids.append(machine_to_id[vm_id])
+            instance_ids.add(machine_to_id[vm_id])
         else:
             logging.info("unable to find vm_id for %s:%s", name, vm_id)
 
@@ -172,25 +170,23 @@ def reimage_vmss_nodes(name: UUID, vm_ids: List[UUID]) -> Optional[Error]:
         compute_client.virtual_machine_scale_sets.begin_reimage_all(
             resource_group,
             str(name),
-            VirtualMachineScaleSetVMInstanceIDs(instance_ids=instance_ids),
+            VirtualMachineScaleSetVMInstanceIDs(instance_ids=list(instance_ids)),
         )
     return None
 
 
-def delete_vmss_nodes(name: UUID, vm_ids: List[UUID]) -> Optional[Error]:
+def delete_vmss_nodes(name: UUID, vm_ids: Set[UUID]) -> Optional[Error]:
     check_can_update(name)
-    # Azure requires VM IDs to be unique
-    vm_ids = list(set(vm_ids))
 
     resource_group = get_base_resource_group()
     logging.info("deleting scaleset VM - name: %s vm_ids:%s", name, vm_ids)
     compute_client = get_compute_client()
 
-    instance_ids = []
+    instance_ids = set()
     machine_to_id = list_instance_ids(name)
     for vm_id in vm_ids:
         if vm_id in machine_to_id:
-            instance_ids.append(machine_to_id[vm_id])
+            instance_ids.add(machine_to_id[vm_id])
         else:
             logging.info("unable to find vm_id for %s:%s", name, vm_id)
 
@@ -198,7 +194,9 @@ def delete_vmss_nodes(name: UUID, vm_ids: List[UUID]) -> Optional[Error]:
         compute_client.virtual_machine_scale_sets.begin_delete_instances(
             resource_group,
             str(name),
-            VirtualMachineScaleSetVMInstanceRequiredIDs(instance_ids=instance_ids),
+            VirtualMachineScaleSetVMInstanceRequiredIDs(
+                instance_ids=list(instance_ids)
+            ),
         )
     return None
 

--- a/src/api-service/__app__/onefuzzlib/azure/vmss.py
+++ b/src/api-service/__app__/onefuzzlib/azure/vmss.py
@@ -153,6 +153,7 @@ def check_can_update(name: UUID) -> Any:
 
 def reimage_vmss_nodes(name: UUID, vm_ids: List[UUID]) -> Optional[Error]:
     check_can_update(name)
+    vm_ids = list(set(vm_ids))
 
     resource_group = get_base_resource_group()
     logging.info("reimaging scaleset VM - name: %s vm_ids:%s", name, vm_ids)
@@ -177,6 +178,7 @@ def reimage_vmss_nodes(name: UUID, vm_ids: List[UUID]) -> Optional[Error]:
 
 def delete_vmss_nodes(name: UUID, vm_ids: List[UUID]) -> Optional[Error]:
     check_can_update(name)
+    vm_ids = list(set(vm_ids))
 
     resource_group = get_base_resource_group()
     logging.info("deleting scaleset VM - name: %s vm_ids:%s", name, vm_ids)

--- a/src/api-service/__app__/onefuzzlib/workers/scalesets.py
+++ b/src/api-service/__app__/onefuzzlib/workers/scalesets.py
@@ -537,7 +537,7 @@ class Scaleset(BASE_SCALESET, ORMMixin):
             )
             return
 
-        machine_ids = []
+        machine_ids = set()
         for node in nodes:
             if node.debug_keep_node:
                 logging.warning(
@@ -547,7 +547,7 @@ class Scaleset(BASE_SCALESET, ORMMixin):
                     node.machine_id,
                 )
             else:
-                machine_ids.append(node.machine_id)
+                machine_ids.add(node.machine_id)
 
         logging.info(
             SCALESET_LOG_PREFIX + "deleting nodes scaleset_id:%s machine_id:%s",
@@ -585,7 +585,7 @@ class Scaleset(BASE_SCALESET, ORMMixin):
             )
             return
 
-        machine_ids = []
+        machine_ids = set()
         for node in nodes:
             if node.debug_keep_node:
                 logging.warning(
@@ -595,7 +595,7 @@ class Scaleset(BASE_SCALESET, ORMMixin):
                     node.machine_id,
                 )
             else:
-                machine_ids.append(node.machine_id)
+                machine_ids.add(node.machine_id)
 
         if not machine_ids:
             logging.info(


### PR DESCRIPTION
Fixes an issue where Azure is now enforcing unique IDs for reimaging & deletion.

```
Exception: HttpResponseError: (InvalidParameter) InstanceIds may not be repeated.
Code: InvalidParameter
Message: InstanceIds may not be repeated.
Target: instanceIds
```