### PR TITLE
force upgrade custom script extensions

### DIFF
--- a/src/api-service/__app__/onefuzzlib/extension.py
+++ b/src/api-service/__app__/onefuzzlib/extension.py
@@ -212,7 +212,6 @@ def agent_config(
             "publisher": "Microsoft.Compute",
             "location": region,
             "force_update_tag": uuid4(),
-            "enable_automatic_upgrade": True,
             "type_handler_version": "1.9",
             "auto_upgrade_minor_version": True,
             "settings": {"commandToExecute": to_execute_cmd, "fileUris": urls},
@@ -250,7 +249,6 @@ def agent_config(
             "location": region,
             "autoUpgradeMinorVersion": True,
             "force_update_tag": uuid4(),
-            "enable_automatic_upgrade": True,
             "settings": {"commandToExecute": to_execute_cmd, "fileUris": urls},
             "protectedSettings": {},
         }

--- a/src/api-service/__app__/onefuzzlib/extension.py
+++ b/src/api-service/__app__/onefuzzlib/extension.py
@@ -5,7 +5,7 @@
 
 import os
 from typing import List, Optional
-from uuid import UUID
+from uuid import UUID, uuid4
 
 from onefuzztypes.enums import OS, AgentMode
 from onefuzztypes.models import AgentConfig, Pool, ReproConfig, Scaleset
@@ -211,6 +211,8 @@ def agent_config(
             "type": "CustomScriptExtension",
             "publisher": "Microsoft.Compute",
             "location": region,
+            "force_update_tag": uuid4(),
+            "enable_automatic_upgrade": True,
             "type_handler_version": "1.9",
             "auto_upgrade_minor_version": True,
             "settings": {"commandToExecute": to_execute_cmd, "fileUris": urls},
@@ -247,6 +249,8 @@ def agent_config(
             "typeHandlerVersion": "2.1",
             "location": region,
             "autoUpgradeMinorVersion": True,
+            "force_update_tag": uuid4(),
+            "enable_automatic_upgrade": True,
             "settings": {"commandToExecute": to_execute_cmd, "fileUris": urls},
             "protectedSettings": {},
         }


### PR DESCRIPTION
By setting a unique `force_update_tag` on each update the VMs are forced to use the latest version each time they push an update.

https://docs.microsoft.com/en-us/python/api/azure-mgmt-compute/azure.mgmt.compute.v2021_03_01.models.virtualmachinescalesetextension?view=azure-python