### PR TITLE
Update to latest `ctrlc`

### DIFF
--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -505,8 +505,9 @@ dependencies = [
 
 [[package]]
 name = "ctrlc"
-version = "3.2.0"
-source = "git+http://github.com/ranweiler/rust-ctrlc?rev=7535c9306557ef69bc07401ba653aa5d7d625e2f#7535c9306557ef69bc07401ba653aa5d7d625e2f"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a19c6cedffdc8c03a3346d723eb20bd85a13362bb96dc2ac000842c6381ec7bf"
 dependencies = [
  "nix",
  "winapi 0.3.9",

--- a/src/agent/Cargo.toml
+++ b/src/agent/Cargo.toml
@@ -18,8 +18,3 @@ members = [
 
 [profile.release]
 lto = "thin"
-
-
-[patch.crates-io]
-# Remove after `Detegr/rust-ctrlc#81` is released.
-ctrlc = { git = "http://github.com/ranweiler/rust-ctrlc", rev = "7535c9306557ef69bc07401ba653aa5d7d625e2f" }


### PR DESCRIPTION
Remove our patched dependency, lock to `ctrlc:3.2.1`.

We temporarily depended on a patched fork of this library because it was depending on a vulnerable version of the `nix` crate. Upstream has now updated, so we can depend on their latest release.