### PR TITLE
update memoization to 0.4.0

### DIFF
--- a/src/api-service/__app__/requirements.txt
+++ b/src/api-service/__app__/requirements.txt
@@ -24,7 +24,7 @@ opencensus-ext-azure~=1.0.2
 pydantic==1.8.2 --no-binary=pydantic
 PyJWT>=2.1.0
 requests~=2.25.1
-memoization~=0.3.1
+memoization~=0.4.0
 github3.py~=2.0.0
 typing-extensions~=3.10.0.0
 jsonpatch==1.32

--- a/src/cli/requirements.txt
+++ b/src/cli/requirements.txt
@@ -5,7 +5,7 @@ semver~=2.13.0
 signalrcore==0.9.2
 asciimatics~=1.13.0
 pydantic~=1.8.1 --no-binary=pydantic
-memoization~=0.3.1
+memoization~=0.4.0
 msrestazure==0.6.4
 azure-storage-blob~=12.8
 azure-applicationinsights==0.1.0


### PR DESCRIPTION
This primarily meant to enable addressing a warning for caching functions without arguments.

https://github.com/lonelyenvoy/python-memoization/releases/tag/v0.4.0