### PR TITLE
Use consistent case for project name in docs

### DIFF
--- a/docs/AADEntitites.md
+++ b/docs/AADEntitites.md
@@ -18,7 +18,7 @@ This is the registration of the OneFuzz instance.
 * Authorized application:
     * OneFuzz CLI registration
 
-### Onefuzz Application Service Principal
+### OneFuzz Application Service Principal
 Service principal linked to the OneFuzz application registration.
 * name: `<instance_name>`
 * Application Id: `<OneFuzz Application registration app_id>`

--- a/docs/comms-channels.md
+++ b/docs/comms-channels.md
@@ -1,4 +1,4 @@
-# Various internal comms channels used in Onefuzz
+# Various internal comms channels used in OneFuzz
 
 Storage Queues:
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,6 @@
-# Getting started using Onefuzz
+# Getting started using OneFuzz
 
-If you have access to an existing Onefuzz instance, skip ahead to [Deploying Jobs](#deploying-jobs).
+If you have access to an existing OneFuzz instance, skip ahead to [Deploying Jobs](#deploying-jobs).
 
 **Microsoft employees:** Please join the [Fuzzing @ Microsoft](https://aka.ms/fuzzingatmicrosoft) team for support.
 
@@ -16,14 +16,14 @@ registered:
 - `Microsoft.Compute`
 - `Microsoft.SignalRService`
 
-## Deploying an instance of Onefuzz
+## Deploying an instance of OneFuzz
 
 Ensure you have Python with `python --version` >= 3.7, [Azure Functions Core Tools
 v3](https://docs.microsoft.com/en-us/azure/azure-functions/functions-run-local),
 and OpenSSL installed.
 
 From the [Latest Release of
-Onefuzz](https://github.com/microsoft/onefuzz/releases) download the
+OneFuzz](https://github.com/microsoft/onefuzz/releases) download the
 `onefuzz-deployment` package.
 
 On a host with the [Azure CLI logged
@@ -42,7 +42,7 @@ to follow a manual step to initialize your CLI config.
 ## Install the CLI
 
 Download the Python SDK (make sure to download both `onefuzz` and `onefuzztypes`)
-from the [Latest Release of Onefuzz](https://github.com/microsoft/onefuzz/releases).
+from the [Latest Release of OneFuzz](https://github.com/microsoft/onefuzz/releases).
 
 If you're using the SDK, install via:
 
@@ -52,7 +52,7 @@ pip install ./onefuzz*.whl
 
 ### Connecting to your instance
 
-Use the `onefuzz config` command to specify your instance of Onefuzz.
+Use the `onefuzz config` command to specify your instance of OneFuzz.
 
 ```
 $ onefuzz config --endpoint https://$ONEFUZZ_INSTANCE_NAME.azurewebsites.net
@@ -61,11 +61,11 @@ $ onefuzz versions check --exact
 $
 ```
 
-From here, you can use Onefuzz.
+From here, you can use OneFuzz.
 
 ## Creating Worker Pools
 
-Onefuzz distributes tasks to pools of workers, and manages workers using [VM Scalesets](https://azure.microsoft.com/en-us/services/virtual-machine-scale-sets/).
+OneFuzz distributes tasks to pools of workers, and manages workers using [VM Scalesets](https://azure.microsoft.com/en-us/services/virtual-machine-scale-sets/).
 
 To create a pool:
 
@@ -184,7 +184,7 @@ $
 
 ### Live debugging of a crash sample
 
-Using the crash report, Onefuzz can enable live remote debugging of the crash
+Using the crash report, OneFuzz can enable live remote debugging of the crash
 using a platform-appropriate debugger (gdb for Linux and cdb for Windows):
 
 ```

--- a/docs/managed-identities.md
+++ b/docs/managed-identities.md
@@ -1,15 +1,15 @@
 # Managed Identities in OneFuzz
 
-Onefuzz makes use of
+OneFuzz makes use of
 [Managed identities](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview)
 both in the API service as well as the managed VMs.
 
-There are currently two uses of Managed Identities within Onefuzz:
+There are currently two uses of Managed Identities within OneFuzz:
 
 1. The API service manages the full lifecycle of VMs, VM Scalesets, and Networks
    in use in OneFuzz. In order to enable this, the service must have appropriate
    role assignments permissions to manage these resources. At the moment, the
-   role assignments granted to the Onefuzz API are:
+   role assignments granted to the OneFuzz API are:
 
    1. [Virtual Machine Contributor](https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#virtual-machine-contributor)
    1. [Network Contributor](https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#network-contributor)
@@ -18,6 +18,6 @@ There are currently two uses of Managed Identities within Onefuzz:
    See [azuredeploy.json](../src/deployment/azuredeploy.json) for the specific
    implementation of these role assignments.
 
-1. VMs created by Onefuzz are created using the Managed Identities without roles
-   assigned in order to enable the Onefuzz agent running in the VMs to
+1. VMs created by OneFuzz are created using the Managed Identities without roles
+   assigned in order to enable the OneFuzz agent running in the VMs to
    authenticate to the service itself.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -1,14 +1,14 @@
-# Notifications in Onefuzz
+# Notifications in OneFuzz
 
-Onefuzz supports built-in [container monitoring](containers.md) and reporting 
-via Notifications.  Onefuzz notifications monitor user specified containers
+OneFuzz supports built-in [container monitoring](containers.md) and reporting
+via Notifications.  OneFuzz notifications monitor user specified containers
 for changes and will perform the notifications upon new file creation.
 
 ## Features
 
 * Arbitrary notification integrations per container
 * Integration is tied to the containers, not tasks, enabling monitoring of
-  container use outside of Onefuzz
+  container use outside of OneFuzz
 
 ## Implementation
 

--- a/docs/notifications/teams.md
+++ b/docs/notifications/teams.md
@@ -1,6 +1,6 @@
 # Notifications via Microsoft Teams
 
-Onefuzz can send notifications to [Microsoft Teams](https://docs.microsoft.com/en-us/microsoftteams/) channels upon new file creation within Onefuzz managed [containers](../containers.md).
+OneFuzz can send notifications to [Microsoft Teams](https://docs.microsoft.com/en-us/microsoftteams/) channels upon new file creation within OneFuzz managed [containers](../containers.md).
 
 ## Notifications
 
@@ -16,7 +16,7 @@ For this purpose, most users will want to monitor `reports` or `unique_reports` 
 ## Integration
 
 1. Create an [incoming webhook in Teams](https://docs.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/connectors-using#setting-up-a-custom-incoming-webhook).
-1. Add a notification to your Onefuzz instance.
+1. Add a notification to your OneFuzz instance.
 
     ```
     onefuzz notifications create <CONTAINER> @./config.json

--- a/docs/screencasts/README.md
+++ b/docs/screencasts/README.md
@@ -1,4 +1,4 @@
-# Screencasts of using Onefuzz
+# Screencasts of using OneFuzz
 
 ## Launching a Job
 ![Launching a job](launching-job.gif)

--- a/docs/ssh-config.md
+++ b/docs/ssh-config.md
@@ -1,6 +1,6 @@
 # SSH within OneFuzz
 
-Onefuzz enables automatically connecting to fuzzing & crash repro nodes via SSH.
+OneFuzz enables automatically connecting to fuzzing & crash repro nodes via SSH.
 Each VM and VM scale set has its own SSH key pair.
 
 On Linux VMs, the public key is written to `~onefuzz/.ssh/authorized_keys`

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,13 +1,13 @@
 # Telemetry
 
-Onefuzz reports two types of telemetry, both via
+OneFuzz reports two types of telemetry, both via
 [AppInsights](https://docs.microsoft.com/en-us/azure/azure-monitor/app/app-insights-overview).
 
-1. Onefuzz records fully featured attributable data is to a user-owned
+1. OneFuzz records fully featured attributable data is to a user-owned
    [AppInsights](https://docs.microsoft.com/en-us/azure/azure-monitor/app/app-insights-overview)
    instance. This goal of this information is to enable users to perform
    detailed analysis of their fuzzing tasks.
-1. Onefuzz reports non-attributable minimal set of runtime statistics to
+1. OneFuzz reports non-attributable minimal set of runtime statistics to
    Microsoft via a Microsoft managed
    [AppInsights](https://docs.microsoft.com/en-us/azure/azure-monitor/app/app-insights-overview)
    instance. The goal is to provide insight to the efficacy of OneFuzz and
@@ -22,7 +22,7 @@ install of OneFuzz in that user's
 [Azure Subscription](https://docs.microsoft.com/en-us/azure/cloud-adoption-framework/decision-guides/subscriptions/).
 
 The user owns and manages all resources used for OneFuzz, including the fuzzing
-nodes. Onefuzz supports both "managed" nodes, where OneFuzz orchestrates the
+nodes. OneFuzz supports both "managed" nodes, where OneFuzz orchestrates the
 lifecycle of the fuzzing nodes via
 [Azure VM Scale Sets](https://docs.microsoft.com/en-us/azure/virtual-machine-scale-sets/overview),
 and "unmanaged" nodes, where users provide compute however they wish (be that


### PR DESCRIPTION
The project named is properly styled "OneFuzz". Update existing documentation to use this consistently.