### PR TITLE
fix issue specifying target_options for libfuzzer targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -357,8 +357,10 @@ jobs:
           cp integration-test.py artifacts/
 
           mkdir -p artifacts/linux-libfuzzer
+          mkdir -p artifacts/linux-libfuzzer-with-options
           (cd libfuzzer ; make )
           cp -r libfuzzer/fuzz.exe libfuzzer/seeds artifacts/linux-libfuzzer
+          cp -r libfuzzer/fuzz.exe libfuzzer/seeds artifacts/linux-libfuzzer-with-options
 
           mkdir -p artifacts/linux-libfuzzer-regression
           (cd libfuzzer-regression ; make )

--- a/src/cli/onefuzz/templates/libfuzzer.py
+++ b/src/cli/onefuzz/templates/libfuzzer.py
@@ -152,7 +152,7 @@ class Libfuzzer(Command):
         #
         # For now, locally extend the `target_options` for this task only, to ensure that
         # test case invocations work as expected.
-        coverage_target_options = target_options or []
+        coverage_target_options = target_options.copy() if target_options else []
         coverage_target_options.append("{input}")
 
         # Opposite precedence to `effective_crash_report_timeout`.

--- a/src/integration-tests/integration-test.py
+++ b/src/integration-tests/integration-test.py
@@ -68,6 +68,7 @@ class Integration(BaseModel):
     disable_check_debugger: Optional[bool] = Field(default=False)
     reboot_after_setup: Optional[bool] = Field(default=False)
     test_repro: Optional[bool] = Field(default=True)
+    target_options: Optional[List[str]]
 
 
 TARGETS: Dict[str, Integration] = {
@@ -89,6 +90,19 @@ TARGETS: Dict[str, Integration] = {
             ContainerType.inputs: 2,
         },
         reboot_after_setup=True,
+    ),
+    "linux-libfuzzer-with-options": Integration(
+        template=TemplateType.libfuzzer,
+        os=OS.linux,
+        target_exe="fuzz.exe",
+        inputs="seeds",
+        wait_for_files={
+            ContainerType.unique_reports: 1,
+            ContainerType.coverage: 1,
+            ContainerType.inputs: 2,
+        },
+        reboot_after_setup=True,
+        target_options=["-runs=1000"],
     ),
     "linux-libfuzzer-dlopen": Integration(
         template=TemplateType.libfuzzer,
@@ -264,6 +278,7 @@ class TestOnefuzz:
                     duration=duration,
                     vm_count=1,
                     reboot_after_setup=config.reboot_after_setup or False,
+                    target_options=config.target_options,
                 )
             elif config.template == TemplateType.libfuzzer_dotnet:
                 if setup is None:
@@ -278,6 +293,7 @@ class TestOnefuzz:
                     setup_dir=setup,
                     duration=duration,
                     vm_count=1,
+                    target_options=config.target_options,
                 )
             elif config.template == TemplateType.libfuzzer_qemu_user:
                 job = self.of.template.libfuzzer.qemu_user(
@@ -289,6 +305,7 @@ class TestOnefuzz:
                     target_exe=target_exe,
                     duration=duration,
                     vm_count=1,
+                    target_options=config.target_options,
                 )
             elif config.template == TemplateType.radamsa:
                 job = self.of.template.radamsa.basic(
@@ -315,6 +332,7 @@ class TestOnefuzz:
                     setup_dir=setup,
                     duration=duration,
                     vm_count=1,
+                    target_options=config.target_options,
                 )
             else:
                 raise NotImplementedError


### PR DESCRIPTION
Users specifying `--target_options` will get an invalid crash report options, as `libfuzzer_crash_report` doesn't require `{input}`.