### PR TITLE
Allow notifications to be retried when an error occurs

### DIFF
--- a/src/api-service/__app__/onefuzzlib/notifications/ado.py
+++ b/src/api-service/__app__/onefuzzlib/notifications/ado.py
@@ -210,6 +210,20 @@ class ADO:
             self.create_new()
 
 
+def is_transient(err: any) -> bool:
+    error_codes = [
+        # "TF401349: An unexpected error has occurred, please verify your request and try again." # noqa: E501
+        "TF401349",
+        # TF26071: This work item has been changed by someone else since you opened it. You will need to refresh it and discard your changes. # noqa: E501
+        "TF26071",
+    ]
+    error_str = str(err)
+    for code in error_codes:
+        if code in error_str:
+            return True
+    return False
+
+
 def notify_ado(
     config: ADOTemplate,
     container: Container,
@@ -244,19 +258,6 @@ def notify_ado(
         AzureDevOpsClientRequestError,
         ValueError,
     ) as err:
-
-        def is_transient(err: any) -> bool:
-            error_codes = [
-                # "TF401349: An unexpected error has occurred, please verify your request and try again."
-                "TF401349",
-                # TF26071: This work item has been changed by someone else since you opened it. You will need to refresh it and discard your changes.
-                "TF26071",
-            ]
-            error_str = str(err)
-            for code in error_codes:
-                if code in error_str:
-                    return True
-            return False
 
         if not fail_task_on_transient_error and is_transient(err):
             raise AdoNotificationException("ADO notification failed") from err

--- a/src/api-service/__app__/onefuzzlib/notifications/ado.py
+++ b/src/api-service/__app__/onefuzzlib/notifications/ado.py
@@ -4,7 +4,7 @@
 # Licensed under the MIT License.
 
 import logging
-from typing import Any, Iterator, List, Optional, Union
+from typing import Iterator, List, Optional, Union
 
 from azure.devops.connection import Connection
 from azure.devops.credentials import BasicAuthentication
@@ -260,6 +260,8 @@ def notify_ado(
     ) as err:
 
         if not fail_task_on_transient_error and is_transient(err):
-            raise AdoNotificationException("ADO notification failed") from err
+            raise AdoNotificationException(
+                "transient ADO notification failure"
+            ) from err
         else:
             fail_task(report, err)

--- a/src/api-service/__app__/onefuzzlib/notifications/ado.py
+++ b/src/api-service/__app__/onefuzzlib/notifications/ado.py
@@ -4,7 +4,7 @@
 # Licensed under the MIT License.
 
 import logging
-from typing import Iterator, List, Optional, Union
+from typing import Any, Iterator, List, Optional, Union
 
 from azure.devops.connection import Connection
 from azure.devops.credentials import BasicAuthentication
@@ -210,7 +210,7 @@ class ADO:
             self.create_new()
 
 
-def is_transient(err: any) -> bool:
+def is_transient(err: Any) -> bool:
     error_codes = [
         # "TF401349: An unexpected error has occurred, please verify your request and try again." # noqa: E501
         "TF401349",

--- a/src/api-service/__app__/onefuzzlib/notifications/ado.py
+++ b/src/api-service/__app__/onefuzzlib/notifications/ado.py
@@ -244,9 +244,8 @@ def notify_ado(
         AzureDevOpsClientRequestError,
         ValueError,
     ) as err:
-        if fail_task_on_transient_error or (
-            "please verify your request and try again" not in str(err)
-        ):
-            fail_task(report, err)
-        else:
+        is_transient = "please verify your request and try again" in str(err)
+        if not fail_task_on_transient_error and is_transient:
             raise AdoNotificationException("ADO notification failed") from err
+        else:
+            fail_task(report, err)

--- a/src/api-service/__app__/onefuzzlib/notifications/ado.py
+++ b/src/api-service/__app__/onefuzzlib/notifications/ado.py
@@ -210,7 +210,7 @@ class ADO:
             self.create_new()
 
 
-def is_transient(err: Any) -> bool:
+def is_transient(err: Exception) -> bool:
     error_codes = [
         # "TF401349: An unexpected error has occurred, please verify your request and try again." # noqa: E501
         "TF401349",

--- a/src/api-service/__app__/onefuzzlib/notifications/ado.py
+++ b/src/api-service/__app__/onefuzzlib/notifications/ado.py
@@ -215,7 +215,7 @@ def notify_ado(
     container: Container,
     filename: str,
     report: Union[Report, RegressionReport],
-    fail_task_on_error: bool,
+    fail_task_on_transient_error: bool,
 ) -> None:
     if isinstance(report, RegressionReport):
         logging.info(
@@ -244,7 +244,7 @@ def notify_ado(
         AzureDevOpsClientRequestError,
         ValueError,
     ) as err:
-        if fail_task_on_error or (
+        if fail_task_on_transient_error or (
             "please verify your request and try again" not in str(err)
         ):
             fail_task(report, err)

--- a/src/api-service/__app__/onefuzzlib/notifications/github_issues.py
+++ b/src/api-service/__app__/onefuzzlib/notifications/github_issues.py
@@ -117,7 +117,7 @@ def github_issue(
     container: Container,
     filename: str,
     report: Optional[Union[Report, RegressionReport]],
-    fail_task_on_error: bool,
+    fail_task_on_transient_error: bool,
 ) -> None:
     if report is None:
         return
@@ -134,7 +134,7 @@ def github_issue(
         handler = GithubIssue(config, container, filename, report)
         handler.process()
     except (GitHubException, ValueError) as err:
-        if fail_task_on_error:
+        if fail_task_on_transient_error:
             fail_task(report, err)
         else:
             raise GithubNotificationException("Github notification failed") from err

--- a/src/api-service/__app__/onefuzzlib/notifications/github_issues.py
+++ b/src/api-service/__app__/onefuzzlib/notifications/github_issues.py
@@ -22,10 +22,6 @@ from ..secrets import get_secret_obj
 from .common import Render, fail_task
 
 
-class GithubNotificationException(Exception):
-    pass
-
-
 class GithubIssue:
     def __init__(
         self,
@@ -117,7 +113,6 @@ def github_issue(
     container: Container,
     filename: str,
     report: Optional[Union[Report, RegressionReport]],
-    fail_task_on_transient_error: bool,
 ) -> None:
     if report is None:
         return
@@ -134,7 +129,4 @@ def github_issue(
         handler = GithubIssue(config, container, filename, report)
         handler.process()
     except (GitHubException, ValueError) as err:
-        if fail_task_on_transient_error:
-            fail_task(report, err)
-        else:
-            raise GithubNotificationException("Github notification failed") from err
+        fail_task(report, err)

--- a/src/api-service/__app__/onefuzzlib/notifications/main.py
+++ b/src/api-service/__app__/onefuzzlib/notifications/main.py
@@ -160,7 +160,7 @@ def new_files(
                 )
 
             if isinstance(notification.config, GithubIssueTemplate):
-                github_issue(notification.config, container, filename, report, True)
+                github_issue(notification.config, container, filename, report)
 
     for (task, containers) in get_queue_tasks():
         if container in containers:

--- a/src/api-service/__app__/onefuzzlib/notifications/main.py
+++ b/src/api-service/__app__/onefuzzlib/notifications/main.py
@@ -127,7 +127,7 @@ def get_queue_tasks() -> Sequence[Tuple[Task, Sequence[str]]]:
     return results
 
 
-def new_files(container: Container, filename: str) -> None:
+def new_files(container: Container, filename: str, fail_task_on_error: bool) -> None:
     notifications = get_notifications(container)
 
     report = get_report_or_regression(
@@ -149,10 +149,12 @@ def new_files(container: Container, filename: str) -> None:
                 continue
 
             if isinstance(notification.config, ADOTemplate):
-                notify_ado(notification.config, container, filename, report)
+                notify_ado(
+                    notification.config, container, filename, report, fail_task_on_error
+                )
 
             if isinstance(notification.config, GithubIssueTemplate):
-                github_issue(notification.config, container, filename, report)
+                github_issue(notification.config, container, filename, report, True)
 
     for (task, containers) in get_queue_tasks():
         if container in containers:

--- a/src/api-service/__app__/onefuzzlib/notifications/main.py
+++ b/src/api-service/__app__/onefuzzlib/notifications/main.py
@@ -127,7 +127,9 @@ def get_queue_tasks() -> Sequence[Tuple[Task, Sequence[str]]]:
     return results
 
 
-def new_files(container: Container, filename: str, fail_task_on_transient_error: bool) -> None:
+def new_files(
+    container: Container, filename: str, fail_task_on_transient_error: bool
+) -> None:
     notifications = get_notifications(container)
 
     report = get_report_or_regression(
@@ -150,7 +152,11 @@ def new_files(container: Container, filename: str, fail_task_on_transient_error:
 
             if isinstance(notification.config, ADOTemplate):
                 notify_ado(
-                    notification.config, container, filename, report, fail_task_on_transient_error
+                    notification.config,
+                    container,
+                    filename,
+                    report,
+                    fail_task_on_transient_error,
                 )
 
             if isinstance(notification.config, GithubIssueTemplate):

--- a/src/api-service/__app__/onefuzzlib/notifications/main.py
+++ b/src/api-service/__app__/onefuzzlib/notifications/main.py
@@ -127,7 +127,7 @@ def get_queue_tasks() -> Sequence[Tuple[Task, Sequence[str]]]:
     return results
 
 
-def new_files(container: Container, filename: str, fail_task_on_error: bool) -> None:
+def new_files(container: Container, filename: str, fail_task_on_transient_error: bool) -> None:
     notifications = get_notifications(container)
 
     report = get_report_or_regression(
@@ -150,7 +150,7 @@ def new_files(container: Container, filename: str, fail_task_on_error: bool) -> 
 
             if isinstance(notification.config, ADOTemplate):
                 notify_ado(
-                    notification.config, container, filename, report, fail_task_on_error
+                    notification.config, container, filename, report, fail_task_on_transient_error
                 )
 
             if isinstance(notification.config, GithubIssueTemplate):

--- a/src/api-service/__app__/queue_file_changes/__init__.py
+++ b/src/api-service/__app__/queue_file_changes/__init__.py
@@ -13,25 +13,29 @@ from ..onefuzzlib.azure.storage import corpus_accounts
 from ..onefuzzlib.events import get_events
 from ..onefuzzlib.notifications.main import new_files
 
+# The number of time the function will be retried if an error occurs
+# https://docs.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-queue-trigger?tabs=csharp#poison-messages
+MAX_DEQUEUE_COUNT = 5
 
-def file_added(event: Dict) -> None:
+
+def file_added(event: Dict, fail_task_on_error: bool) -> None:
     parts = event["data"]["url"].split("/")[3:]
     container = parts[0]
     path = "/".join(parts[1:])
     logging.info("file added container: %s - path: %s", container, path)
-    new_files(container, path)
+    new_files(container, path, fail_task_on_error)
 
 
 def main(msg: func.QueueMessage, dashboard: func.Out[str]) -> None:
     event = json.loads(msg.get_body())
-
+    last_try = msg.dequeue_count == MAX_DEQUEUE_COUNT
     if event["topic"] not in corpus_accounts():
         return
 
     if event["eventType"] != "Microsoft.Storage.BlobCreated":
         return
 
-    file_added(event)
+    file_added(event, last_try)
 
     events = get_events()
     if events:

--- a/src/api-service/__app__/queue_file_changes/__init__.py
+++ b/src/api-service/__app__/queue_file_changes/__init__.py
@@ -18,12 +18,12 @@ from ..onefuzzlib.notifications.main import new_files
 MAX_DEQUEUE_COUNT = 5
 
 
-def file_added(event: Dict, fail_task_on_error: bool) -> None:
+def file_added(event: Dict, fail_task_on_transient_error: bool) -> None:
     parts = event["data"]["url"].split("/")[3:]
     container = parts[0]
     path = "/".join(parts[1:])
     logging.info("file added container: %s - path: %s", container, path)
-    new_files(container, path, fail_task_on_error)
+    new_files(container, path, fail_task_on_transient_error)
 
 
 def main(msg: func.QueueMessage, dashboard: func.Out[str]) -> None:


### PR DESCRIPTION
This PR introduce a new parameter `fail_task_on_transient_error` to the notification function. This parameter  is set to `True` when the maximum number of retry is reached for the queue message. 
This allows us the specify the behavior on failure by throwing an exception when a retry is required or fail the task otherwise.

