### PR TITLE
Replace notifications by default

### DIFF
--- a/src/api-service/__app__/notifications/__init__.py
+++ b/src/api-service/__app__/notifications/__init__.py
@@ -39,7 +39,11 @@ def post(req: func.HttpRequest) -> func.HttpResponse:
     if isinstance(request, Error):
         return not_ok(request, context="notification create")
 
-    entry = Notification.create(container=request.container, config=request.config)
+    entry = Notification.create(
+        container=request.container,
+        config=request.config,
+        replace_existing=request.replace_existing,
+    )
     if isinstance(entry, Error):
         return not_ok(entry, context="notification create")
 

--- a/src/api-service/__app__/notifications/__init__.py
+++ b/src/api-service/__app__/notifications/__init__.py
@@ -7,16 +7,29 @@ import logging
 
 import azure.functions as func
 from onefuzztypes.models import Error
-from onefuzztypes.requests import NotificationCreate, NotificationGet
+from onefuzztypes.requests import (
+    NotificationCreate,
+    NotificationGet,
+    NotificationSearch,
+)
 
 from ..onefuzzlib.endpoint_authorization import call_if_user
 from ..onefuzzlib.events import get_events
 from ..onefuzzlib.notifications.main import Notification
-from ..onefuzzlib.request import not_ok, ok, parse_request
+from ..onefuzzlib.request import not_ok, ok, parse_request, parse_uri
 
 
 def get(req: func.HttpRequest) -> func.HttpResponse:
-    entries = Notification.search()
+    logging.info("notification search")
+    request = parse_uri(NotificationSearch, req)
+    if isinstance(request, Error):
+        return not_ok(request, context="notification search")
+
+    if request.container:
+        entries = Notification.search(query={"container": request.container})
+    else:
+        entries = Notification.search()
+
     return ok(entries)
 
 

--- a/src/api-service/__app__/onefuzzlib/job_templates/templates.py
+++ b/src/api-service/__app__/onefuzzlib/job_templates/templates.py
@@ -87,7 +87,9 @@ class JobTemplateIndex(BASE_INDEX, ORMMixin):
             for task_container in request.containers:
                 if task_container.type == notification_config.container_type:
                     notification = Notification.create(
-                        task_container.name, notification_config.notification.config
+                        task_container.name,
+                        notification_config.notification.config,
+                        True,
                     )
                     if isinstance(notification, Error):
                         return notification

--- a/src/api-service/__app__/onefuzzlib/notifications/main.py
+++ b/src/api-service/__app__/onefuzzlib/notifications/main.py
@@ -58,29 +58,25 @@ class Notification(models.Notification, ORMMixin):
         return notification
 
     @classmethod
-    def get_existing(
-        cls, container: Container, config: NotificationTemplate
-    ) -> Optional["Notification"]:
-        notifications = Notification.search(query={"container": [container]})
-        for notification in notifications:
-            if notification.config == config:
-                return notification
-        return None
-
-    @classmethod
     def key_fields(cls) -> Tuple[str, str]:
         return ("notification_id", "container")
 
     @classmethod
     def create(
-        cls, container: Container, config: NotificationTemplate
+        cls, container: Container, config: NotificationTemplate, replace_existing: bool
     ) -> Result["Notification"]:
         if not container_exists(container, StorageType.corpus):
             return Error(code=ErrorCode.INVALID_REQUEST, errors=["invalid container"])
 
-        existing = cls.get_existing(container, config)
-        if existing is not None:
-            return existing
+        if replace_existing:
+            existing = cls.search(query={"container": [container]})
+            for entry in existing:
+                logging.info(
+                    "replacing existing notification: %s",
+                    entry.notification_id,
+                    container,
+                )
+                entry.delete()
 
         entry = cls(container=container, config=config)
         entry.save()

--- a/src/cli/onefuzz/api.py
+++ b/src/cli/onefuzz/api.py
@@ -692,11 +692,17 @@ class Notifications(Endpoint):
     endpoint = "notifications"
 
     def create(
-        self, container: primitives.Container, config: models.NotificationConfig
+        self,
+        container: primitives.Container,
+        config: models.NotificationConfig,
+        *,
+        replace_existing: bool = True,
     ) -> models.Notification:
         """Create a notification based on a config file"""
 
-        config = requests.NotificationCreate(container=container, config=config.config)
+        config = requests.NotificationCreate(
+            container=container, config=config.config, replace_existing=replace_existing
+        )
         return self._req_model("POST", models.Notification, data=config)
 
     def create_teams(

--- a/src/cli/onefuzz/api.py
+++ b/src/cli/onefuzz/api.py
@@ -766,11 +766,17 @@ class Notifications(Endpoint):
             data=requests.NotificationGet(notification_id=notification_id_expanded),
         )
 
-    def list(self) -> List[models.Notification]:
+    def list(
+        self, *, container: Optional[List[primitives.Container]] = None
+    ) -> List[models.Notification]:
         """List notification integrations"""
 
         self.logger.debug("listing notification integrations")
-        return self._req_model_list("GET", models.Notification)
+        return self._req_model_list(
+            "GET",
+            models.Notification,
+            data=requests.NotificationSearch(container=container),
+        )
 
 
 class Tasks(Endpoint):

--- a/src/cli/onefuzz/api.py
+++ b/src/cli/onefuzz/api.py
@@ -696,7 +696,7 @@ class Notifications(Endpoint):
         container: primitives.Container,
         config: models.NotificationConfig,
         *,
-        replace_existing: bool = True,
+        replace_existing: bool = False,
     ) -> models.Notification:
         """Create a notification based on a config file"""
 

--- a/src/cli/onefuzz/template.py
+++ b/src/cli/onefuzz/template.py
@@ -63,17 +63,16 @@ class Template(Command):
                     self.onefuzz.tasks.delete(task.task_id)
 
                 if stop_notifications:
-                    notifications = self.onefuzz.notifications.list()
-                    for container in task.config.containers:
-                        for notification in notifications:
-                            if container.name == notification.container:
-                                self.logger.info(
-                                    "removing notification: %s",
-                                    notification.notification_id,
-                                )
-                                self.onefuzz.notifications.delete(
-                                    notification.notification_id
-                                )
+                    container_names = [x.name for x in task.config.containers]
+                    notifications = self.onefuzz.notifications.list(
+                        container=container_names
+                    )
+                    for notification in notifications:
+                        self.logger.info(
+                            "removing notification: %s",
+                            notification.notification_id,
+                        )
+                        self.onefuzz.notifications.delete(notification.notification_id)
 
 
 Template.stop.__doc__ = "stop a template job"

--- a/src/cli/onefuzz/templates/__init__.py
+++ b/src/cli/onefuzz/templates/__init__.py
@@ -119,7 +119,7 @@ class JobHelper:
             container = self.containers[ContainerType.reports]
 
         self.logger.info("creating notification config for %s", container)
-        self.onefuzz.notifications.create(container, config)
+        self.onefuzz.notifications.create(container, config, replace_existing=True)
 
     def upload_setup(
         self,

--- a/src/cli/onefuzz/templates/__init__.py
+++ b/src/cli/onefuzz/templates/__init__.py
@@ -123,8 +123,8 @@ class JobHelper:
             return
 
         config_dict = json.loads(config.json())
-        for entry in self.onefuzz.notifications.list():
-            if entry.container == container and entry.config == config_dict:
+        for entry in self.onefuzz.notifications.list(container=[container]):
+            if entry.config == config_dict:
                 self.logger.debug(
                     "notification already exists: %s", entry.notification_id
                 )

--- a/src/cli/onefuzz/templates/__init__.py
+++ b/src/cli/onefuzz/templates/__init__.py
@@ -3,7 +3,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-import json
 import os
 import tempfile
 import zipfile
@@ -118,17 +117,6 @@ class JobHelper:
             container = self.containers[ContainerType.unique_reports]
         else:
             container = self.containers[ContainerType.reports]
-
-        if not container:
-            return
-
-        config_dict = json.loads(config.json())
-        for entry in self.onefuzz.notifications.list(container=[container]):
-            if entry.config == config_dict:
-                self.logger.debug(
-                    "notification already exists: %s", entry.notification_id
-                )
-                return
 
         self.logger.info("creating notification config for %s", container)
         self.onefuzz.notifications.create(container, config)

--- a/src/pytypes/onefuzztypes/requests.py
+++ b/src/pytypes/onefuzztypes/requests.py
@@ -41,6 +41,7 @@ class JobSearch(BaseRequest):
 
 class NotificationCreate(BaseRequest, NotificationConfig):
     container: Container
+    replace_existing: bool = Field(default=True)
 
 
 class NotificationSearch(BaseRequest):

--- a/src/pytypes/onefuzztypes/requests.py
+++ b/src/pytypes/onefuzztypes/requests.py
@@ -41,7 +41,7 @@ class JobSearch(BaseRequest):
 
 class NotificationCreate(BaseRequest, NotificationConfig):
     container: Container
-    replace_existing: bool = Field(default=True)
+    replace_existing: bool = Field(default=False)
 
 
 class NotificationSearch(BaseRequest):

--- a/src/pytypes/onefuzztypes/requests.py
+++ b/src/pytypes/onefuzztypes/requests.py
@@ -43,6 +43,10 @@ class NotificationCreate(BaseRequest, NotificationConfig):
     container: Container
 
 
+class NotificationSearch(BaseRequest):
+    container: Optional[List[Container]]
+
+
 class NotificationGet(BaseRequest):
     notification_id: UUID
 


### PR DESCRIPTION
This PR adds two features:

1. On creating notifications for containers that already have notification configs, this replaces the existing notifications by default
2. Instead of returning all containers, then iterating over all containers, enable searching the notifications by container name