### PR TITLE
fix running check-pr without test arguments

### DIFF
--- a/src/utils/check-pr/check-pr.py
+++ b/src/utils/check-pr/check-pr.py
@@ -176,7 +176,7 @@ class Deployer:
         self.region = region
         self.subscription_id = subscription_id
         self.skip_tests = skip_tests
-        self.test_args = test_args
+        self.test_args = test_args or []
         self.repo = repo
 
     def merge(self) -> None:


### PR DESCRIPTION
I added `--test_args` to work around the Windows libfuzzer integration tests failing, which enables this workflow to only run the linux integration tests.

`check-pr.py --pr 1268 --test_args --os_list linux`

However, I had not tested without --test_args, since all of the integration tests I was running included passing some argument.

There was a bug that if users didn't provide a value for --test_args, it would generate an exception.

This addresses that bug.