### PR TITLE
use flake8 on deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -309,10 +309,11 @@ jobs:
         set -ex
         cd src/deployment
         python -m pip install --upgrade pip
-        pip install mypy isort black types-requests
+        pip install mypy isort black types-requests flake8
         mypy .
         isort --profile black . --check
         black . --check
+        flake8 *.py
     - name: Package Onefuzz
       run: |
           set -ex

--- a/src/deployment/.flake8
+++ b/src/deployment/.flake8
@@ -1,0 +1,5 @@
+[flake8]
+ignore = E203, E266, E501, W503
+max-line-length = 80
+max-complexity = 18
+select = B,C,E,F,W,T4,B9

--- a/src/deployment/deploy.py
+++ b/src/deployment/deploy.py
@@ -252,8 +252,9 @@ class Client:
         return add_application_password(object_id, self.get_subscription_id())
 
     def get_instance_url(self) -> str:
-        ## The url to access the instance
-        ## This also represents the legacy identifier_uris of the application registration
+        # The url to access the instance
+        # This also represents the legacy identifier_uris of the application
+        # registration
         if self.multi_tenant_domain:
             return "https://%s/%s" % (
                 self.multi_tenant_domain,
@@ -263,10 +264,11 @@ class Client:
             return "https://%s.azurewebsites.net" % self.application_name
 
     def get_identifier_url(self) -> str:
-        ## The used to identify the application registration via the identifier_uris field
-        ## Depending on the environment this value needs to be from an approved domain
-        ## The format of this value is derived from the default value proposed by azure when creating
-        ## an application registration api://{guid}/...
+        # This is used to identify the application registration via the
+        # identifier_uris field.  Depending on the environment this value needs
+        # to be from an approved domain The format of this value is derived
+        # from the default value proposed by azure when creating an application
+        # registration api://{guid}/...
         if self.multi_tenant_domain:
             return "api://%s/%s" % (
                 self.multi_tenant_domain,

--- a/src/deployment/deploy.py
+++ b/src/deployment/deploy.py
@@ -277,7 +277,7 @@ class Client:
         else:
             return "api://%s.azurewebsites.net" % self.application_name
 
-    def setup_rbac(self) -> None:
+    def setup_rbac(self) -> None:  # noqa: C901
         """
         Setup the client application for the OneFuzz instance.
         By default, Service Principals do not have access to create

--- a/src/utils/check-pr/check-pr.py
+++ b/src/utils/check-pr/check-pr.py
@@ -176,7 +176,7 @@ class Deployer:
         self.region = region
         self.subscription_id = subscription_id
         self.skip_tests = skip_tests
-        self.test_args = test_args
+        self.test_args = test_args or []
         self.repo = repo
 
     def merge(self) -> None:


### PR DESCRIPTION
All of the rest of the python codebases within the repo use flake8 as
part of the lint process.  This aligns the deployment code with the
practice.