### PR TITLE
Update `pete` to 0.8.0

### DIFF
--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -1840,8 +1840,9 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pete"
-version = "0.7.0"
-source = "git+http://github.com/ranweiler/pete?rev=efeb0769b4376d22a33328553c31ce331a7261ad#efeb0769b4376d22a33328553c31ce331a7261ad"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5abe343c643f2fadc7649db57083c62ce818d7bf89393f3bc70f7051adfa2b"
 dependencies = [
  "libc",
  "memoffset",

--- a/src/agent/Cargo.toml
+++ b/src/agent/Cargo.toml
@@ -23,6 +23,3 @@ lto = "thin"
 [patch.crates-io]
 # Remove after `Detegr/rust-ctrlc#81` is released.
 ctrlc = { git = "http://github.com/ranweiler/rust-ctrlc", rev = "7535c9306557ef69bc07401ba653aa5d7d625e2f" }
-
-# Remove after `ranweiler/pete#71` is released.
-pete = { git = "http://github.com/ranweiler/pete", rev = "efeb0769b4376d22a33328553c31ce331a7261ad" }

--- a/src/agent/coverage/Cargo.toml
+++ b/src/agent/coverage/Cargo.toml
@@ -32,7 +32,7 @@ pdb = "0.7"
 winapi = "0.3"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-pete = "0.7"
+pete = "0.8"
 procfs = "0.10"
 
 [dev-dependencies]

--- a/src/agent/onefuzz/Cargo.toml
+++ b/src/agent/onefuzz/Cargo.toml
@@ -53,6 +53,6 @@ cpp_demangle = "0.3"
 nix = "0.23"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-pete = "0.7"
+pete = "0.8"
 rstack = "0.3"
 proc-maps = "0.1"


### PR DESCRIPTION
Update to latest version. Not picked up by Dependabot due to patching.