### PR TITLE
Migrate AppInsights Azure resources from classic to work book based

### DIFF
--- a/src/deployment/azuredeploy.json
+++ b/src/deployment/azuredeploy.json
@@ -388,8 +388,17 @@
                 "OWNER": "[parameters('owner')]"
             }
         },
+
         {
-            "apiVersion": "2015-05-01",
+            "type": "Microsoft.OperationalInsights/workspaces",
+            "apiVersion": "2020-08-01",
+            "name": "[parameters('name')]",
+            "location": "[resourceGroup().location]",
+            "properties": {}
+        },
+
+        {
+            "apiVersion": "2020-02-02-preview",
             "name": "[parameters('name')]",
             "type": "microsoft.insights/components",
             "location": "[resourceGroup().location]",
@@ -397,11 +406,15 @@
             "properties": {
                 "ApplicationId": "[parameters('name')]",
                 "Application_Type": "other",
-                "RetentionInDays": "[variables('log_retention')]"
+                "RetentionInDays": "[variables('log_retention')]",
+                "WorkspaceResourceId" : "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('name'))]"
             },
             "tags": {
                 "OWNER": "[parameters('owner')]"
             },
+            "dependsOn" : [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('name'))]"
+            ],
             "resources": [
                 {
                     "name": "df20765c-ed5b-46f9-a47b-20f4aaf7936d",


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_

## PR Checklist
* [x] Applies to work item: #1273 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/onefuzz) and sign the CLI.
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_
Updated `azuredeploy.json` ARM template to deploy newer version of app insights

## Validation Steps Performed

_How does someone test & validate?_

Run `deploy.py` script to deploy fresh instance of OneFuzz or deploy on existing deployment to upgrade App Insights. Deploying on existing OneFuzz instance preserved app insights data.