### PR TITLE
use managed identity reader access for scaleset configs

### DIFF
--- a/src/api-service/__app__/onefuzzlib/azure/containers.py
+++ b/src/api-service/__app__/onefuzzlib/azure/containers.py
@@ -222,7 +222,8 @@ def get_file_url(container: Container, name: str, storage_type: StorageType) -> 
     if not client:
         raise Exception("unable to find container: %s - %s" % (container, storage_type))
 
-    return f"{get_url(client.account_name)}/{container}/{name}"
+    # get_url has a trailing '/'
+    return f"{get_url(client.account_name)}{container}/{name}"
 
 
 def get_file_sas_url(

--- a/src/api-service/__app__/onefuzzlib/azure/containers.py
+++ b/src/api-service/__app__/onefuzzlib/azure/containers.py
@@ -217,6 +217,14 @@ def get_container_sas_url(
     )
 
 
+def get_file_url(container: Container, name: str, storage_type: StorageType) -> str:
+    client = find_container(container, storage_type)
+    if not client:
+        raise Exception("unable to find container: %s - %s" % (container, storage_type))
+
+    return f"{get_url(client.account_name)}/{container}/{name}"
+
+
 def get_file_sas_url(
     container: Container,
     name: str,

--- a/src/api-service/__app__/onefuzzlib/azure/vmss.py
+++ b/src/api-service/__app__/onefuzzlib/azure/vmss.py
@@ -212,6 +212,7 @@ def update_extensions(name: UUID, extensions: List[Any]) -> None:
         str(name),
         {"virtual_machine_profile": {"extension_profile": {"extensions": extensions}}},
     )
+    logging.info("VM extensions updated: %s", name)
 
 
 def create_vmss(

--- a/src/deployment/azuredeploy.json
+++ b/src/deployment/azuredeploy.json
@@ -751,7 +751,7 @@
             "name": "[guid(concat(resourceGroup().id, '-user_managed_idenity_read_blob'))]",
             "properties": {
                 "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', variables('Storage Blob Data Reader'))]",
-                "principalId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('scaleset_identity')), '2018-02-01', 'Full').properties.principalId]"
+                "principalId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('scaleset_identity')), '2018-11-30', 'Full').properties.principalId]"
             },
             "DependsOn": [
                 "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountNameFunc'))]"

--- a/src/deployment/azuredeploy.json
+++ b/src/deployment/azuredeploy.json
@@ -66,6 +66,7 @@
         "Network Contributor": "4d97b98b-1d4f-4787-a291-c67834d212e7",
         "Storage Account Contributor": "17d1049b-9a84-46fb-8f53-869881c3d3ab",
         "Virtual Machine Contributor": "9980e02c-c2be-4d73-94e8-173b1dc7cf3c",
+        "Storage Blob Data Reader": "2a2b9908-6ea1-4ae2-8e65-a410df84e7d1",
         "keyVaultName": "[concat('of-kv-', uniquestring(resourceGroup().id))]"
     },
     "functions": [
@@ -739,6 +740,21 @@
             },
             "DependsOn": [
                 "[resourceId('Microsoft.Web/sites', parameters('name'))]"
+            ],
+            "tags": {
+                "OWNER": "[parameters('owner')]"
+            }
+        },
+        {
+            "type": "Microsoft.Authorization/roleAssignments",
+            "apiVersion": "2017-09-01",
+            "name": "[guid(concat(resourceGroup().id, '-user_managed_idenity_read_blob'))]",
+            "properties": {
+                "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', variables('Storage Blob Data Reader'))]",
+                "principalId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('scaleset_identity')), '2018-02-01', 'Full').properties.principalId]"
+            },
+            "DependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountNameFunc'))]"
             ],
             "tags": {
                 "OWNER": "[parameters('owner')]"

--- a/src/deployment/azuredeploy.json
+++ b/src/deployment/azuredeploy.json
@@ -747,7 +747,7 @@
         },
         {
             "type": "Microsoft.Authorization/roleAssignments",
-            "apiVersion": "2018-11-30",
+            "apiVersion": "2017-09-01",
             "name": "[guid(concat(resourceGroup().id, '-user_managed_idenity_read_blob'))]",
             "properties": {
                 "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', variables('Storage Blob Data Reader'))]",

--- a/src/deployment/azuredeploy.json
+++ b/src/deployment/azuredeploy.json
@@ -747,7 +747,7 @@
         },
         {
             "type": "Microsoft.Authorization/roleAssignments",
-            "apiVersion": "2017-09-01",
+            "apiVersion": "2018-07-01",
             "name": "[guid(concat(resourceGroup().id, '-user_managed_idenity_read_blob'))]",
             "properties": {
                 "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', variables('Storage Blob Data Reader'))]",

--- a/src/deployment/azuredeploy.json
+++ b/src/deployment/azuredeploy.json
@@ -747,7 +747,7 @@
         },
         {
             "type": "Microsoft.Authorization/roleAssignments",
-            "apiVersion": "2017-09-01",
+            "apiVersion": "2018-11-30",
             "name": "[guid(concat(resourceGroup().id, '-user_managed_idenity_read_blob'))]",
             "properties": {
                 "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', variables('Storage Blob Data Reader'))]",


### PR DESCRIPTION
The new custom script extension configs are not always pulled during reimage.  As such, VMs that outlive the SAS duration may not reimage correctly.

This moves to using a role assignment created at deployment for the scalesets to give read access to the `config` blob storage using the managed identity, rather than using SAS URLs.

https://docs.microsoft.com/en-us/azure/virtual-machines/extensions/custom-script-linux#property-managedidentity

Short-life VMs (proxies & repros) continue to use the existing SAS mechanism.