### PR TITLE
process all expired nodes rather than those not already marked for deletion

### DIFF
--- a/src/api-service/__app__/onefuzzlib/workers/nodes.py
+++ b/src/api-service/__app__/onefuzzlib/workers/nodes.py
@@ -456,12 +456,9 @@ class Node(BASE_NODE, ORMMixin):
         time_filter = "Timestamp lt datetime'%s'" % (
             (datetime.datetime.utcnow() - NODE_REIMAGE_TIME).isoformat()
         )
-        # skip any nodes already marked for reimage/deletion
         for node in cls.search(
             query={
                 "scaleset_id": [scaleset_id],
-                "reimage_requested": [False],
-                "delete_requested": [False],
             },
             raw_unchecked_filter=time_filter,
         ):

--- a/src/api-service/__app__/onefuzzlib/workers/pools.py
+++ b/src/api-service/__app__/onefuzzlib/workers/pools.py
@@ -227,7 +227,6 @@ class Pool(BASE_POOL, ORMMixin):
             delete_queue(self.get_pool_queue(), StorageType.corpus)
             ShrinkQueue(self.pool_id).delete()
             logging.info("pool stopped, deleting: %s", self.name)
-            self.state = PoolState.halt
             self.delete()
             return
 


### PR DESCRIPTION
This makes sure debug_keep_node is reset and the rest of the reimage processing occurs regardless of reimage_requested and delete_requested being set.

Without this, nodes that are marked `debug_keep_node` do not get reimaged/deleted.