### PR TITLE
Work around for newly-upgraded pip breaking pip-licenses

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
         set -ex
         ls artifacts
         cd src/cli
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip==21.2.4
         pip install -r requirements-dev.txt
         pip-licenses -uf json > onefuzz/data/licenses.json
         python setup.py sdist bdist_wheel

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,7 @@ jobs:
         set -ex
         ls artifacts
         cd src/cli
+        # Workaround: pin `pip` version until raimon49/pip-licenses#113 is fixed.
         python -m pip install --upgrade pip==21.2.4
         pip install -r requirements-dev.txt
         pip-licenses -uf json > onefuzz/data/licenses.json


### PR DESCRIPTION
can be reverted once https://github.com/raimon49/pip-licenses/issues/113 is fixed

## Summary of the Pull Request

_What is this about?_

## PR Checklist
* [ ] Applies to work item: #xxx
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/onefuzz) and sign the CLI.
* [X] Tests added/passed
* [ ] Requires documentation to be updated
* [X] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_
Pin pip version

## Validation Steps Performed

_How does someone test & validate?_
Run OneFuzz CLI in github CI pipeline