### PR TITLE
Update `nix`, patch dependents

### DIFF
--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -1638,7 +1638,7 @@ dependencies = [
  "input-tester",
  "lazy_static",
  "log",
- "nix 0.22.0",
+ "nix 0.23.0",
  "notify",
  "onefuzz-telemetry",
  "pete",

--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -506,10 +506,9 @@ dependencies = [
 [[package]]
 name = "ctrlc"
 version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "377c9b002a72a0b2c1a18c62e2f3864bdfea4a015e3683a96e24aa45dd6c02d1"
+source = "git+http://github.com/ranweiler/rust-ctrlc?rev=7535c9306557ef69bc07401ba653aa5d7d625e2f#7535c9306557ef69bc07401ba653aa5d7d625e2f"
 dependencies = [
- "nix 0.22.0",
+ "nix",
  "winapi 0.3.9",
 ]
 
@@ -1503,19 +1502,6 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1e25ee6b412c2a1e3fcb6a4499a5c1bfe7f43e014bdce9a6b6666e5aa2d187"
-dependencies = [
- "bitflags",
- "cc",
- "cfg-if 1.0.0",
- "libc",
- "memoffset",
-]
-
-[[package]]
-name = "nix"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f305c2c2e4c39a82f7bf0bf65fb557f9070ce06781d4f2454295cc34b1c43188"
@@ -1638,7 +1624,7 @@ dependencies = [
  "input-tester",
  "lazy_static",
  "log",
- "nix 0.23.0",
+ "nix",
  "notify",
  "onefuzz-telemetry",
  "pete",
@@ -1859,7 +1845,7 @@ source = "git+http://github.com/ranweiler/pete?rev=efeb0769b4376d22a33328553c31c
 dependencies = [
  "libc",
  "memoffset",
- "nix 0.23.0",
+ "nix",
  "thiserror",
 ]
 

--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -198,9 +198,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "1.2.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "block-buffer"
@@ -509,7 +509,7 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "377c9b002a72a0b2c1a18c62e2f3864bdfea4a015e3683a96e24aa45dd6c02d1"
 dependencies = [
- "nix",
+ "nix 0.22.0",
  "winapi 0.3.9",
 ]
 
@@ -1503,9 +1503,22 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.22.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7555d6c7164cc913be1ce7f95cbecdabda61eb2ccd89008524af306fb7f5031"
+checksum = "cf1e25ee6b412c2a1e3fcb6a4499a5c1bfe7f43e014bdce9a6b6666e5aa2d187"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
+name = "nix"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f305c2c2e4c39a82f7bf0bf65fb557f9070ce06781d4f2454295cc34b1c43188"
 dependencies = [
  "bitflags",
  "cc",
@@ -1625,7 +1638,7 @@ dependencies = [
  "input-tester",
  "lazy_static",
  "log",
- "nix",
+ "nix 0.22.0",
  "notify",
  "onefuzz-telemetry",
  "pete",
@@ -1842,12 +1855,11 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 [[package]]
 name = "pete"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53df4a56d46a8eaf305d99b6c52e461d1c76aef2099b65cfae43c4ecb0e4dd89"
+source = "git+http://github.com/ranweiler/pete?rev=efeb0769b4376d22a33328553c31ce331a7261ad#efeb0769b4376d22a33328553c31ce331a7261ad"
 dependencies = [
  "libc",
  "memoffset",
- "nix",
+ "nix 0.23.0",
  "thiserror",
 ]
 

--- a/src/agent/Cargo.toml
+++ b/src/agent/Cargo.toml
@@ -18,3 +18,6 @@ members = [
 
 [profile.release]
 lto = "thin"
+
+[patch.crates-io]
+pete = { git = "http://github.com/ranweiler/pete", rev = "efeb0769b4376d22a33328553c31ce331a7261ad" }

--- a/src/agent/Cargo.toml
+++ b/src/agent/Cargo.toml
@@ -19,5 +19,6 @@ members = [
 [profile.release]
 lto = "thin"
 
+# Remove after `pete 0.8` released.
 [patch.crates-io]
 pete = { git = "http://github.com/ranweiler/pete", rev = "efeb0769b4376d22a33328553c31ce331a7261ad" }

--- a/src/agent/Cargo.toml
+++ b/src/agent/Cargo.toml
@@ -19,6 +19,10 @@ members = [
 [profile.release]
 lto = "thin"
 
-# Remove after `pete 0.8` released.
+
 [patch.crates-io]
+# Remove after `Detegr/rust-ctrlc#81` is released.
+ctrlc = { git = "http://github.com/ranweiler/rust-ctrlc", rev = "7535c9306557ef69bc07401ba653aa5d7d625e2f" }
+
+# Remove after `ranweiler/pete#71` is released.
 pete = { git = "http://github.com/ranweiler/pete", rev = "efeb0769b4376d22a33328553c31ce331a7261ad" }

--- a/src/agent/onefuzz/Cargo.toml
+++ b/src/agent/onefuzz/Cargo.toml
@@ -50,7 +50,7 @@ debugger = { path = "../debugger" }
 
 [target.'cfg(target_family = "unix")'.dependencies]
 cpp_demangle = "0.3"
-nix = "0.22"
+nix = "0.23"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 pete = "0.7"


### PR DESCRIPTION
Temporarily depend on patched `pete`, `ctrlc` crates so we only use the latest `nix`.

We can depend on upstream `ctrlc` after https://github.com/Detegr/rust-ctrlc/pull/81 is merged and/or released.

Replaces #1303.

- [x] Integration tests