### PR TITLE
Fix case of logger format string specifier

### DIFF
--- a/src/api-service/__app__/onefuzzlib/workers/nodes.py
+++ b/src/api-service/__app__/onefuzzlib/workers/nodes.py
@@ -285,7 +285,7 @@ class Node(BASE_NODE, ORMMixin):
         if self.state not in NodeState.can_process_new_work():
             logging.info(
                 "can_process_new_work node not in appropriate state for new work"
-                "machine_id:%s state:%S",
+                "machine_id:%s state:%s",
                 self.machine_id,
                 self.state.name,
             )


### PR DESCRIPTION
Fix a log statement with an invalid format string specifier. At runtime, the invalid specifier causes the service to throw a `ValueError`. This is typically invoked in the `agent_can_schedule` function [here](https://github.com/microsoft/onefuzz/blob/main/src/api-service/__app__/agent_can_schedule/__init__.py#L33).