### PR TITLE
add command to give basic information on a pool

### DIFF
--- a/src/cli/onefuzz/cli.py
+++ b/src/cli/onefuzz/cli.py
@@ -490,16 +490,16 @@ class Builder:
             level += 1
 
 
-def render(result: Any) -> Any:
+def normalize(result: Any) -> Any:
     """Convert arbitrary result streams into something filterable with jmespath"""
     if isinstance(result, BaseModel):
-        return render(result.dict(exclude_none=True))
+        return normalize(result.dict(exclude_none=True))
     if isinstance(result, Model):
-        return render(result.as_dict())
+        return normalize(result.as_dict())
     if isinstance(result, list):
-        return [render(x) for x in result]
+        return [normalize(x) for x in result]
     if isinstance(result, dict):
-        return {render(k): render(v) for (k, v) in result.items()}
+        return {normalize(k): normalize(v) for (k, v) in result.items()}
     if isinstance(result, Enum):
         return result.name
     if isinstance(result, UUID):
@@ -507,7 +507,7 @@ def render(result: Any) -> Any:
     if isinstance(result, (int, float, str)):
         return result
 
-    logging.debug(f"unable to render type f{type(result)}")
+    logging.debug(f"unable to normalize type f{type(result)}")
 
     return result
 
@@ -516,7 +516,7 @@ def output(result: Any, output_format: str, expression: Optional[Any]) -> None:
     if isinstance(result, bytes):
         sys.stdout.buffer.write(result)
     else:
-        result = render(result)
+        result = normalize(result)
         if expression is not None:
             result = expression.search(result)
         if result is not None:

--- a/src/cli/onefuzz/status/cmd.py
+++ b/src/cli/onefuzz/status/cmd.py
@@ -22,7 +22,9 @@ def short(value: UUID) -> str:
 
 
 class PoolStatus(BaseModel):
+    # number of nodes in each node state
     node_state: Dict[NodeState, int]
+    # number of VMs used for each task
     tasks: Dict[UUID, int]
 
 

--- a/src/cli/onefuzz/status/cmd.py
+++ b/src/cli/onefuzz/status/cmd.py
@@ -4,11 +4,12 @@
 # Licensed under the MIT License.
 
 from collections import defaultdict
-from typing import DefaultDict, List, Optional, Set
+from typing import DefaultDict, Dict, List, Optional, Set
 from uuid import UUID
 
-from onefuzztypes.enums import ContainerType, JobState
+from onefuzztypes.enums import ContainerType, JobState, NodeState
 from onefuzztypes.primitives import Container
+from pydantic import BaseModel
 
 from ..api import UUID_EXPANSION, Command
 from .cache import JobFilter
@@ -20,8 +21,34 @@ def short(value: UUID) -> str:
     return str(value).split("-")[0]
 
 
+class PoolStatus(BaseModel):
+    node_state: Dict[NodeState, int]
+    tasks: Dict[UUID, int]
+
+
 class Status(Command):
     """Monitor status of Onefuzz Instance"""
+
+    def pool(self, *, name: str) -> PoolStatus:
+        pool = self.onefuzz.pools.get(name)
+        nodes = self.onefuzz.nodes.list(pool_name=pool.name)
+
+        tasks = {}
+        node_state = {}
+        for node in nodes:
+            if node.state not in node_state:
+                node_state[node.state] = 0
+            node_state[node.state] += 1
+
+            if node.state not in [NodeState.free, NodeState.init]:
+                node = self.onefuzz.nodes.get(node.machine_id)
+                if node.tasks is not None:
+                    for entry in node.tasks:
+                        task_id, _task_state = entry
+                        if task_id not in tasks:
+                            tasks[task_id] = 0
+                        tasks[task_id] += 1
+        return PoolStatus(tasks=tasks, node_state=node_state)
 
     def project(
         self,


### PR DESCRIPTION
The command `onefuzz status pool pool-name` now provides something akin to:

```
❯ onefuzz status pool default
{
    "node_state": {
        "free": 5,
        "busy": 1
    },
    "tasks": {
        "312c725b-a3ca-4718-97b0-793b9a5ca27a": 1
    }
}
```