### PR TITLE
require {input} in target_env or target_options for generator and coverage tasks

### DIFF
--- a/src/api-service/__app__/onefuzzlib/tasks/config.py
+++ b/src/api-service/__app__/onefuzzlib/tasks/config.py
@@ -123,6 +123,19 @@ def check_target_exe(config: TaskConfig, definition: TaskDefinition) -> None:
         LOGGER.warning(err)
 
 
+def target_uses_input(config: TaskConfig) -> bool:
+    if config.task.target_options is not None:
+        for option in config.task.target_options:
+            if "{input}" in option:
+                return True
+    if config.task.target_env is not None:
+        for (key, value) in config.task.target_env.items():
+            if "{input}" in key or "{input}" in value:
+                return True
+
+    return False
+
+
 def check_config(config: TaskConfig) -> None:
     if config.task.type not in TASK_DEFINITIONS:
         raise TaskConfigError("unsupported task type: %s" % config.task.type.name)
@@ -141,6 +154,12 @@ def check_config(config: TaskConfig) -> None:
         err = "missing supervisor_exe"
         LOGGER.error(err)
         raise TaskConfigError("missing supervisor_exe")
+
+    if (
+        TaskFeature.target_must_use_input in definition.features
+        and not target_uses_input(config)
+    ):
+        raise TaskConfigError("{input} must be used in target_env or target_options")
 
     if config.vm:
         if not check_val(definition.vm.compare, definition.vm.value, config.vm.count):

--- a/src/api-service/__app__/onefuzzlib/tasks/config.py
+++ b/src/api-service/__app__/onefuzzlib/tasks/config.py
@@ -129,8 +129,8 @@ def target_uses_input(config: TaskConfig) -> bool:
             if "{input}" in option:
                 return True
     if config.task.target_env is not None:
-        for (key, value) in config.task.target_env.items():
-            if "{input}" in key or "{input}" in value:
+        for value in config.task.target_env.values():
+            if "{input}" in value:
                 return True
 
     return False

--- a/src/api-service/__app__/onefuzzlib/tasks/defs.py
+++ b/src/api-service/__app__/onefuzzlib/tasks/defs.py
@@ -21,6 +21,7 @@ TASK_DEFINITIONS = {
             TaskFeature.target_options,
             TaskFeature.target_timeout,
             TaskFeature.coverage_filter,
+            TaskFeature.target_must_use_input,
         ],
         vm=VmDefinition(compare=Compare.Equal, value=1),
         containers=[
@@ -375,6 +376,7 @@ TASK_DEFINITIONS = {
             TaskFeature.check_debugger,
             TaskFeature.check_retry_count,
             TaskFeature.ensemble_sync_delay,
+            TaskFeature.target_must_use_input,
         ],
         vm=VmDefinition(compare=Compare.AtLeast, value=1),
         containers=[

--- a/src/pytypes/onefuzztypes/enums.py
+++ b/src/pytypes/onefuzztypes/enums.py
@@ -81,6 +81,7 @@ class TaskFeature(Enum):
     report_list = "report_list"
     minimized_stack_depth = "minimized_stack_depth"
     coverage_filter = "coverage_filter"
+    target_must_use_input = "target_must_use_input"
 
 
 # Permissions for an Azure Blob Storage Container.


### PR DESCRIPTION
Fixes #925 