### PR TITLE
save the agents in a per-$(uname) directory during build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,12 +325,12 @@ jobs:
               cp artifacts/azcopy/azcopy artifacts/azcopy/ThirdPartyNotice.txt src/deployment/tools/linux
               cp artifacts/azcopy/azcopy.exe artifacts/azcopy/ThirdPartyNotice.txt src/deployment/tools/win64
           fi
-          cp artifacts/agent/onefuzz-supervisor.exe src/deployment/tools/win64/
-          cp artifacts/agent/onefuzz-agent.exe src/deployment/tools/win64/
-          cp artifacts/agent/onefuzz_supervisor.pdb src/deployment/tools/win64/
-          cp artifacts/agent/onefuzz_agent.pdb src/deployment/tools/win64/
-          cp artifacts/agent/onefuzz-supervisor src/deployment/tools/linux/
-          cp artifacts/agent/onefuzz-agent src/deployment/tools/linux/
+          cp artifacts/agent-MINGW*/onefuzz-supervisor.exe src/deployment/tools/win64/
+          cp artifacts/agent-MINGW*/onefuzz-agent.exe src/deployment/tools/win64/
+          cp artifacts/agent-MINGW*/onefuzz_supervisor.pdb src/deployment/tools/win64/
+          cp artifacts/agent-MINGW*/onefuzz_agent.pdb src/deployment/tools/win64/
+          cp artifacts/agent-Linux/onefuzz-supervisor src/deployment/tools/linux/
+          cp artifacts/agent-Linux/onefuzz-agent src/deployment/tools/linux/
           cp artifacts/proxy/onefuzz-proxy-manager src/deployment/tools/linux/
           cp artifacts/service/api-service.zip src/deployment
           cp -r artifacts/third-party src/deployment

--- a/src/ci/agent.sh
+++ b/src/ci/agent.sh
@@ -25,7 +25,7 @@ if [ "${GITHUB_REF}" != "" ]; then
     fi
 fi
 
-mkdir -p artifacts/agent
+mkdir -p artifacts/agent-$(uname)
 
 cd src/agent
 
@@ -53,11 +53,11 @@ cargo test --release --workspace
 # TODO: once Salvo is integrated, this can get deleted
 cargo build --release --manifest-path ./onefuzz-telemetry/Cargo.toml --all-features
 
-cp target/release/onefuzz-agent* ../../artifacts/agent
-cp target/release/onefuzz-supervisor* ../../artifacts/agent
+cp target/release/onefuzz-agent* ../../artifacts/agent-$(uname)
+cp target/release/onefuzz-supervisor* ../../artifacts/agent-$(uname)
 
 if exists target/release/*.pdb; then
     for file in target/release/*.pdb; do
-        cp ${file} ../../artifacts/agent
+        cp ${file} ../../artifacts/agent-$(uname)
     done
 fi


### PR DESCRIPTION
This fixes a race condition from the linux & osx agent builds, that if the osx builds take longer than linux builds, we produce an invalid release.