### PR TITLE
Use fallible callbacks for `Mapping` placeholders

### DIFF
--- a/src/agent/onefuzz/src/expand.rs
+++ b/src/agent/onefuzz/src/expand.rs
@@ -115,7 +115,8 @@ impl<'a> Expand<'a> {
         let val = match self.values.get(&PlaceHolder::Input.get_string()) {
             Some(ExpandedValue::Path(fp)) => {
                 let file = PathBuf::from(fp);
-                digest_file_blocking(file).ok().map(ExpandedValue::Scalar)
+                let hash = digest_file_blocking(file)?;
+                Some(ExpandedValue::Scalar(hash))
             }
             _ => None,
         };


### PR DESCRIPTION
The template expansion machinery allows `Mapping` placeholders which use a partial callback to provide an expansion value on demand. Add fallibility to the callback signature, which lets us avoid distinguish between callback errors and absent values. Update existing `Mapping` callbacks to return errors in some places where we currently map them to `None`.