### PR TITLE
retry when preauthorized application are invalid

### DIFF
--- a/src/deployment/registration.py
+++ b/src/deployment/registration.py
@@ -386,7 +386,7 @@ def authorize_application(
 
         onefuzz_app_id = onefuzz_app["id"]
 
-        def add_preauthorized_app(app_list: Any) -> None:
+        def add_preauthorized_app(app_list: List[Dict]) -> None:
             try:
                 query_microsoft_graph(
                     method="PATCH",
@@ -404,6 +404,9 @@ def authorize_application(
                     if invalid_app_id:
                         for app in app_list:
                             if app["appId"] == invalid_app_id:
+                                logger.warning(
+                                    f"removing invalid id {invalid_app_id} for the next request"
+                                )
                                 app_list.remove(app)
 
                 raise e

--- a/src/deployment/registration.py
+++ b/src/deployment/registration.py
@@ -391,7 +391,8 @@ def authorize_application(
                 )
             except GraphQueryError as e:
                 m = re.search(
-                    "Property PreAuthorizedApplication references applications (.*) that cannot be found.",
+                    "Property PreAuthorizedApplication references "
+                    "applications (.*) that cannot be found.",
                     e.message,
                 )
                 if m:


### PR DESCRIPTION
## Summary of the Pull Request

Handles the case when an application registration is deleted but is still referenced as a preauthorized application in the instance registration. 
This adds a logic to remove any invalid application id form the request to authorize applications.
closes #1171

How to test:
1 - create multiple registration `python registration.py create_cli_registration <instance_namm> subscription_id  --registration_name <name>`
2- delete some of the application registration  in the azure portal
3- create another registration with step 1


Tested
[x] 0 deleted app
[x]1 deleted app

Could not test with >1 app because i had redeployed my environment and the issue does not repro in my new  instance application registration.
