### PR TITLE
App role assignment not respected when creating a new cli app registration

### DIFF
--- a/src/deployment/registration.py
+++ b/src/deployment/registration.py
@@ -272,9 +272,7 @@ def create_application_registration(
             continue
 
     authorize_application(UUID(registered_app.app_id), UUID(app.app_id))
-    assign_app_role(
-        onefuzz_instance_name, name, subscription_id, approle
-    )
+    assign_app_role(onefuzz_instance_name, name, subscription_id, approle)
     return registered_app
 
 

--- a/src/deployment/registration.py
+++ b/src/deployment/registration.py
@@ -273,7 +273,7 @@ def create_application_registration(
 
     authorize_application(UUID(registered_app.app_id), UUID(app.app_id))
     assign_app_role(
-        onefuzz_instance_name, name, subscription_id, OnefuzzAppRole.ManagedNode
+        onefuzz_instance_name, name, subscription_id, approle
     )
     return registered_app
 


### PR DESCRIPTION
Fix a bug in `create_application_registration` when assigning the approle, the value was hardcoded to `ManagedNode`.

Closes #1292 

validation:
- create a new cli registration `python registration.py create_cli_registration <instance> <subscription>`
- in azure the azure portal : Azure Active Directory >> Enterprise Application >>  <registration_name> > Permissions 
   verify that the CliClient is assigned