### PR TITLE
add srcview crate

### DIFF
--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -179,6 +179,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "bitvec"
+version = "0.19.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8942c8d352ae1838c9dda0b0ca2ab657696ef2232a20147cf1b30ae1a9cb4321"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -288,7 +300,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b076e143e1d9538dde65da30f8481c2a6c44040edb8e02b9bf1351edb92ce3"
 dependencies = [
  "lazy_static",
- "nom",
+ "nom 5.1.2",
  "serde",
 ]
 
@@ -748,6 +760,12 @@ name = "fuchsia-zircon-sys"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
+
+[[package]]
+name = "funty"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "futures"
@@ -1465,6 +1483,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "6.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7413f999671bd4745a7b624bd370a569fb6bc574b23c83a3c5ed2e453f3d5e2"
+dependencies = [
+ "bitvec",
+ "funty",
+ "lexical-core",
+ "memchr",
+ "version_check",
+]
+
+[[package]]
 name = "notify"
 version = "4.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1956,6 +1987,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "radium"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
+
+[[package]]
 name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2444,6 +2481,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "srcview"
+version = "0.1.0"
+dependencies = [
+ "log",
+ "nom 6.1.2",
+ "pdb",
+ "regex",
+ "serde",
+ "xml-rs",
+]
+
+[[package]]
 name = "stacktrace-parser"
 version = "0.1.0"
 dependencies = [
@@ -2572,6 +2621,12 @@ dependencies = [
  "rayon",
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -3130,6 +3185,12 @@ dependencies = [
  "winapi 0.2.8",
  "winapi-build",
 ]
+
+[[package]]
+name = "wyz"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
 name = "xml-rs"

--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -274,7 +274,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4aedb84272dbe89af497cf81375129abda4fc0a9e7c5d317498c15cc30c0d27"
 dependencies = [
- "nom",
+ "nom 5.1.2",
 ]
 
 [[package]]
@@ -526,19 +526,13 @@ dependencies = [
 
 [[package]]
 name = "ctrlc"
-version = "3.1.9"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "232295399409a8b7ae41276757b5a1cc21032848d42bff2352261f958b3ca29a"
+checksum = "377c9b002a72a0b2c1a18c62e2f3864bdfea4a015e3683a96e24aa45dd6c02d1"
 dependencies = [
- "nix 0.20.0",
+ "nix 0.22.0",
  "winapi 0.3.9",
 ]
-
-[[package]]
-name = "data-encoding"
-version = "2.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
 
 [[package]]
 name = "deadpool"
@@ -699,9 +693,9 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d34cfa13a63ae058bfa601fe9e313bbdb3746427c1459185464ce0fcf62e1e8"
+checksum = "975ccf83d8d9d0d84682850a38c8169027be83368805971cc4f238c2b245bc98"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -1075,9 +1069,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60daa14be0e0786db0f03a9e57cb404c9d756eed2b6c62b9ea98ec5743ec75a9"
+checksum = "399c583b2979440c60be0821a6199eca73bc3c8dcd9d070d75ac726e2c6186e5"
 dependencies = [
  "bytes 1.0.1",
  "http",
@@ -1086,9 +1080,9 @@ dependencies = [
 
 [[package]]
 name = "http-types"
-version = "2.11.1"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad077d89137cd3debdce53c66714dc536525ef43fe075d41ddc0a8ac11f85957"
+checksum = "6e9b187a72d63adbfba487f48095306ac823049cb504ee195541e91c7775f5ad"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -1278,9 +1272,9 @@ checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "js-sys"
-version = "0.3.51"
+version = "0.3.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83bdfbace3a0e81a4253f73b49e960b053e396a11012cbd49b9b74d6a2b67062"
+checksum = "ce791b7ca6638aae45be056e068fc756d871eb3b3b10b8efa62d1c9cec616752"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1322,9 +1316,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.98"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
+checksum = "a7f823d141fe0a24df1e23b4af4e3c7ba9e5966ec514ea068c93024aa7deb765"
 
 [[package]]
 name = "libclusterfuzz"
@@ -1530,21 +1524,22 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa9b4819da1bc61c0ea48b63b7bc8604064dd43013e7cc325df098d49cd7c18a"
+checksum = "5c3728fec49d363a50a8828a190b379a446cc5cf085c06259bbbeb34447e4ec7"
 dependencies = [
  "bitflags",
  "cc",
  "cfg-if 1.0.0",
  "libc",
+ "memoffset",
 ]
 
 [[package]]
 name = "nix"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c3728fec49d363a50a8828a190b379a446cc5cf085c06259bbbeb34447e4ec7"
+checksum = "cf1e25ee6b412c2a1e3fcb6a4499a5c1bfe7f43e014bdce9a6b6666e5aa2d187"
 dependencies = [
  "bitflags",
  "cc",
@@ -2195,9 +2190,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ab49abadf3f9e1c4bc499e8845e152ad87d2ad2d30371841171169e9d75feee"
+checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
 dependencies = [
  "bitflags",
 ]
@@ -2427,11 +2422,10 @@ dependencies = [
 
 [[package]]
 name = "serde_qs"
-version = "0.7.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5af82de3c6549b001bec34961ff2d6a54339a87bab37ce901b693401f27de6cb"
+checksum = "d8a72808528a89fa9eca23bbb6a1eb92cb639b881357269b6510f11e50c0f8a9"
 dependencies = [
- "data-encoding",
  "percent-encoding",
  "serde",
  "thiserror",
@@ -2511,9 +2505,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f173ac3d1a7e3b28003f40de0b5ce7fe2710f9b9dc3fc38664cebee46b3b6527"
+checksum = "c307a32c1c5c437f38c7fd45d753050587732ba8628319fbdf12a7e289ccc590"
 
 [[package]]
 name = "sm"
@@ -3095,9 +3089,9 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.74"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54ee1d4ed486f78874278e63e4069fc1ab9f6a18ca492076ffb90c5eb2997fd"
+checksum = "b608ecc8f4198fe8680e2ed18eccab5f0cd4caaf3d83516fa5fb2e927fda2586"
 dependencies = [
  "cfg-if 1.0.0",
  "serde",
@@ -3107,9 +3101,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.74"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b33f6a0694ccfea53d94db8b2ed1c3a8a4c86dd936b13b9f0a15ec4a451b900"
+checksum = "580aa3a91a63d23aac5b6b267e2d13cb4f363e31dce6c352fca4752ae12e479f"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -3122,9 +3116,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.24"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fba7978c679d53ce2d0ac80c8c175840feb849a161664365d1287b41f2e67f1"
+checksum = "16646b21c3add8e13fdb8f20172f8a28c3dbf62f45406bcff0233188226cfe0c"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -3134,9 +3128,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.74"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "088169ca61430fe1e58b8096c24975251700e7b1f6fd91cc9d59b04fb9b18bd4"
+checksum = "171ebf0ed9e1458810dfcb31f2e766ad6b3a89dbda42d8901f2b268277e5f09c"
 dependencies = [
  "quote 1.0.9",
  "wasm-bindgen-macro-support",
@@ -3144,9 +3138,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.74"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be2241542ff3d9f241f5e2cb6dd09b37efe786df8851c54957683a49f0987a97"
+checksum = "6c2657dd393f03aa2a659c25c6ae18a13a4048cebd220e147933ea837efc589f"
 dependencies = [
  "proc-macro2 1.0.28",
  "quote 1.0.9",
@@ -3157,15 +3151,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.74"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7cff876b8f18eed75a66cf49b65e7f967cb354a7aa16003fb55dbfd25b44b4f"
+checksum = "2e0c4a743a309662d45f4ede961d7afa4ba4131a59a639f29b0069c3798bbcc2"
 
 [[package]]
 name = "web-sys"
-version = "0.3.51"
+version = "0.3.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e828417b379f3df7111d3a2a9e5753706cae29c41f7c4029ee9fd77f3e09e582"
+checksum = "01c70a82d842c9979078c772d4a1344685045f1a5628f677c2b2eab4dd7d2696"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/src/agent/Cargo.toml
+++ b/src/agent/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "onefuzz-supervisor",
     "onefuzz-telemetry",
     "reqwest-retry",
+    "srcview",
     "storage-queue",
     "win-util",
     "libclusterfuzz",

--- a/src/agent/srcview/Cargo.toml
+++ b/src/agent/srcview/Cargo.toml
@@ -4,6 +4,11 @@ version = "0.1.0"
 edition = "2018"
 license = "MIT"
 
+[features]
+# Feature to gate tests that depend on binary artifacts, should be removed when
+# #1143 is resolved.
+binary-tests = []
+
 [dependencies]
 log = "0.4"
 nom = "6"

--- a/src/agent/srcview/Cargo.toml
+++ b/src/agent/srcview/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "srcview"
+version = "0.1.0"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+log = "0.4"
+nom = "6"
+pdb = "0.7"
+regex = "1"
+serde = { version = "1", features = ["derive"] }
+xml-rs = "0.8"

--- a/src/agent/srcview/Cargo.toml
+++ b/src/agent/srcview/Cargo.toml
@@ -2,8 +2,7 @@
 name = "srcview"
 version = "0.1.0"
 edition = "2018"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+license = "MIT"
 
 [dependencies]
 log = "0.4"

--- a/src/agent/srcview/README.md
+++ b/src/agent/srcview/README.md
@@ -27,7 +27,7 @@ See [`azure-pipelines.yml`](azure-pipelines.yml).
 
 Install [Coverage Gutters](https://marketplace.visualstudio.com/items?itemName=ryanluker.vscode-coverage-gutters),
 then place a file named `coverage.xml` at a location such that the relative
-file paths match your repo. Note that this is a fille you should generate
+file paths match your repo. Note that this is a file you should generate
 yourself, and that the `coverage.xml` included in this repo will probably not
 help you. From there, navigate to any file you expect to see coverage in. If
 the paths and coverage file correctly line up, you should see red or green bars

--- a/src/agent/srcview/README.md
+++ b/src/agent/srcview/README.md
@@ -1,0 +1,34 @@
+# srcview
+
+A library for mapping module+offset to source:line. Note that you'll get
+significantly better results if you use instruction level coverage as
+opposed to branch. Alternatively you're welcome to post-process branch
+coverage into instruction, but this project does not assist with that.
+
+## Docs
+
+`cargo doc --open`
+
+## Usage
+
+See [`examples/dump_cobertura.rs`](examples/dump_cobertura.rs).
+
+This can be run with `cargo run --example dump_cobertura res\example.pdb res\example.txt`.
+
+The biggest challenge when making this work is likely getting the absolute PDB
+paths to match relative paths inside your repo. To make this a bit easier, you
+can dump the PDB paths with: `cargo run --example dump_paths res\example.pdb`
+
+## ADO Integration
+
+See [`azure-pipelines.yml`](azure-pipelines.yml).
+
+## VSCode Integration
+
+Install [Coverage Gutters](https://marketplace.visualstudio.com/items?itemName=ryanluker.vscode-coverage-gutters),
+then place a file named `coverage.xml` at a location such that the relative
+file paths match your repo. Note that this is a fille you should generate
+yourself, and that the `coverage.xml` included in this repo will probably not
+help you. From there, navigate to any file you expect to see coverage in. If
+the paths and coverage file correctly line up, you should see red or green bars
+next to the source lines.

--- a/src/agent/srcview/TODO.md
+++ b/src/agent/srcview/TODO.md
@@ -1,0 +1,6 @@
+# TODO
+- add trace/info/warn
+- flesh out modoff parser error
+- consider using Cow to reduce memory usage
+- consider mixed case module names?
+- redo xml generation to not be hand-rolled

--- a/src/agent/srcview/examples/dump_cobertura.rs
+++ b/src/agent/srcview/examples/dump_cobertura.rs
@@ -1,0 +1,52 @@
+use std::path::Path;
+use std::{env, fs, process};
+
+use srcview::{ModOff, Report, SrcLine, SrcView};
+
+fn main() {
+    let args = env::args().collect::<Vec<String>>();
+
+    if args.len() != 3 {
+        eprintln!("Usage: {} <pdb> <modoff.txt>", args[0]);
+        process::exit(1);
+    }
+
+    let pdb_path = Path::new(&args[1]);
+    let modoff_path = Path::new(&args[2]);
+
+    // read our modoff file and parse it to a vector
+    let modoff_data = fs::read_to_string(&modoff_path).unwrap();
+    let modoffs = ModOff::parse(&modoff_data).unwrap();
+
+    // create all the likely module base names -- do we care about mixed case
+    // here?
+    let bare = pdb_path.file_stem().unwrap().to_string_lossy();
+    let exe = format!("{}.exe", bare);
+    let dll = format!("{}.dll", bare);
+    let sys = format!("{}.sys", bare);
+
+    // create our new SrcView and insert our only pdb into it
+    // we don't know what the modoff module will be, so create a mapping from
+    // all likely names to the pdb
+
+    let mut srcview = SrcView::new();
+
+    // in theory we could refcount the pdbcache's to save resources here, but
+    // Im not sure thats necesary...
+    srcview.insert(&bare, pdb_path).unwrap();
+    srcview.insert(&exe, pdb_path).unwrap();
+    srcview.insert(&dll, pdb_path).unwrap();
+    srcview.insert(&sys, pdb_path).unwrap();
+
+    // Convert our ModOffs to SrcLine so we can draw it
+    let coverage: Vec<SrcLine> = modoffs
+        .into_iter()
+        .filter_map(|m| srcview.modoff(&m))
+        .collect();
+
+    // Generate our report, filtering on our example path
+    let r = Report::new(&coverage, &srcview, Some(r"E:\\1f\\coverage\\example")).unwrap();
+
+    // Format it as cobertura and display it
+    println!("{}", r.cobertura(Some(r"E:\\1f\\coverage\\")).unwrap());
+}

--- a/src/agent/srcview/examples/dump_cobertura.rs
+++ b/src/agent/srcview/examples/dump_cobertura.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 use std::path::Path;
 use std::{env, fs, process};
 

--- a/src/agent/srcview/examples/dump_modoff.rs
+++ b/src/agent/srcview/examples/dump_modoff.rs
@@ -1,0 +1,16 @@
+use std::{env, fs, process};
+
+use srcview::ModOff;
+
+fn main() {
+    let args = env::args().collect::<Vec<String>>();
+
+    if args.len() != 2 {
+        eprintln!("Usage: {} <modoff.txt>", args[0]);
+        process::exit(1);
+    }
+
+    let modoff = fs::read_to_string(&args[1]).unwrap();
+
+    println!("{:#?}", ModOff::parse(&modoff).unwrap());
+}

--- a/src/agent/srcview/examples/dump_modoff.rs
+++ b/src/agent/srcview/examples/dump_modoff.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 use std::{env, fs, process};
 
 use srcview::ModOff;

--- a/src/agent/srcview/examples/dump_paths.rs
+++ b/src/agent/srcview/examples/dump_paths.rs
@@ -1,0 +1,24 @@
+use std::path::PathBuf;
+use std::{env, process};
+
+use srcview::SrcView;
+
+fn main() {
+    let args = env::args().collect::<Vec<String>>();
+
+    if args.len() != 2 {
+        eprintln!("Usage: {} <pdb>", args[0]);
+        process::exit(1);
+    }
+
+    let pdb_path = PathBuf::from(&args[1]);
+
+    let mut srcview = SrcView::new();
+    srcview
+        .insert(pdb_path.file_stem().unwrap().to_str().unwrap(), &pdb_path)
+        .unwrap();
+
+    for path in srcview.paths() {
+        println!("{}", path.display());
+    }
+}

--- a/src/agent/srcview/examples/dump_paths.rs
+++ b/src/agent/srcview/examples/dump_paths.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 use std::path::PathBuf;
 use std::{env, process};
 

--- a/src/agent/srcview/examples/dump_srcloc.rs
+++ b/src/agent/srcview/examples/dump_srcloc.rs
@@ -1,0 +1,28 @@
+use std::{env, fs, process};
+
+use srcview::{ModOff, SrcView};
+
+fn main() {
+    let args = env::args().collect::<Vec<String>>();
+
+    if args.len() != 3 {
+        eprintln!("Usage: {} <pdb> <modoff.txt>", args[0]);
+        process::exit(1);
+    }
+
+    let pdb_path = &args[1];
+    let modoff_path = &args[2];
+
+    let modoff_data = fs::read_to_string(&modoff_path).unwrap();
+    let modoffs = ModOff::parse(&modoff_data).unwrap();
+    let mut srcview = SrcView::new();
+    srcview.insert("example.exe", pdb_path).unwrap();
+
+    for modoff in &modoffs {
+        print!(" +{:04x} ", modoff.offset);
+        match srcview.modoff(&modoff) {
+            Some(srcloc) => println!("{}", srcloc),
+            None => println!(""),
+        }
+    }
+}

--- a/src/agent/srcview/examples/dump_srcloc.rs
+++ b/src/agent/srcview/examples/dump_srcloc.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 use std::{env, fs, process};
 
 use srcview::{ModOff, SrcView};

--- a/src/agent/srcview/res/example.txt
+++ b/src/agent/srcview/res/example.txt
@@ -1,0 +1,15 @@
+example.exe+00006f70
+example.exe+00006f75
+example.exe+00006f79
+example.exe+00006f7d
+example.exe+00006f81
+example.exe+00006f82
+example.exe+00006f85
+example.exe+00006f87
+example.exe+00006f89
+example.exe+00006f8b
+example.exe+00006f9b
+example.exe+00006fa2
+example.exe+00006fa7
+example.exe+00006fa9
+example.exe+00006fad

--- a/src/agent/srcview/src/lib.rs
+++ b/src/agent/srcview/src/lib.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! # srcview
 //!
 //! srcview is a crate for converting module+offset (modoff) coverage traces to source and line

--- a/src/agent/srcview/src/lib.rs
+++ b/src/agent/srcview/src/lib.rs
@@ -1,0 +1,102 @@
+//! # srcview
+//!
+//! srcview is a crate for converting module+offset (modoff) coverage traces to source and line
+//! number such that they can be visualized in an editor web frontend. It's job is split into
+//! two parts: first creating a `SrcView` from debug info, then turning that `SrcView` and coverage into
+//! a `Report`.
+//!
+//! ## SrcView
+//!
+//! There are two fundamental datatypes the crate defines, `ModOff` and `SrcLine`. `ModOff` is a module
+//! name + offset from it's base, and SrcLine is an absolute path and line number. From a high
+//! level, srcview converts modoff to srcline using debug info (PDBs only presently), then collects
+//! and formats that debug info into a report. A `SrcView` is a collection of debug info (PdbCache)
+//! mappings, and each debug info exposes four mappings:
+//!  - ModOff to SrcLine (1:1)
+//!  - Path to all valid SrcLines (1:n)
+//!  - Path to all Symbols in that file (1:n)
+//!  - Symbol to all valid SrcLines (1:n)
+//!
+//! A SrcView is a queryable collection of debug information, it _does not_ contain any coverage
+//! information directly. It is simply the data extracted from the relevant debug structures in a
+//! conviently queryable form.
+//!
+//! ## SrcView Examples
+//!
+//! ```text
+//!              module                    offset
+//!
+//! ┌─────────┐
+//! │         │           ┌──────────────┐
+//! │ SrcView │ ─────┬───►│PdbCache - foo│
+//! │         │      │    └──────────────┘         ┌──────────────────────────┐
+//! └─────────┘      │                         ┌──►│SrcLine - z:\src\fizz.c:41│
+//!                  │    ┌──────────────┐     │   │SrcLine - z:\src\fizz.c:42│
+//!                  ├───►│PdbCache - bar├─────┤   └──────────────────────────┘
+//!                  │    └──────────────┘     │
+//!                  │                         │   ┌──────────────────────────┐
+//!                  │    ┌──────────────┐     └──►│SrcLine - z:\src\quux.c:65│
+//!                  └───►│PdbCache - baz│         └──────────────────────────┘
+//!                       └──────────────┘
+//! ```
+//!
+//! For example, bar+1234 might map to z:\src\quux.c:65.
+//!
+//! Absolute path to all valid SrcLine or Symbols in that path:
+//! ```text
+//!                <all>                    path
+//! ┌─────────┐
+//! │         │           ┌──────────────┐
+//! │ SrcView │ ─────┬───►│PdbCache - foo│
+//! │         │      │    └──────────────┘         ┌──────────────────────────┐
+//! └─────────┘      │                         ┌──►│SrcLine - z:\src\fizz.c:41│
+//!                  │    ┌──────────────┐     │   │SrcLine - z:\src\fizz.c:42│
+//!                  ├───►│PdbCache - bar├─────┤   └──────────────────────────┘
+//!                  │    └──────────────┘     │
+//!                  │                         │   ┌──────────────────────────┐
+//!                  │    ┌──────────────┐     └──►│SrcLine - z:\src\quux.c:65│
+//!                  └───►│PdbCache - baz├──┐      └──────────────────────────┘
+//!                       └──────────────┘  │
+//!                                         │      ┌──────────────────────────┐
+//!                                         └─────►│SrcLine - z:\src\fizz.c:43│
+//!                                                └──────────────────────────┘
+//! ```
+//!
+//! For example if we were asking for SrcLines, z:\src\fizz.c would iterate over all
+//! pdbcache's and return a list of z:\src\fizz.c:41, z:\src\fizz.c:42, z:\src.fizz.c:65.
+//! If we were asking for a list of symbols for a path, we might get back
+//! FunctionOne, FunctionTwo, SomeGlobal, etc.
+//!
+//! Finally, we can query for symbol (e.g. `foo!FunctionOne`) to `SrcLine`. This functions
+//! exactly like the others and will return a collection of `SrcLine`.
+//!
+//! ## Report
+//!
+//! Once we have a `SrcView`, we can combine that with the coverage set (i.e. `&[ModOff]`) to create
+//! a `Report`. A `Report` is fundamentally the same info as a SrcView, except keyed around file paths
+//! and with some statistics computed from the coverage info.
+//!
+//! Additionally, `Report` handles some of the messier parts:
+//!  - Using regex's to filter `SrcView` contents, this lets you exclude things like the CRT from your
+//!    output reports.
+//!  - Using regex's to fixup input paths. All paths from PDBs are absolute, but most coverage
+//!    visualization wants them to match a directory path. For example, if you have a git repo in
+//!    ADO that is named 'test', it might be built on a build machine under 'z:\src\test`. To get
+//!    the paths to match, we need to filter off 'z:\src\test'.
+//!  - The actually emission of the coverage report itself. Right now this is only in Cobertura, but
+//!    its not hard to imagine other formats being added.
+//!  - Compute the coverage statistics on directories
+//!
+//! `Report` is significantly messier than `SrcView` and as of writing this I expect there to still be bugs.
+//!
+mod modoff;
+mod pdbcache;
+mod report;
+mod srcline;
+mod srcview;
+
+pub use self::srcview::SrcView;
+pub use modoff::{ModOff, ModOffParseError};
+pub use pdbcache::PdbCache;
+pub use report::Report;
+pub use srcline::SrcLine;

--- a/src/agent/srcview/src/modoff.rs
+++ b/src/agent/srcview/src/modoff.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 use std::cmp::Ordering;
 use std::error::Error;
 use std::fmt;

--- a/src/agent/srcview/src/modoff.rs
+++ b/src/agent/srcview/src/modoff.rs
@@ -1,0 +1,220 @@
+use std::cmp::Ordering;
+use std::error::Error;
+use std::fmt;
+
+use log::*;
+
+use nom::bytes::complete::{tag, take_till1, take_while};
+use nom::character::complete::line_ending;
+use nom::combinator::{eof, map_res, opt};
+use nom::multi::many0;
+use nom::IResult;
+
+/// A module name and an offset
+#[derive(Clone, Eq, PartialEq, Hash)]
+pub struct ModOff {
+    pub module: String,
+    pub offset: usize,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+pub enum ModOffParseError {
+    InvalidFormat,
+}
+
+impl From<nom::Err<nom::error::Error<&str>>> for ModOffParseError {
+    fn from(_: nom::Err<nom::error::Error<&str>>) -> Self {
+        ModOffParseError::InvalidFormat
+    }
+}
+
+impl Error for ModOffParseError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        // TODO percolate up the nom error...
+        None
+    }
+}
+
+impl fmt::Display for ModOffParseError {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(fmt, "invalid modoff")
+    }
+}
+
+impl fmt::Debug for ModOff {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("ModOff")
+            .field("module", &self.module)
+            .field("offset", &format_args!("{:#x}", self.offset))
+            .finish()
+    }
+}
+
+impl fmt::Display for ModOff {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(fmt, "{}+{:x}", &self.module, self.offset)
+    }
+}
+
+impl Ord for ModOff {
+    fn cmp(&self, other: &Self) -> Ordering {
+        let path_cmp = self.module.cmp(&other.module);
+
+        if path_cmp != Ordering::Equal {
+            return path_cmp;
+        }
+
+        self.offset.cmp(&other.offset)
+    }
+}
+
+impl PartialOrd for ModOff {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl ModOff {
+    pub fn new(module: &str, offset: usize) -> Self {
+        Self {
+            module: module.to_owned(),
+            offset,
+        }
+    }
+
+    fn parse_module(input: &str) -> IResult<&str, String> {
+        let (input, module) = take_till1(|c| c == '+')(input)?;
+
+        Ok((input, module.to_owned()))
+    }
+
+    fn from_hex(input: &str) -> Result<usize, std::num::ParseIntError> {
+        usize::from_str_radix(input, 16)
+    }
+
+    fn is_hex_digit(c: char) -> bool {
+        c.is_digit(16)
+    }
+
+    fn parse_offset(input: &str) -> IResult<&str, usize> {
+        let (input, _) = opt(tag("0x"))(input)?;
+        map_res(take_while(Self::is_hex_digit), Self::from_hex)(input)
+    }
+
+    fn parse_modoff(input: &str) -> IResult<&str, Self> {
+        // TODO add modoff comment support -- lines starting with # or ;
+        let (input, module) = Self::parse_module(input)?;
+        let (input, _) = tag("+")(input)?;
+        let (input, offset) = Self::parse_offset(input)?;
+        let (input, _) = opt(line_ending)(input)?;
+
+        Ok((input, Self { module, offset }))
+    }
+
+    /// Parse a newline separate string of modoffs to a `Vec`
+    ///
+    /// # Arguments
+    ///
+    /// * `input` - A string containing new line separated '<module>+<hex offset>'
+    ///
+    /// # Errors
+    ///
+    /// If the input string contains invalid module+offset
+    ///
+    /// # Example
+    /// ```
+    /// use srcview::ModOff;
+    ///
+    /// assert_eq!(
+    ///     vec![
+    ///         ModOff::new("foo.exe", 0x4141),
+    ///         ModOff::new("foo.exe", 0x4242)
+    ///     ],
+    ///     ModOff::parse("foo.exe+4141\nfoo.exe+4242").unwrap()
+    /// );
+    /// ```
+    pub fn parse(input: &str) -> Result<Vec<Self>, ModOffParseError> {
+        let (input, res) = many0(Self::parse_modoff)(input)?;
+        let (_, _) = eof(input)?;
+
+        info!("parsed {} modoff entries", res.len());
+
+        Ok(res)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_empty() {
+        let empty: Vec<ModOff> = Vec::new();
+        assert_eq!(empty, ModOff::parse("").unwrap());
+    }
+
+    #[test]
+    fn parse_good() {
+        assert_eq!(
+            vec![ModOff::new("foo.exe", 0x4141)],
+            ModOff::parse("foo.exe+4141").unwrap()
+        );
+    }
+
+    #[test]
+    fn parse_good_multiple_unix() {
+        assert_eq!(
+            vec![
+                ModOff::new("foo.exe", 0x4141),
+                ModOff::new("foo.exe", 0x4242)
+            ],
+            ModOff::parse("foo.exe+4141\nfoo.exe+4242").unwrap()
+        );
+    }
+
+    #[test]
+    fn parse_good_multiple_windows() {
+        assert_eq!(
+            vec![
+                ModOff::new("foo.exe", 0x4141),
+                ModOff::new("foo.exe", 0x4242),
+            ],
+            ModOff::parse("foo.exe+4141\r\nfoo.exe+4242").unwrap()
+        );
+    }
+
+    #[test]
+    fn parse_good_leading_0x() {
+        assert_eq!(
+            vec![ModOff::new("foo.exe", 0x4141)],
+            ModOff::parse("foo.exe+0x4141").unwrap()
+        );
+    }
+
+    #[test]
+    fn parse_bad_no_module() {
+        assert_eq!(Err(ModOffParseError::InvalidFormat), ModOff::parse("+4141"));
+    }
+    #[test]
+    fn parse_bad_no_plus() {
+        assert_eq!(
+            Err(ModOffParseError::InvalidFormat),
+            ModOff::parse("foo.exe4141")
+        );
+    }
+    #[test]
+    fn parse_bad_no_digits() {
+        assert_eq!(
+            Err(ModOffParseError::InvalidFormat),
+            ModOff::parse("foo.exe+")
+        );
+    }
+
+    #[test]
+    fn parse_bad_bad_digits() {
+        assert_eq!(
+            Err(ModOffParseError::InvalidFormat),
+            ModOff::parse("foo.exe+41zz")
+        );
+    }
+}

--- a/src/agent/srcview/src/pdbcache.rs
+++ b/src/agent/srcview/src/pdbcache.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 use std::collections::BTreeMap;
 use std::fs::File;
 use std::path::{Path, PathBuf};

--- a/src/agent/srcview/src/pdbcache.rs
+++ b/src/agent/srcview/src/pdbcache.rs
@@ -1,0 +1,104 @@
+use std::collections::BTreeMap;
+use std::fs::File;
+use std::path::{Path, PathBuf};
+
+use log::*;
+use pdb::{FallibleIterator, SymbolData, PDB};
+use serde::{Deserialize, Serialize};
+
+use crate::SrcLine;
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct PdbCache {
+    offset_to_line: BTreeMap<usize, SrcLine>,
+    symbol_to_lines: BTreeMap<String, Vec<SrcLine>>,
+    path_to_symbols: BTreeMap<PathBuf, Vec<String>>,
+    path_to_lines: BTreeMap<PathBuf, Vec<usize>>,
+}
+
+impl PdbCache {
+    pub fn new<P: AsRef<Path>>(pdb: P) -> Result<Self, Box<dyn std::error::Error>> {
+        let mut offset_to_line: BTreeMap<usize, SrcLine> = BTreeMap::new();
+        let mut symbol_to_lines: BTreeMap<String, Vec<SrcLine>> = BTreeMap::new();
+        let mut path_to_symbols: BTreeMap<PathBuf, Vec<String>> = BTreeMap::new();
+        let mut path_to_lines: BTreeMap<PathBuf, Vec<usize>> = BTreeMap::new();
+
+        let pdbfile = File::open(pdb)?;
+        let mut pdb = PDB::open(pdbfile)?;
+
+        let address_map = pdb.address_map()?;
+        let string_table = pdb.string_table()?;
+
+        let dbi = pdb.debug_information()?;
+        let mut modules = dbi.modules()?;
+        while let Some(module) = modules.next()? {
+            let info = match pdb.module_info(&module)? {
+                Some(info) => info,
+                None => {
+                    warn!("no module info: {:?}", &module);
+                    continue;
+                }
+            };
+
+            let program = info.line_program()?;
+            let mut symbols = info.symbols()?;
+
+            while let Some(symbol) = symbols.next()? {
+                if let Ok(SymbolData::Procedure(proc)) = symbol.parse() {
+                    let mut lines = program.lines_at_offset(proc.offset);
+                    while let Some(line_info) = lines.next()? {
+                        let rva = line_info.offset.to_rva(&address_map).expect("invalid rva");
+                        let file_info = program.get_file_info(line_info.file_index)?;
+                        let file_name = file_info.name.to_string_lossy(&string_table)?;
+
+                        let sym = proc.name.to_string().to_owned().to_string(); // gross
+                        let path = PathBuf::from(file_name.into_owned());
+                        let line = line_info.line_start as usize;
+
+                        let srcloc = SrcLine::new(path.clone(), line);
+
+                        offset_to_line.insert(rva.0 as usize, srcloc.clone());
+                        symbol_to_lines
+                            .entry(sym.clone())
+                            .or_default()
+                            .push(srcloc.clone());
+                        path_to_symbols
+                            .entry(path.clone())
+                            .or_default()
+                            .push(sym.clone());
+                        path_to_lines.entry(path.clone()).or_default().push(line);
+                    }
+                }
+            }
+        }
+
+        Ok(Self {
+            offset_to_line,
+            symbol_to_lines,
+            path_to_symbols,
+            path_to_lines,
+        })
+    }
+
+    pub fn offset(&self, off: &usize) -> Option<&SrcLine> {
+        self.offset_to_line.get(off)
+    }
+
+    pub fn paths(&self) -> impl Iterator<Item = &PathBuf> {
+        self.path_to_lines.keys()
+    }
+
+    pub fn path_symbols<P: AsRef<Path>>(&self, path: P) -> Option<impl Iterator<Item = &str>> {
+        self.path_to_symbols
+            .get(path.as_ref())
+            .map(|x| x.iter().map(|y| y.as_str()))
+    }
+
+    pub fn path_lines<P: AsRef<Path>>(&self, path: P) -> Option<impl Iterator<Item = &usize>> {
+        self.path_to_lines.get(path.as_ref()).map(|x| x.iter())
+    }
+
+    pub fn symbol(&self, sym: &str) -> Option<impl Iterator<Item = &SrcLine>> {
+        self.symbol_to_lines.get(sym).map(|x| x.iter())
+    }
+}

--- a/src/agent/srcview/src/report.rs
+++ b/src/agent/srcview/src/report.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::path::{Path, PathBuf};

--- a/src/agent/srcview/src/report.rs
+++ b/src/agent/srcview/src/report.rs
@@ -1,0 +1,499 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use regex::Regex;
+use xml::writer::{EmitterConfig, XmlEvent};
+
+use crate::{SrcLine, SrcView};
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct FileCov {
+    symbols: BTreeMap<String, BTreeSet<SrcLine>>,
+    lines: Vec<usize>,
+    hits: Vec<usize>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+struct DirCov {
+    hits: usize,
+    lines: usize,
+}
+
+impl DirCov {
+    fn new(hits: usize, lines: usize) -> Self {
+        Self { hits, lines }
+    }
+}
+
+/// A path keyed structure to store both coverage and source info such that we can easily emit a
+/// serialized representation of the source and its coverage
+pub struct Report {
+    filecov: BTreeMap<PathBuf, FileCov>,
+    dircov: BTreeMap<PathBuf, DirCov>,
+    overall: DirCov,
+}
+
+impl Report {
+    /// Create a new report from coverage, a `SrcView`, and an optional regex
+    ///
+    /// # Arguments
+    ///
+    /// * `coverage` - The hit set of SrcLines
+    /// * `srcview` - The total set of SrcLines
+    /// * `include_regex` - A regular expression that will be applied against the file
+    ///                     paths from the srcview. Any files matching this regex will be
+    ///                     included in the output report. This is to exclude dependencies
+    ///                     (e.g. the CRT) and should frequently be your project root. E.g.
+    ///                     if you have git repo 'Foo' that was built on z:\src\Foo, a
+    ///                     reasonable regex might be r'z:\\src\\Foo' (note that is is a
+    ///                     raw string and the backslashes are to escape backreferences in
+    ///                     the regex). A of `None` matches all files and includes them.
+    ///
+    /// # Errors
+    ///
+    /// If the regex cannot be compiled
+    ///
+    /// # Example
+    /// ```no_run
+    /// use srcview::{ModOff, Report, SrcLine, SrcView};
+    ///
+    /// let modoff_data = std::fs::read_to_string("coverage.modoff.txt").unwrap();
+    /// let modoffs = ModOff::parse(&modoff_data).unwrap();
+    ///
+    /// let mut srcview = SrcView::new();
+    /// srcview.insert("example.exe", "example.pdb").unwrap();
+    ///
+    /// let coverage: Vec<SrcLine> = modoffs
+    ///     .into_iter()
+    ///     .filter_map(|m| srcview.modoff(&m))
+    ///     .collect();
+    ///
+    /// let r = Report::new(&coverage, &srcview, Some(r"E:\\1f\\coverage\\example")).unwrap();
+    /// ```
+    pub fn new(
+        coverage: &[SrcLine],
+        srcview: &SrcView,
+        include_regex: Option<&str>,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        let include = include_regex.map(|f| Regex::new(f)).transpose()?;
+        let filecov = Self::compute_filecov(coverage, srcview, &include);
+
+        // should this function take &[ModOff] and perform the conversion itself?
+
+        let mut r = Self {
+            filecov,
+            // these will be populated by compute_dircov
+            dircov: BTreeMap::new(),
+            overall: DirCov::new(0, 0),
+        };
+
+        r.compute_dircov();
+
+        Ok(r)
+    }
+
+    // should only be called from new, function to initalize file coverage
+    fn compute_filecov(
+        coverage: &[SrcLine],
+        srcview: &SrcView,
+        include: &Option<Regex>,
+    ) -> BTreeMap<PathBuf, FileCov> {
+        let uniq_cov: BTreeSet<SrcLine> = coverage.iter().cloned().collect();
+
+        let mut filecov = BTreeMap::new();
+
+        for path in srcview.paths() {
+            if !Self::relevant_path(path, include) {
+                continue;
+            }
+
+            let path_srclocs: Vec<SrcLine> = srcview
+                .path_lines(path)
+                .unwrap()
+                .map(|line| SrcLine::new(path, line))
+                .collect();
+
+            let mut lines = vec![];
+            let mut hits = vec![];
+            let mut symbols = BTreeMap::new();
+
+            for srcloc in &path_srclocs {
+                lines.push(srcloc.line);
+
+                if uniq_cov.contains(srcloc) {
+                    hits.push(srcloc.line);
+                }
+            }
+
+            lines.sort_unstable();
+            hits.sort_unstable();
+
+            if let Some(path_symbols) = srcview.path_symbols(path) {
+                for symbol in path_symbols {
+                    let symbol_srclocs: BTreeSet<SrcLine> =
+                        srcview.symbol(&symbol).unwrap().cloned().collect();
+
+                    symbols.insert(symbol, symbol_srclocs);
+                }
+            }
+
+            filecov.insert(
+                path.clone(),
+                FileCov {
+                    lines,
+                    hits,
+                    symbols,
+                },
+            );
+        }
+
+        filecov
+    }
+
+    // should only be called from `new`, function to initialize directory coverage and overall
+    // coverage. File coverage must be already initialized at this point
+    fn compute_dircov(&mut self) {
+        // need to make a copy so we don't hold an immutable reference to self in the loop
+        let paths: Vec<PathBuf> = self.paths().cloned().collect();
+
+        // on windows we can have multiple roots, e.g. c:\ and z:\. Thus we need to track all
+        // the roots we see and their coverage to total them later for overall project coverage
+        let mut overall: BTreeMap<PathBuf, DirCov> = BTreeMap::new();
+
+        for path in paths {
+            let mut anc = path.ancestors();
+
+            // the /foo/bar/baz.c - discard baz.c
+            let _ = anc.next();
+
+            // for the rest of the directories, lets compute them
+            for dir in anc {
+                // if we've already computed it, were good
+                if self.dir(dir).is_some() {
+                    continue;
+                }
+
+                let mut hits = 0;
+                let mut lines = 0;
+
+                // get every file that matches this directory and total it
+                for file in self.filter_files(dir) {
+                    let cov = self.file(&file).unwrap();
+
+                    hits += cov.hits.len();
+                    lines += cov.lines.len();
+                }
+
+                self.dircov
+                    .insert(dir.to_path_buf(), DirCov::new(hits, lines));
+            }
+
+            // now lets get the root so we can compute the overall stats
+            let anc = path.ancestors();
+
+            if let Some(root) = anc.last() {
+                // at this point we know we've computed this
+                let dircov = *self.dircov.get(root).unwrap();
+
+                // we don't really care if we're overwriting it
+                overall.insert(root.to_path_buf(), dircov);
+            }
+        }
+
+        let mut total = DirCov::new(0, 0);
+
+        for dircov in overall.values() {
+            total.hits += dircov.hits;
+            total.lines += dircov.lines;
+        }
+
+        self.overall = total;
+    }
+
+    fn file<P: AsRef<Path>>(&self, path: P) -> Option<&FileCov> {
+        self.filecov.get(path.as_ref())
+    }
+
+    fn dir<P: AsRef<Path>>(&self, path: P) -> Option<&DirCov> {
+        self.dircov.get(path.as_ref())
+    }
+
+    fn paths(&self) -> impl Iterator<Item = &PathBuf> {
+        self.filecov.keys()
+    }
+
+    fn dirs(&self) -> impl Iterator<Item = &PathBuf> {
+        self.dircov.keys()
+    }
+
+    fn filter_files<P: AsRef<Path>>(&self, path: P) -> impl Iterator<Item = &PathBuf> {
+        self.paths().filter(move |p| p.starts_with(path.as_ref()))
+    }
+
+    fn dir_has_files<P: AsRef<Path>>(&self, path: P) -> bool {
+        for file in self.filter_files(path.as_ref()) {
+            let mut anc = file.ancestors();
+            let _ = anc.next();
+            if let Some(dir) = anc.next() {
+                if dir == path.as_ref() {
+                    return true;
+                }
+            }
+        }
+
+        false
+    }
+
+    // wrapper to allow eronomic filtering with an option
+    fn filter_path<P: AsRef<Path> + fmt::Debug>(path: P, filter: &Option<Regex>) -> PathBuf {
+        match filter {
+            Some(regex) => {
+                // we need our path as a string to regex it
+                let path_string = path
+                    .as_ref()
+                    .to_str()
+                    .unwrap_or_else(|| panic!("could not utf8 decode path: {:?}", path));
+
+                let filtered = regex.replace(path_string, "").into_owned();
+
+                PathBuf::from(filtered)
+            }
+            None => path.as_ref().to_path_buf(),
+        }
+    }
+
+    // wrapper to allow ergonomic testing of our include regex inside an option against a
+    // path
+    fn relevant_path<P: AsRef<Path> + fmt::Debug>(path: P, include: &Option<Regex>) -> bool {
+        match include {
+            Some(regex) => {
+                // we need our path as a string to regex it
+                let path_string = path
+                    .as_ref()
+                    .to_str()
+                    .unwrap_or_else(|| panic!("could not utf8 decode path: {:?}", path));
+
+                regex.is_match(path_string)
+            }
+            None => true,
+        }
+    }
+
+    /// Generate a Cobertura report
+    ///
+    /// # Arguments
+    ///
+    /// * `filter_regex` - This a search and replace regex that is applied to all file
+    ///                    paths that will appear in the output report. This is specifically
+    ///                    useful as many coverage visualization tools will require paths to
+    ///                    match, and by default debug paths include the build machine info.
+    ///                    For example, if our repo is 'Foo' and has `test.c` in it, the
+    ///                    debug path could be `z:\build\Foo\test.c`. In the generated report
+    ///                    we would want to strip off the build info and the repo name, such
+    ///                    that the path that remains is relative to the repo root. As a
+    ///                    result we might pass r"z:\\build\Foo\\". When applied to our SrcView
+    ///                    paths this will replace that regex with the empty string, leaving the
+    ///                    path `test.c` which relative to our repo root is correct. A value of
+    ///                    `None` will not filter any paths.
+    ///
+    /// # Errors
+    ///
+    /// * If the filter regex cannot be compiled
+    /// * If there is an error writing the output xml
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use srcview::{ModOff, Report, SrcLine, SrcView};
+    ///
+    /// let modoff_data = std::fs::read_to_string("coverage.modoff.txt").unwrap();
+    /// let modoffs = ModOff::parse(&modoff_data).unwrap();
+    ///
+    /// let mut srcview = SrcView::new();
+    /// srcview.insert("example.exe", "example.pdb").unwrap();
+    ///
+    /// let coverage: Vec<SrcLine> = modoffs
+    ///     .into_iter()
+    ///     .filter_map(|m| srcview.modoff(&m))
+    ///     .collect();
+    ///
+    /// // in this case our repo is `coverage`, and has an `example` directory containing
+    /// // our code files. Anything that matches this path shoudl be included.
+    /// let r = Report::new(&coverage, &srcview, Some(r"E:\\1f\\coverage\\example")).unwrap();
+
+    /// // However when generating the report, we want to strip off only the repo name --
+    /// // `example` is inside the repo so to make the paths line up we need to leave it.
+    /// let xml = r.cobertura(Some(r"E:\\1f\coverage\\")).unwrap();
+    ///
+    /// println!("{}", xml);
+    /// ```
+    pub fn cobertura(
+        &self,
+        filter_regex: Option<&str>,
+    ) -> Result<String, Box<dyn std::error::Error>> {
+        let filter = filter_regex.map(|f| Regex::new(f)).transpose()?;
+
+        let mut backing: Vec<u8> = Vec::new();
+        let mut ew = EmitterConfig::new()
+            .perform_indent(true)
+            .create_writer(&mut backing);
+
+        // xml-rs does not support DTD entries yet, but thankfully ADO's parser is loose
+
+        let unixtime = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time before unix epoch, wtf")
+            .as_secs();
+
+        ew.write(
+            XmlEvent::start_element("coverage")
+                .attr("lines-valid", &format!("{}", self.overall.lines))
+                .attr("lines-covered", &format!("{}", self.overall.hits))
+                .attr(
+                    "line-rate",
+                    &format!(
+                        "{:.02}",
+                        self.overall.hits as f32 / self.overall.lines as f32
+                    ),
+                )
+                .attr("branches-valid", "0")
+                .attr("branches-covered", "0")
+                .attr("branch-rate", "0")
+                .attr("timestamp", &format!("{}", unixtime))
+                .attr("complexity", "0")
+                .attr("version", "0.1"),
+        )?;
+        ew.write(XmlEvent::start_element("sources"))?;
+        ew.write(XmlEvent::start_element("source"))?;
+        ew.write(XmlEvent::characters(""))?;
+        ew.write(XmlEvent::end_element())?; // source
+        ew.write(XmlEvent::end_element())?; // sources
+        ew.write(XmlEvent::start_element("packages"))?;
+
+        for dir in self.dirs() {
+            if !self.dir_has_files(dir) {
+                continue;
+            }
+
+            let display_dir = Self::filter_path(dir, &filter).display().to_string();
+
+            ew.write(XmlEvent::start_element("package").attr("name", &display_dir))?;
+            ew.write(XmlEvent::start_element("classes"))?;
+
+            //
+            // PER-FILE
+            //
+
+            for path in self.filter_files(dir) {
+                let display_path = Self::filter_path(path, &filter).display().to_string();
+
+                let filecov = self.file(path).unwrap();
+
+                let file_srclocs: BTreeSet<SrcLine> = filecov
+                    .lines
+                    .iter()
+                    .map(|line| SrcLine::new(path, *line))
+                    .collect();
+                let hit_srclocs: BTreeSet<SrcLine> = filecov
+                    .hits
+                    .iter()
+                    .map(|line| SrcLine::new(path, *line))
+                    .collect();
+
+                ew.write(
+                    XmlEvent::start_element("class")
+                        .attr("name", &display_path)
+                        .attr("filename",  &display_path)
+                        .attr(
+                            "line-rate",
+                            &format!(
+                                "{:.02}",
+                                filecov.hits.len() as f32 / filecov.lines.len() as f32
+                            ),
+                        )
+                        .attr("branch-rate", "0"),
+                )?;
+
+                //
+                // METHODS
+                //
+
+                ew.write(XmlEvent::start_element("methods"))?;
+
+                for (symbol, symbol_srclocs) in filecov.symbols.iter() {
+                    let mut symbol_hits = 0;
+                    for hit in &hit_srclocs {
+                        if symbol_srclocs.contains(hit) {
+                            symbol_hits += 1;
+                        }
+                    }
+
+                    ew.write(
+                        XmlEvent::start_element("method")
+                            .attr("name", symbol)
+                            .attr("signature", "")
+                            .attr(
+                                "line-rate",
+                                &format!(
+                                    "{:.02}",
+                                    symbol_hits as f32 / symbol_srclocs.len() as f32
+                                ),
+                            )
+                            .attr("branch-rate", "0"),
+                    )?;
+                    ew.write(XmlEvent::start_element("lines"))?;
+
+                    for srcloc in symbol_srclocs {
+                        let hits = if hit_srclocs.contains(srcloc) {
+                            "1"
+                        } else {
+                            "0"
+                        };
+
+                        ew.write(
+                            XmlEvent::start_element("line")
+                                .attr("number", &format!("{}", srcloc.line))
+                                .attr("hits", hits)
+                                .attr("branch", "false"),
+                        )?;
+                        ew.write(XmlEvent::end_element())?; // line
+                    }
+
+                    ew.write(XmlEvent::end_element())?; // lines
+                    ew.write(XmlEvent::end_element())?; // method
+                }
+                ew.write(XmlEvent::end_element())?; // methods
+                ew.write(XmlEvent::start_element("lines"))?;
+
+                //
+                // LINES
+                //
+                for srcloc in &file_srclocs {
+                    let hits = if hit_srclocs.contains(srcloc) {
+                        "1"
+                    } else {
+                        "0"
+                    };
+
+                    ew.write(
+                        XmlEvent::start_element("line")
+                            .attr("number", &format!("{}", srcloc.line))
+                            .attr("hits", hits)
+                            .attr("branch", "false"),
+                    )?;
+                    ew.write(XmlEvent::end_element())?; // line
+                }
+                ew.write(XmlEvent::end_element())?; // lines
+                ew.write(XmlEvent::end_element())?; // class
+            }
+            ew.write(XmlEvent::end_element())?; // classes
+            ew.write(XmlEvent::end_element())?; // package
+        }
+        ew.write(XmlEvent::end_element())?; // packages
+        ew.write(XmlEvent::end_element())?; // coverage
+
+        Ok(String::from_utf8(backing)?)
+    }
+}

--- a/src/agent/srcview/src/report.rs
+++ b/src/agent/srcview/src/report.rs
@@ -405,7 +405,7 @@ impl Report {
                 ew.write(
                     XmlEvent::start_element("class")
                         .attr("name", &display_path)
-                        .attr("filename",  &display_path)
+                        .attr("filename", &display_path)
                         .attr(
                             "line-rate",
                             &format!(

--- a/src/agent/srcview/src/srcline.rs
+++ b/src/agent/srcview/src/srcline.rs
@@ -1,0 +1,43 @@
+use std::cmp::Ordering;
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+/// A path and a line number
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct SrcLine {
+    pub path: PathBuf,
+    pub line: usize,
+}
+
+impl fmt::Display for SrcLine {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(fmt, "{}:{}", &self.path.display(), self.line)
+    }
+}
+
+impl Ord for SrcLine {
+    fn cmp(&self, other: &Self) -> Ordering {
+        let path_cmp = self.path.cmp(&other.path);
+
+        if path_cmp != Ordering::Equal {
+            return path_cmp;
+        }
+
+        self.line.cmp(&other.line)
+    }
+}
+
+impl PartialOrd for SrcLine {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl SrcLine {
+    pub fn new<P: AsRef<Path>>(path: P, line: usize) -> Self {
+        let path = path.as_ref().to_owned();
+        Self { path, line }
+    }
+}

--- a/src/agent/srcview/src/srcline.rs
+++ b/src/agent/srcview/src/srcline.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 use std::cmp::Ordering;
 use std::fmt;
 use std::path::{Path, PathBuf};

--- a/src/agent/srcview/src/srcview.rs
+++ b/src/agent/srcview/src/srcview.rs
@@ -1,0 +1,246 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::{ModOff, PdbCache, SrcLine};
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct SrcView(BTreeMap<String, PdbCache>);
+
+/// A SrcView is a collection of zero or more PdbCaches for easy querying. It stores all
+/// the mapping information from the PDBs. It does _not_ contain any coverage information.
+impl SrcView {
+    /// Create's a new SrcView
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Insert a new pdb into the SrcView, returning any previous pdb info that you're
+    /// replacing. In most cases this return value can be ignored.
+    ///
+    /// # Arguments
+    ///
+    /// * `module` - Module name to store the PDB info as
+    /// * `pdb` - Path to PDB
+    ///
+    /// # Errors
+    ///
+    ///  If the provided PDB cannot be parsed or contains otherwise unexpected data.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use srcview::SrcView;
+    ///
+    /// let mut sv = SrcView::new();
+    ///
+    /// // Map the contents of 'example.pdb' to the module name 'example.exe'
+    /// sv.insert("example.exe", r"z:\src\example.pdb").unwrap();
+    ///
+    /// // you can now query sv for info from example.exe...
+    /// ```
+    pub fn insert<P: AsRef<Path>>(
+        &mut self,
+        module: &str,
+        pdb: P,
+    ) -> Result<Option<PdbCache>, Box<dyn std::error::Error>> {
+        let cache = PdbCache::new(pdb)?;
+        Ok(self.0.insert(module.to_owned(), cache))
+    }
+
+    /// Resolve a modoff to SrcLine, if one exists
+    ///
+    /// # Arguments
+    ///
+    /// * `modoff` - Reference to a ModOff you'd like to resolve
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use srcview::{ModOff, SrcView};
+    ///
+    /// let mut sv = SrcView::new();
+    ///
+    /// // Map the contents of 'example.pdb' to the module name 'example.exe'
+    /// sv.insert("example.exe", r"z:\src\example.pdb").unwrap();
+    ///
+    /// let modoff = ModOff::new("example.exe", 0x4141);
+    ///
+    /// if let Some(srcline) = sv.modoff(&modoff) {
+    ///     println!("Resolved {} to {}", modoff, srcline);
+    /// }
+    /// ```
+    pub fn modoff(&self, modoff: &ModOff) -> Option<SrcLine> {
+        match self.0.get(&modoff.module) {
+            Some(cache) => cache.offset(&modoff.offset).cloned(),
+            None => None,
+        }
+    }
+
+    /// Resolve a symbol (e.g. module!name) to its possible SrcLines, if such a symbol
+    /// exists
+    ///
+    /// # Arguments
+    ///
+    /// * `sym` - A symbol name you'd like to query in the form of `<module>!<name>`
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use srcview::SrcView;
+    ///
+    /// let mut sv = SrcView::new();
+    ///
+    /// // Map the contents of 'example.pdb' to the module name 'example.exe'
+    /// sv.insert("example.exe", r"z:\src\example.pdb").unwrap();
+    ///
+    /// if let Some(srclines) = sv.symbol("example.exe!main") {
+    ///     println!("example.exe!main has the following valid source lines:");
+    ///     for line in srclines {
+    ///         println!(" - {}", line);
+    ///     }
+    /// };
+    /// ```
+    pub fn symbol(&self, sym: &str) -> Option<impl Iterator<Item = &SrcLine>> {
+        let split: Vec<&str> = sym.split('!').collect();
+
+        if split.len() < 2 {
+            return None;
+        }
+
+        let module = split[0];
+        let name: String = split[1..].join("!");
+
+        match self.0.get(module) {
+            Some(cache) => cache.symbol(&name),
+            None => None,
+        }
+    }
+
+    /// Resolve a path to its possible SrcLines, if such a path exists
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - An absolute path that possibly matches one from the debug info
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use srcview::SrcView;
+    ///
+    /// let mut sv = SrcView::new();
+    ///
+    /// // Map the contents of 'example.pdb' to the module name 'example.exe'
+    /// sv.insert("example.exe", r"z:\src\example.pdb").unwrap();
+    ///
+    /// if let Some(srclines) = sv.path_lines(r"z:\src\example.c") {
+    ///     println!("example.c has the following valid source lines:");
+    ///     for line in srclines {
+    ///         println!(" - {}", line);
+    ///     }
+    /// }
+    /// ```
+    pub fn path_lines<P: AsRef<Path>>(&self, path: P) -> Option<impl Iterator<Item = usize>> {
+        // we want to unique the lines in use across all loaded pdbs
+        let mut r: BTreeSet<usize> = BTreeSet::new();
+
+        for cache in self.0.values() {
+            if let Some(lines) = cache.path_lines(path.as_ref()) {
+                for line in lines {
+                    r.insert(*line);
+                }
+            }
+        }
+
+        if r.is_empty() {
+            return None;
+        }
+
+        // convert to a vec
+        let mut v: Vec<usize> = r.into_iter().collect();
+
+        // lists of line numbers are nicer when theyre sorted...
+        v.sort_unstable();
+
+        Some(v.into_iter())
+    }
+
+    /// Resolve a path to its possible symbols, if such a path exists
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - An absolute path that possibly matches one from the debug info
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use srcview::SrcView;
+    ///
+    /// let mut sv = SrcView::new();
+    ///
+    /// // Map the contents of 'example.pdb' to the module name 'example.exe'
+    /// sv.insert("example.exe", r"z:\src\example.pdb").unwrap();
+    ///
+    /// if let Some(symbols) = sv.path_symbols(r"z:\src\example.c") {
+    ///     println!("example.c has the following valid symbols:");
+    ///     for line in symbols {
+    ///         println!(" - {}", line);
+    ///     }
+    /// }
+    /// ```
+    pub fn path_symbols<P: AsRef<Path>>(&self, path: P) -> Option<impl Iterator<Item = String>> {
+        // we want to unique the lines in use across all loaded pdbs
+        let mut r: BTreeSet<String> = BTreeSet::new();
+
+        for (module, cache) in self.0.iter() {
+            if let Some(symbols) = cache.path_symbols(path.as_ref()) {
+                for sym in symbols {
+                    r.insert(format!("{}!{}", module, sym.to_string()));
+                }
+            }
+        }
+
+        if r.is_empty() {
+            return None;
+        }
+
+        // convert to a vec
+        let mut v: Vec<String> = r.into_iter().collect();
+
+        // lists of symbols are nicer when theyre sorted...
+        v.sort();
+
+        Some(v.into_iter())
+    }
+
+    /// Returns an iterator over all paths in the SrcView
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use srcview::SrcView;
+    ///
+    /// let mut sv = SrcView::new();
+    ///
+    /// // Map the contents of 'example.pdb' to the module name 'example.exe'
+    /// sv.insert("example.exe", r"z:\src\example.pdb").unwrap();
+    ///
+    /// println!("paths in example.pdb:");
+    ///
+    /// for path in sv.paths() {
+    ///     println!(" - {}", path.display());
+    /// }
+    /// ```
+    pub fn paths(&self) -> impl Iterator<Item = &PathBuf> {
+        let mut r: BTreeSet<&PathBuf> = BTreeSet::new();
+
+        for cache in self.0.values() {
+            for pb in cache.paths() {
+                r.insert(pb);
+            }
+        }
+
+        r.into_iter()
+    }
+}

--- a/src/agent/srcview/src/srcview.rs
+++ b/src/agent/srcview/src/srcview.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 

--- a/src/agent/srcview/tests/modoff.rs
+++ b/src/agent/srcview/tests/modoff.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 use std::path::PathBuf;
 use std::{env, fs};
 

--- a/src/agent/srcview/tests/modoff.rs
+++ b/src/agent/srcview/tests/modoff.rs
@@ -1,0 +1,34 @@
+use std::path::PathBuf;
+use std::{env, fs};
+
+use srcview::ModOff;
+
+#[test]
+fn parse_modoff() {
+    let root = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let path: PathBuf = [&root, "res", "example.txt"].iter().collect();
+
+    let modoff = fs::read_to_string(&path).unwrap();
+    let modoffs = ModOff::parse(&modoff).unwrap();
+
+    assert_eq!(
+        modoffs,
+        vec![
+            ModOff::new("example.exe", 0x6f70),
+            ModOff::new("example.exe", 0x6f75),
+            ModOff::new("example.exe", 0x6f79),
+            ModOff::new("example.exe", 0x6f7d),
+            ModOff::new("example.exe", 0x6f81),
+            ModOff::new("example.exe", 0x6f82),
+            ModOff::new("example.exe", 0x6f85),
+            ModOff::new("example.exe", 0x6f87),
+            ModOff::new("example.exe", 0x6f89),
+            ModOff::new("example.exe", 0x6f8b),
+            ModOff::new("example.exe", 0x6f9b),
+            ModOff::new("example.exe", 0x6fa2),
+            ModOff::new("example.exe", 0x6fa7),
+            ModOff::new("example.exe", 0x6fa9),
+            ModOff::new("example.exe", 0x6fad),
+        ]
+    );
+}

--- a/src/agent/srcview/tests/srcview.rs
+++ b/src/agent/srcview/tests/srcview.rs
@@ -1,0 +1,67 @@
+use std::env;
+use std::path::PathBuf;
+
+use srcview::{ModOff, SrcLine, SrcView};
+
+fn test_srcview() -> SrcView {
+    let root = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let pdb_path: PathBuf = [&root, "res", "example.pdb"].iter().collect();
+
+    let mut srcview = SrcView::new();
+    srcview.insert("example.exe", pdb_path).unwrap();
+
+    srcview
+}
+
+#[test]
+fn modoff() {
+    let srcview = test_srcview();
+
+    let good_modoff = ModOff::new("example.exe", 0x6f70);
+    assert_eq!(
+        srcview.modoff(&good_modoff),
+        Some(SrcLine::new("E:\\1f\\coverage\\example\\example.c", 3))
+    );
+
+    let bad_offset = ModOff::new("example.exe", 0x4141);
+    assert_eq!(srcview.modoff(&bad_offset), None);
+
+    let bad_module = ModOff::new("foo.exe", 0x4141);
+    assert_eq!(srcview.modoff(&bad_module), None);
+}
+
+#[test]
+fn symbol() {
+    let srcview = test_srcview();
+
+    let good: Vec<&SrcLine> = srcview.symbol("example.exe!main").unwrap().collect();
+
+    assert_eq!(
+        good,
+        vec![
+            &SrcLine::new("E:\\1f\\coverage\\example\\example.c", 3),
+            &SrcLine::new("E:\\1f\\coverage\\example\\example.c", 4),
+            &SrcLine::new("E:\\1f\\coverage\\example\\example.c", 5),
+            &SrcLine::new("E:\\1f\\coverage\\example\\example.c", 6),
+            &SrcLine::new("E:\\1f\\coverage\\example\\example.c", 7),
+            &SrcLine::new("E:\\1f\\coverage\\example\\example.c", 10),
+            &SrcLine::new("E:\\1f\\coverage\\example\\example.c", 11),
+        ]
+    );
+
+    assert!(srcview.symbol("dosenotexist").is_none());
+}
+
+#[test]
+fn path() {
+    let srcview = test_srcview();
+
+    let good: Vec<usize> = srcview
+        .path_lines("E:\\1f\\coverage\\example\\example.c")
+        .unwrap()
+        .collect();
+
+    assert_eq!(good, vec![3, 4, 5, 6, 7, 10, 11]);
+
+    assert!(srcview.path_lines("z:\\does\\not\\exist.c").is_none());
+}

--- a/src/agent/srcview/tests/srcview.rs
+++ b/src/agent/srcview/tests/srcview.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 use std::env;
 use std::path::PathBuf;
 

--- a/src/agent/srcview/tests/srcview.rs
+++ b/src/agent/srcview/tests/srcview.rs
@@ -1,6 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+// tests depends on example.pdb
+// $ sha256sum example.pdb
+// ecc4214d687c97e9c8afd0c84b4b75383eaa0a237f8a8ca5049478f63b2c98b9  example.pdb
+
 use std::env;
 use std::path::PathBuf;
 
@@ -17,6 +21,7 @@ fn test_srcview() -> SrcView {
 }
 
 #[test]
+#[cfg_attr(not(feature = "binary-tests"), ignore)]
 fn modoff() {
     let srcview = test_srcview();
 
@@ -34,6 +39,7 @@ fn modoff() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "binary-tests"), ignore)]
 fn symbol() {
     let srcview = test_srcview();
 
@@ -56,6 +62,7 @@ fn symbol() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "binary-tests"), ignore)]
 fn path() {
     let srcview = test_srcview();
 


### PR DESCRIPTION
## Summary of the Pull Request

`srcview` is a crate which ingests debug info (currently only PDB) and execution traces and then generates source/line based coverage report which can be visualized elsewhere (ADO, VSCode). Currently the only supported report format is Cobertura. The intent is that fuzzer authors can use these reports to identify gaps in their coverage and address them, as well as track the fuzzers efficacy over time.

## PR Checklist
* [ ] Applies to work item: #xxx
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/onefuzz) and sign the CLI.
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

The crate is reasonably documented -- `cargo doc --open` is probably the best current source of info.

This PR includes all the standalone srcview code, documentation, and tests. It does _not_ include any integration work with the rest of the 1f repo.

In terms of specific integration work I'm aware of:
- We will  need to expose the allow and denylist regex's to the user via fuzzer job configuration
- While we should be able to convert between coverage formats via `iter.map(|(module, offset)| ModOff::new(module, offset)).collect()`, we might want to introduce a ModOff collection type instead of just using a Vec. Open to feedback here.

## Validation Steps Performed

The examples and documentation show usage and validation.
