### PR TITLE
sync batch processed results after every 10 inputs

### DIFF
--- a/src/agent/onefuzz-agent/src/tasks/coverage/generic.rs
+++ b/src/agent/onefuzz-agent/src/tasks/coverage/generic.rs
@@ -286,8 +286,8 @@ impl<'a> TaskContext<'a> {
                     if entry.file_type().await?.is_file() {
                         self.record_input(&entry.path()).await?;
                         count += 1;
-                        // make sure we save & sync coverage every 10 inputs
 
+                        // make sure we save & sync coverage every 10 inputs
                         if count % 10 == 0 {
                             self.save_and_sync_coverage().await?;
                         }

--- a/src/agent/onefuzz-agent/src/tasks/coverage/generic.rs
+++ b/src/agent/onefuzz-agent/src/tasks/coverage/generic.rs
@@ -286,6 +286,11 @@ impl<'a> TaskContext<'a> {
                     if entry.file_type().await?.is_file() {
                         self.record_input(&entry.path()).await?;
                         count += 1;
+                        // make sure we save & sync coverage every 10 inputs
+
+                        if count % 10 == 0 {
+                            self.save_and_sync_coverage().await?;
+                        }
                     } else {
                         warn!("skipping non-file dir entry: {}", entry.path().display());
                     }

--- a/src/agent/onefuzz-agent/src/tasks/coverage/libfuzzer_coverage.rs
+++ b/src/agent/onefuzz-agent/src/tasks/coverage/libfuzzer_coverage.rs
@@ -160,6 +160,7 @@ impl CoverageTask {
             })?;
         let mut seen_inputs = false;
 
+        let mut count = 0;
         loop {
             let input = match corpus.next_entry().await {
                 Ok(Some(input)) => input,
@@ -172,6 +173,12 @@ impl CoverageTask {
 
             processor.test_input(&input.path()).await?;
             seen_inputs = true;
+            count += 1;
+
+            // sync the coverage container after every 10 inputs
+            if count % 10 == 0 {
+                self.config.coverage.sync_push().await?;
+            }
         }
 
         Ok(seen_inputs)


### PR DESCRIPTION
When we have a analysis task with a large number of initial inputs, it may take an excessively long time before results show up in the analysis container.

This PR makes it such that we sync the analysis container after every 10 inputs.