### PR TITLE
fix container documentation to align with how coverage also maps to build & platform now

### DIFF
--- a/docs/containers.md
+++ b/docs/containers.md
@@ -15,7 +15,7 @@ As an example, the libFuzzer fuzzing task uses the following:
   files saved in the `inputs` container are bidirectionally synced with the blob
   store.
 * `readonly_inputs`: An arbitrary set of additional input seed corpus containers.
-  This container automatically pulls new files \_from* the blob store, but
+  This container automatically pulls new files _from_ the blob store, but
   nothing saved to these containers on the fuzzing VM is synced _to_ the
   container.
 
@@ -36,32 +36,32 @@ namespaced GUID to enable automatic re-use of containers across multiple builds
 of the same target. NOTE: A helper utility is available to craft namespaced
 GUIDs `onefuzz utils namespaced_guid`.
 
-As an example, setup containers are namespaced with the `project`, `name`,
-`build`, and `platform` (Linux or Windows). All other containers (inputs,
-crashes, coverage, etc) use `project` and `name`.
+As an example, setup and coverage containers are namespaced with the `project`,
+`name`, `build`, and `platform` (Linux or Windows). All other containers
+(inputs, crashes, reports, etc) use `project` and `name`.
 
 Example:
 
 The `libfuzzer` template with the project 'myproject', the name of 'mytarget',
-and build of 'build_1' on the Linux platform uses the following:
+and build of `build_1` on the Linux platform uses the following:
 
 * oft-setup-fd4addc373f3551caf780e80abaaa658
+* oft-coverage-fd4addc373f3551caf780e80abaaa658
 * oft-inputs-d532156b72765c21be5a29f73718af7e
 * oft-crashes-d532156b72765c21be5a29f73718af7e
 * oft-reports-d532156b72765c21be5a29f73718af7e
 * oft-unique-reports-d532156b72765c21be5a29f73718af7e
 * oft-no-repro-d532156b72765c21be5a29f73718af7e
-* oft-coverage-d532156b72765c21be5a29f73718af7e
 
-The same target, but build_2 uses the following containers:
+The same target, but `build_2` uses the following containers:
 
 * oft-setup-270ee492f18c5f71a0a3e1cffcb98f77
+* oft-coverage-270ee492f18c5f71a0a3e1cffcb98f77
 * oft-inputs-d532156b72765c21be5a29f73718af7e
 * oft-crashes-d532156b72765c21be5a29f73718af7e
 * oft-reports-d532156b72765c21be5a29f73718af7e
 * oft-unique-reports-d532156b72765c21be5a29f73718af7e
 * oft-no-repro-d532156b72765c21be5a29f73718af7e
-* oft-coverage-d532156b72765c21be5a29f73718af7e
 
 The only difference is a unique oft-setup container.
 


### PR DESCRIPTION
Source used to calculate names:

https://github.com/microsoft/onefuzz/blob/7da4352e275835a18d097de544adc1166fd18f9f/src/cli/onefuzz/api.py#L1611-L1642