### PR TITLE
Add a username to the resource group name created by check-pr utility.

### DIFF
--- a/src/utils/check-pr/check-pr.py
+++ b/src/utils/check-pr/check-pr.py
@@ -279,14 +279,14 @@ class Deployer:
 def main() -> None:
     # Get a name that can be added to the resource group name
     # to make it easy to identify the owner
-    cmd = ["az", "ad", "signed-in-user", "show", "--query", "mailNickname"]
-    name = subprocess.run(cmd, capture_output=True, encoding='UTF-8')
+    cmd = ["az", "ad", "signed-in-user", "show", "--query", "mailNickname", "-o", "tsv"]
+    name = subprocess.check_output(cmd, encoding="UTF-8")
 
-    # The result from az includes quotes and a newline
+    # The result from az includes a newline
     # which we strip out.
-    name = name.stdout.strip()[1:-1]
+    name = name.strip()
 
-    default_instance = f'pr-check-{name}-%s' % uuid.uuid4().hex
+    default_instance = f"pr-check-{name}-%s" % uuid.uuid4().hex
     parser = argparse.ArgumentParser()
     parser.add_argument("--instance", default=default_instance)
     group = parser.add_mutually_exclusive_group()

--- a/src/utils/check-pr/check-pr.py
+++ b/src/utils/check-pr/check-pr.py
@@ -277,7 +277,16 @@ class Deployer:
 
 
 def main() -> None:
-    default_instance = "pr-check-%s" % uuid.uuid4().hex
+    # Get a name that can be added to the resource group name
+    # to make it easy to identify the owner
+    cmd = ["az", "ad", "signed-in-user", "show", "--query", "mailNickname"]
+    name = subprocess.run(cmd, capture_output=True, encoding='UTF-8')
+
+    # The result from az includes quotes and a newline
+    # which we strip out.
+    name = name.stdout.strip()[1:-1]
+
+    default_instance = f'pr-check-{name}-%s' % uuid.uuid4().hex
     parser = argparse.ArgumentParser()
     parser.add_argument("--instance", default=default_instance)
     group = parser.add_mutually_exclusive_group()


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_
This change adds a username to the resource group name created by the check-pr utility. This makes it easy to identify who's resources these are. 

## PR Checklist
* [ ] Applies to work item: #xxx
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/onefuzz) and sign the CLI.
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_
A small change to the check-pr.py script.

## Validation Steps Performed
Ran the script on both wsl2 and powershell to verify it works on both windows and linux printing out the created resource group name. 
Ran the script on wsl2 to verify the resource group name is created correctly. 

_How does someone test & validate?_
Run the script and look for the resource group name. 
