### PR TITLE
ignore table exists errors from integration testing at the functions layer

### DIFF
--- a/src/integration-tests/integration-test.py
+++ b/src/integration-tests/integration-test.py
@@ -791,7 +791,7 @@ class TestOnefuzz:
             # which relate to azure-retry issues
             if (
                 message.startswith("Client-Request-ID=")
-                and "ResourceNotFound" in message
+                and ("ResourceNotFound" in message or "TableAlreadyExists" in message)
                 and entry.get("sdkVersion", "").startswith("azurefunctions")
             ):
                 continue


### PR DESCRIPTION
This relates to retry issues and isn't something that the integration tests should fail on.