### PR TITLE
attempt to log panic stack trace to the supervisor failure log

### DIFF
--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7a2e47a1fbe209ee101dd6d61285226744c6c8d3c21c8dc878ba6cb9f467f3a"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -131,6 +140,21 @@ dependencies = [
  "pin-project",
  "rand 0.8.4",
  "tokio",
+]
+
+[[package]]
+name = "backtrace"
+version = "0.3.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7815ea54e4d821e791162e078acbebfd6d8c8939cd559c9335dceb1c8ca7282"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
 ]
 
 [[package]]
@@ -882,6 +906,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e4075386626662786ddb0ec9081e7c7eeb1ba31951f447ca780ef9f5d568189"
+
+[[package]]
 name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1498,6 +1528,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a38f2be3697a57b4060074ff41b44c16870d916ad7877c17696e063257482bc7"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1596,6 +1635,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "backtrace",
  "clap",
  "downcast-rs",
  "env_logger",

--- a/src/agent/onefuzz-supervisor/Cargo.toml
+++ b/src/agent/onefuzz-supervisor/Cargo.toml
@@ -25,6 +25,7 @@ uuid = { version = "0.8", features = ["serde", "v4"] }
 clap = "2.33"
 reqwest-retry = { path = "../reqwest-retry" }
 onefuzz-telemetry = { path = "../onefuzz-telemetry" }
+backtrace = "0.3"
 
 [target.'cfg(target_family = "unix")'.dependencies]
 users = "0.11"

--- a/src/agent/onefuzz-supervisor/src/logpanic.rs
+++ b/src/agent/onefuzz-supervisor/src/logpanic.rs
@@ -1,0 +1,22 @@
+use crate::failure::save_failure;
+use backtrace::Backtrace;
+use std::panic;
+use std::sync::Once;
+
+fn panic_hook(info: &panic::PanicInfo) {
+    let err = anyhow!("supervisor panicked: {}\n{:?}", info, Backtrace::new());
+    if let Err(err) = save_failure(&err) {
+        error!("unable to write panic log: {:?}", err);
+    }
+}
+
+pub fn set_panic_handler() {
+    static SET_HOOK: Once = Once::new();
+    SET_HOOK.call_once(move || {
+        let old_hook = panic::take_hook();
+        panic::set_hook(Box::new(move |info| {
+            panic_hook(&info);
+            old_hook(info);
+        }));
+    });
+}

--- a/src/agent/onefuzz-supervisor/src/main.rs
+++ b/src/agent/onefuzz-supervisor/src/main.rs
@@ -15,7 +15,7 @@ extern crate onefuzz;
 
 use crate::{
     config::StaticConfig, coordinator::StateUpdateEvent, heartbeat::init_agent_heartbeat,
-    logpanic::set_panic_handler, work::WorkSet, worker::WorkerEvent,
+    panic::set_panic_handler, work::WorkSet, worker::WorkerEvent,
 };
 use std::path::PathBuf;
 
@@ -36,7 +36,7 @@ pub mod debug;
 pub mod done;
 pub mod failure;
 pub mod heartbeat;
-pub mod logpanic;
+pub mod panic;
 pub mod reboot;
 pub mod scheduler;
 pub mod setup;

--- a/src/agent/onefuzz-supervisor/src/main.rs
+++ b/src/agent/onefuzz-supervisor/src/main.rs
@@ -15,7 +15,7 @@ extern crate onefuzz;
 
 use crate::{
     config::StaticConfig, coordinator::StateUpdateEvent, heartbeat::init_agent_heartbeat,
-    work::WorkSet, worker::WorkerEvent,
+    logpanic::set_panic_handler, work::WorkSet, worker::WorkerEvent,
 };
 use std::path::PathBuf;
 
@@ -36,6 +36,7 @@ pub mod debug;
 pub mod done;
 pub mod failure;
 pub mod heartbeat;
+pub mod logpanic;
 pub mod reboot;
 pub mod scheduler;
 pub mod setup;
@@ -60,6 +61,8 @@ fn main() -> Result<()> {
     env_logger::init();
 
     let opt = Opt::from_args();
+
+    set_panic_handler();
 
     match opt {
         Opt::Run(opt) => run(opt)?,

--- a/src/agent/onefuzz-supervisor/src/panic.rs
+++ b/src/agent/onefuzz-supervisor/src/panic.rs
@@ -1,7 +1,6 @@
 use crate::failure::save_failure;
 use backtrace::Backtrace;
-use std::panic;
-use std::sync::Once;
+use std::{panic, sync::Once};
 
 fn panic_hook(info: &panic::PanicInfo) {
     let err = anyhow!("supervisor panicked: {}\n{:?}", info, Backtrace::new());


### PR DESCRIPTION
While investigating #1042, I found a gap in logs that is indicative of the supervisor panicking.  

This PR adds a panic handler that reuses the existing 'failure log' mechanism to record the panic and backtrace.  The failure log mechanism enables recording runtime errors to a file, which is sent to the service on restart.