### PR TITLE
move to using released appinsights version

### DIFF
--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -52,11 +52,15 @@ checksum = "61604a8f862e1d5c3229fdd78f8b02c68dcf73a4c4b05fd636d12240aaa242c1"
 
 [[package]]
 name = "appinsights"
-version = "0.1.5"
-source = "git+https://github.com/dmolokanov/appinsights-rs?rev=0af6ec83bad1c050160f5258ab08e9834596ce20#0af6ec83bad1c050160f5258ab08e9834596ce20"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "950f6c4b26a794a356139e416b90598eb11b218c89cb657b93b935b88871969b"
 dependencies = [
+ "async-trait",
  "chrono",
- "crossbeam-channel",
+ "crossbeam-queue",
+ "futures-channel",
+ "futures-util",
  "hostname",
  "http",
  "log",
@@ -65,6 +69,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sm",
+ "tokio",
  "uuid",
 ]
 

--- a/src/agent/onefuzz-telemetry/Cargo.toml
+++ b/src/agent/onefuzz-telemetry/Cargo.toml
@@ -11,11 +11,7 @@ z3 = ["z3-sys"]
 intel_instructions = ["iced-x86"]
 
 [dependencies]
-# appinsights-rs haas included optional support for rustls since 2020-10, but
-# not the feature has not been released yet.  This is the pinned to the most
-# recent git hash as of 2021-06-30.  Once released, this should be reverted to
-# use released versions
-appinsights = { git = "https://github.com/dmolokanov/appinsights-rs", rev = "0af6ec83bad1c050160f5258ab08e9834596ce20", features=["rustls"], default-features = false }
+appinsights = { version = "0.2", features=["blocking", "rustls"], default-features = false }
 log = "0.4"
 uuid = { version = "0.8", features = ["serde", "v4"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/src/agent/onefuzz-telemetry/src/lib.rs
+++ b/src/agent/onefuzz-telemetry/src/lib.rs
@@ -63,7 +63,7 @@ impl fmt::Display for InstanceTelemetryKey {
     }
 }
 
-pub type TelemetryClient = appinsights::TelemetryClient<appinsights::InMemoryChannel>;
+pub type TelemetryClient = appinsights::blocking::TelemetryClient;
 pub enum ClientType {
     Instance,
     Microsoft,


### PR DESCRIPTION
appinsights 0.2 was released, enabling rustls by default.  As such, we
can now track the released versions rather than a specific git hash.
