### PR TITLE
Add storage queue write to example deployment role

### DIFF
--- a/src/deployment/deployment-role.json
+++ b/src/deployment/deployment-role.json
@@ -27,6 +27,7 @@
     "Microsoft.Storage/storageAccounts/listKeys/action",
     "Microsoft.Storage/storageAccounts/read",
     "Microsoft.Storage/storageAccounts/write",
+    "Microsoft.Storage/storageAccounts/queueServices/queues/write",
     "Microsoft.Web/serverfarms/read",
     "Microsoft.Web/serverfarms/write",
     "Microsoft.Web/sites/*",


### PR DESCRIPTION
With the recent move to deploy using ARM for storage queues, the permission Microsoft.Storage/storageAccounts/queueServices/queues/write needs to be included in the custom deployment role.