### PR TITLE
don't overload `list` builtin

### DIFF
--- a/src/api-service/__app__/containers/__init__.py
+++ b/src/api-service/__app__/containers/__init__.py
@@ -47,7 +47,7 @@ def get(req: func.HttpRequest) -> func.HttpResponse:
                 read=True,
                 write=True,
                 delete=True,
-                list=True,
+                list_=True,
             ),
             metadata=metadata,
         )

--- a/src/api-service/__app__/onefuzzlib/azure/containers.py
+++ b/src/api-service/__app__/onefuzzlib/azure/containers.py
@@ -140,7 +140,7 @@ def create_container(
         read=True,
         write=True,
         delete=True,
-        list=True,
+        list_=True,
     )
 
 
@@ -164,7 +164,7 @@ def get_container_sas_url_service(
     read: bool = False,
     write: bool = False,
     delete: bool = False,
-    list: bool = False,
+    list_: bool = False,
     delete_previous_version: bool = False,
     tag: bool = False,
 ) -> str:
@@ -180,7 +180,7 @@ def get_container_sas_url_service(
             read=read,
             write=write,
             delete=delete,
-            list=list,
+            list=list_,
             delete_previous_version=delete_previous_version,
             tag=tag,
         ),
@@ -202,7 +202,7 @@ def get_container_sas_url(
     read: bool = False,
     write: bool = False,
     delete: bool = False,
-    list: bool = False,
+    list_: bool = False,
 ) -> str:
     client = find_container(container, storage_type)
     if not client:
@@ -213,7 +213,7 @@ def get_container_sas_url(
         read=read,
         write=write,
         delete=delete,
-        list=list,
+        list_=list_,
     )
 
 

--- a/src/api-service/__app__/onefuzzlib/extension.py
+++ b/src/api-service/__app__/onefuzzlib/extension.py
@@ -140,13 +140,13 @@ def update_managed_scripts() -> None:
                 Container("instance-specific-setup"),
                 StorageType.config,
                 read=True,
-                list=True,
+                list_=True,
             )
         ),
         "azcopy sync '%s' tools"
         % (
             get_container_sas_url(
-                Container("tools"), StorageType.config, read=True, list=True
+                Container("tools"), StorageType.config, read=True, list_=True
             )
         ),
     ]
@@ -291,7 +291,7 @@ def repro_extensions(
             "azcopy sync '%s' ./setup"
             % (
                 get_container_sas_url(
-                    setup_container, StorageType.corpus, read=True, list=True
+                    setup_container, StorageType.corpus, read=True, list_=True
                 )
             ),
         ]

--- a/src/api-service/__app__/onefuzzlib/tasks/config.py
+++ b/src/api-service/__app__/onefuzzlib/tasks/config.py
@@ -262,7 +262,7 @@ def build_task_config(
                         read=ContainerPermission.Read in container_def.permissions,
                         write=ContainerPermission.Write in container_def.permissions,
                         delete=ContainerPermission.Delete in container_def.permissions,
-                        list=ContainerPermission.List in container_def.permissions,
+                        list_=ContainerPermission.List in container_def.permissions,
                     ),
                 }
             )

--- a/src/api-service/__app__/onefuzzlib/tasks/scheduler.py
+++ b/src/api-service/__app__/onefuzzlib/tasks/scheduler.py
@@ -199,7 +199,7 @@ def build_work_set(tasks: List[Task]) -> Optional[Tuple[BucketConfig, WorkSet]]:
 
     if bucket_config:
         setup_url = get_container_sas_url(
-            bucket_config.setup_container, StorageType.corpus, read=True, list=True
+            bucket_config.setup_container, StorageType.corpus, read=True, list_=True
         )
 
         work_set = WorkSet(


### PR DESCRIPTION
This removes overloading the `list` built-in.