### PR TITLE
address non-utf8 errors in testing

### DIFF
--- a/src/agent/input-tester/src/tester.rs
+++ b/src/agent/input-tester/src/tester.rs
@@ -387,7 +387,7 @@ impl Tester {
                 let mut logs_dir = PathBuf::from(&copied_file);
                 logs_dir.set_file_name(format!(
                     "{}-logs",
-                    logs_dir.file_stem().unwrap().to_str().unwrap()
+                    logs_dir.file_stem().unwrap().to_string_lossy()
                 ));
                 self.create_test_failure_artifacts(&logs_dir, &result, &copied_file)?;
                 Ok(Some(new_test_result(

--- a/src/agent/onefuzz/src/expand.rs
+++ b/src/agent/onefuzz/src/expand.rs
@@ -124,7 +124,7 @@ impl<'a> Expand<'a> {
             Some(ExpandedValue::Path(fp)) => {
                 let file = PathBuf::from(fp);
                 let stem = file.file_stem()?;
-                let name_as_str = String::from(stem.to_str()?);
+                let name_as_str = stem.to_string_lossy().to_string();
                 Some(ExpandedValue::Scalar(name_as_str))
             }
             _ => None,
@@ -136,7 +136,7 @@ impl<'a> Expand<'a> {
             Some(ExpandedValue::Path(fp)) => {
                 let file = PathBuf::from(fp);
                 let name = file.file_name()?;
-                let name_as_str = String::from(name.to_str()?);
+                let name_as_str = name.to_string_lossy().to_string();
                 Some(ExpandedValue::Scalar(name_as_str))
             }
             _ => None,

--- a/src/agent/onefuzz/src/input_tester.rs
+++ b/src/agent/onefuzz/src/input_tester.rs
@@ -9,7 +9,7 @@ use crate::{
     expand::Expand,
     process::run_cmd,
 };
-use anyhow::{Error, Result};
+use anyhow::{Context, Error, Result};
 #[cfg(target_os = "linux")]
 use nix::sys::signal::{kill, Signal};
 use stacktrace_parser::CrashLog;
@@ -364,7 +364,9 @@ impl<'a> Tester<'a> {
             // 3. if we have an ASAN log to STDERR
             if crash_log.is_none() {
                 crash_log = if let Some(asan_dir) = &asan_dir {
-                    check_asan_path(asan_dir.path()).await?
+                    check_asan_path(asan_dir.path())
+                        .await
+                        .context("parsing ASAN logs failed")?
                 } else {
                     None
                 };
@@ -372,7 +374,9 @@ impl<'a> Tester<'a> {
 
             if crash_log.is_none() && self.check_asan_stderr {
                 if let Some(output) = output {
-                    crash_log = check_asan_string(output.stderr).await?;
+                    crash_log = check_asan_string(output.stderr)
+                        .await
+                        .context("parsing STDERR as ASAN failed")?;
                 }
             }
 
@@ -385,7 +389,11 @@ impl<'a> Tester<'a> {
     }
 
     pub async fn is_crash(&self, input_file: impl AsRef<Path>) -> Result<bool> {
-        let test_result = self.test_input(input_file).await?;
+        let input_file = input_file.as_ref();
+        let test_result = self
+            .test_input(input_file)
+            .await
+            .with_context(|| format!("testing input failed: {}", input_file.display()))?;
         Ok(test_result.crash_log.is_some())
     }
 }


### PR DESCRIPTION
This PR primarily addresses parsing non-UTF8 data from the application under test exposed by the inclusion of #1087.

Additionally, this PR does the following:
* Adds context to the generator tasks related to testing applications (helpful for finding this bug)
* Moves from `OsStr.to_str`, which is fallible in the case of non-utf8 values, to `to_string_lossy` in the potential callstacks of the generator.  This is primarily in filenames and can occur with misbehaving generators or applications.