### PR TITLE
Pool shrink queue

### DIFF
--- a/src/api-service/__app__/agent_registration/__init__.py
+++ b/src/api-service/__app__/agent_registration/__init__.py
@@ -102,7 +102,8 @@ def post(req: func.HttpRequest) -> func.HttpResponse:
         node.delete()
 
     node = Node.create(
-        pool_name=registration_request.pool_name,
+        pool_id=pool.pool_id,
+        pool_name=pool.name,
         machine_id=registration_request.machine_id,
         scaleset_id=registration_request.scaleset_id,
         version=registration_request.version,

--- a/src/api-service/__app__/onefuzzlib/workers/nodes.py
+++ b/src/api-service/__app__/onefuzzlib/workers/nodes.py
@@ -48,6 +48,7 @@ class Node(BASE_NODE, ORMMixin):
     def create(
         cls,
         *,
+        pool_id: UUID,
         pool_name: PoolName,
         machine_id: UUID,
         scaleset_id: Optional[UUID],
@@ -55,6 +56,7 @@ class Node(BASE_NODE, ORMMixin):
         new: bool = False,
     ) -> "Node":
         node = cls(
+            pool_id=pool_id,
             pool_name=pool_name,
             machine_id=machine_id,
             scaleset_id=scaleset_id,
@@ -78,11 +80,14 @@ class Node(BASE_NODE, ORMMixin):
     def search_states(
         cls,
         *,
+        pool_id: Optional[UUID] = None,
         scaleset_id: Optional[UUID] = None,
         states: Optional[List[NodeState]] = None,
         pool_name: Optional[PoolName] = None,
     ) -> List["Node"]:
         query: QueryFilter = {}
+        if pool_id:
+            query["pool_id"] = [pool_id]
         if scaleset_id:
             query["scaleset_id"] = [scaleset_id]
         if states:
@@ -95,6 +100,7 @@ class Node(BASE_NODE, ORMMixin):
     def search_outdated(
         cls,
         *,
+        pool_id: Optional[UUID] = None,
         scaleset_id: Optional[UUID] = None,
         states: Optional[List[NodeState]] = None,
         pool_name: Optional[PoolName] = None,
@@ -102,6 +108,8 @@ class Node(BASE_NODE, ORMMixin):
         num_results: Optional[int] = None,
     ) -> List["Node"]:
         query: QueryFilter = {}
+        if pool_id:
+            query["pool_id"] = [pool_id]
         if scaleset_id:
             query["scaleset_id"] = [scaleset_id]
         if states:

--- a/src/api-service/__app__/onefuzzlib/workers/nodes.py
+++ b/src/api-service/__app__/onefuzzlib/workers/nodes.py
@@ -253,6 +253,10 @@ class Node(BASE_NODE, ORMMixin):
     def could_shrink_scaleset(self) -> bool:
         if self.scaleset_id and ShrinkQueue(self.scaleset_id).should_shrink():
             return True
+
+        if self.pool_id and ShrinkQueue(self.pool_id).should_shrink():
+            return True
+
         return False
 
     def can_process_new_work(self) -> bool:

--- a/src/api-service/__app__/onefuzzlib/workers/scalesets.py
+++ b/src/api-service/__app__/onefuzzlib/workers/scalesets.py
@@ -378,6 +378,9 @@ class Scaleset(BASE_SCALESET, ORMMixin):
                 if ShrinkQueue(self.scaleset_id).should_shrink():
                     node.set_halt()
                     to_delete.append(node)
+                elif ShrinkQueue(pool.pool_id).should_shrink():
+                    node.set_halt()
+                    to_delete.append(node)
                 else:
                     to_reimage.append(node)
 


### PR DESCRIPTION
This isn't used at the moment, but pulled forwards from the autoscale
PR.  The functionality replicates the scaleset based shrink-queue, but
at the context of pools.

This is built on top of #1049, which should be merged first.