### PR TITLE
Remove `Stream` impl for `DirectoryMonitor`

### DIFF
--- a/src/agent/onefuzz-agent/src/local/common.rs
+++ b/src/agent/onefuzz-agent/src/local/common.rs
@@ -4,11 +4,9 @@ use anyhow::Result;
 use backoff::{future::retry, Error as BackoffError, ExponentialBackoff};
 use clap::{App, Arg, ArgMatches};
 use flume::Sender;
-use onefuzz::jitter::delay_with_jitter;
 use onefuzz::{blob::url::BlobContainerUrl, monitor::DirectoryMonitor, syncdir::SyncedDir};
 use path_absolutize::Absolutize;
 use reqwest::Url;
-use std::task::Poll;
 use std::{
     collections::HashMap,
     env::current_dir,
@@ -275,17 +273,12 @@ impl DirectoryMonitorQueue {
         let handle: tokio::task::JoinHandle<Result<()>> = tokio::spawn(async move {
             let mut monitor = DirectoryMonitor::new(directory_path_clone.clone());
             monitor.start()?;
-            loop {
-                match monitor.poll_file() {
-                    Poll::Ready(Some(file_path)) => {
-                        let file_url = Url::from_file_path(file_path)
-                            .map_err(|_| anyhow!("invalid file path"))?;
-                        queue.enqueue(file_url).await?;
-                    }
-                    Poll::Ready(None) => break,
-                    Poll::Pending => delay_with_jitter(Duration::from_secs(1)).await,
-                }
+
+            while let Some(file_path) = monitor.next_file().await {
+                let file_url = Url::from_file_path(file_path).map_err(|_| anyhow!("invalid file path"))?;
+                queue.enqueue(file_url).await?;
             }
+
             Ok(())
         });
 

--- a/src/agent/onefuzz-agent/src/local/common.rs
+++ b/src/agent/onefuzz-agent/src/local/common.rs
@@ -275,7 +275,8 @@ impl DirectoryMonitorQueue {
             monitor.start()?;
 
             while let Some(file_path) = monitor.next_file().await {
-                let file_url = Url::from_file_path(file_path).map_err(|_| anyhow!("invalid file path"))?;
+                let file_url =
+                    Url::from_file_path(file_path).map_err(|_| anyhow!("invalid file path"))?;
                 queue.enqueue(file_url).await?;
             }
 

--- a/src/agent/onefuzz-agent/src/tasks/report/crash_report.rs
+++ b/src/agent/onefuzz-agent/src/tasks/report/crash_report.rs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 use anyhow::{Context, Result};
-use futures::StreamExt;
 use onefuzz::{blob::BlobUrl, monitor::DirectoryMonitor, syncdir::SyncedDir};
 use onefuzz_telemetry::{
     Event::{
@@ -276,7 +275,7 @@ pub async fn monitor_reports(
 
     let mut monitor = DirectoryMonitor::new(base_dir);
     monitor.start()?;
-    while let Some(file) = monitor.next().await {
+    while let Some(file) = monitor.next_file().await {
         let result = parse_report_file(file).await?;
         result.save(unique_reports, reports, no_crash).await?;
     }

--- a/src/agent/onefuzz/src/monitor.rs
+++ b/src/agent/onefuzz/src/monitor.rs
@@ -2,7 +2,10 @@
 // Licensed under the MIT License.
 
 use std::path::PathBuf;
-use std::sync::{self, mpsc::{Receiver as SyncReceiver, RecvError}};
+use std::sync::{
+    self,
+    mpsc::{Receiver as SyncReceiver, RecvError},
+};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
@@ -64,7 +67,7 @@ impl DirectoryMonitor {
             match event? {
                 DebouncedEvent::Create(path) => {
                     return Some(path);
-                },
+                }
                 DebouncedEvent::Remove(path) => {
                     if path == self.dir {
                         // The directory we were watching was removed; we're done.
@@ -82,7 +85,9 @@ impl DirectoryMonitor {
     }
 }
 
-fn into_async<T: Send + 'static>(sync_receiver: SyncReceiver<T>) -> (UnboundedReceiver<T>, JoinHandle<()>) {
+fn into_async<T: Send + 'static>(
+    sync_receiver: SyncReceiver<T>,
+) -> (UnboundedReceiver<T>, JoinHandle<()>) {
     let (sender, receiver) = unbounded_channel();
 
     let handle = thread::spawn(move || {

--- a/src/agent/onefuzz/src/monitor.rs
+++ b/src/agent/onefuzz/src/monitor.rs
@@ -4,7 +4,7 @@
 use std::path::PathBuf;
 use std::sync::{
     self,
-    mpsc::{Receiver as SyncReceiver, RecvError},
+    mpsc::Receiver as SyncReceiver,
 };
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
@@ -91,23 +91,17 @@ fn into_async<T: Send + 'static>(
     let (sender, receiver) = unbounded_channel();
 
     let handle = thread::spawn(move || {
-        loop {
-            match sync_receiver.recv() {
-                Ok(msg) => {
-                    if sender.send(msg).is_err() {
-                        // The async receiver is closed. We can't do anything else, so
-                        // drop this message and the sync receiver.
-                        break;
-                    }
-                }
-                Err(RecvError) => {
-                    // We'll never receive any more events.
-                    //
-                    // Exit the loop, which will drop our `sender` and hang up.
-                    break;
-                }
+        while let Ok(msg) = sync_receiver.recv() {
+            if sender.send(msg).is_err() {
+                // The async receiver is closed. We can't do anything else, so
+                // drop this message and the sync receiver.
+                break;
             }
         }
+
+        // We'll never receive any more events.
+        //
+        // Drop our `Sender` and hang up.
     });
 
     (receiver, handle)


### PR DESCRIPTION
The manual implementation of `Stream` for `DirectoryMonitor` misused the `Waker` provided by `poll_next()`. In practice, this resulted in telling the executor to poll the stream again _immediately_ after any non-terminal `try_recv()`. The end result was equivalent to calling `try_recv()` in a tight loop. This pegged agent CPU usage as soon as we started monitoring directories for new files.

Now, we take a much simpler approach. The private `into_async()` shim function spawns a thread that blocks on new (synchronous) `Receiver` messages, and then immediately sends them to an unbounded async `Receiver`. All subsequent API surface can thus be effortlessly async.

`DirectoryMonitor` now exports a public `next_file()` async method, which is equivalent in practice to implementing `Stream`. We aren't using any `Stream` combinators, we don't lose anything in doing this. We can also use this to impl `Stream` again later, if needed.

- [x] Locally tested that agent directory monitoring use sites pick up new files
- [x] Confirmed that agent CPU usage drops from 100% to < 1%.
- [ ] Manually tested tasks on deployed instance