### PR TITLE
temporarily ignore type errors from azure-storage-blob

### DIFF
--- a/src/cli/mypy.ini
+++ b/src/cli/mypy.ini
@@ -11,6 +11,12 @@ warn_return_any = True
 warn_unused_configs = True
 warn_unused_ignores = True
 
+# azure-storage-blob 12.9.0 includes invalid type signatures.  This change
+# should be backed out once upstream addresses the type signature issue.
+# ref: https://github.com/Azure/azure-sdk-for-python/issues/20771
+[mypy-azure.storage.blob.*]
+ignore_errors = True
+
 [mypy-signalrcore.*]
 ignore_missing_imports = True
 


### PR DESCRIPTION
azure-storage-blob 12.9.0 includes invalid type signatures.  This change
should be backed out once upstream addresses the type signature issue.
ref: https://github.com/Azure/azure-sdk-for-python/issues/20771