### PR TITLE
limit the azcopy concurrency

### DIFF
--- a/src/agent/onefuzz/src/az_copy.rs
+++ b/src/agent/onefuzz/src/az_copy.rs
@@ -58,6 +58,7 @@ async fn az_impl(mode: Mode, src: &OsStr, dst: &OsStr, args: &[&str]) -> Result<
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .env("AZCOPY_LOG_LOCATION", temp_dir.path())
+        .env("AZCOPY_CONCURRENCY_VALUE", 32)
         .arg(mode.to_string())
         .arg(&src)
         .arg(&dst)

--- a/src/agent/onefuzz/src/az_copy.rs
+++ b/src/agent/onefuzz/src/az_copy.rs
@@ -58,7 +58,7 @@ async fn az_impl(mode: Mode, src: &OsStr, dst: &OsStr, args: &[&str]) -> Result<
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .env("AZCOPY_LOG_LOCATION", temp_dir.path())
-        .env("AZCOPY_CONCURRENCY_VALUE", 32)
+        .env("AZCOPY_CONCURRENCY_VALUE", "32")
         .arg(mode.to_string())
         .arg(&src)
         .arg(&dst)


### PR DESCRIPTION
When running tasks with large numbers of machines, on VMs with large numbers of cores, with large numbers of files, we rapidly hit Azure Storage performance caps.

azcopy sets the concurrency rate to 32*NUM_CORES.  On a job with hundreds of VMs, this well exceeds the requests-per-second cap of storage accounts.

Ref: https://docs.microsoft.com/en-us/azure/storage/common/storage-use-azcopy-optimize#increase-the-number-of-concurrent-requests