### PR TITLE
revert pip breaking pip-licenses workaround

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,8 +89,7 @@ jobs:
         set -ex
         ls artifacts
         cd src/cli
-        # Workaround: pin `pip` version until raimon49/pip-licenses#113 is fixed.
-        python -m pip install --upgrade pip==21.2.4
+        python -m pip install --upgrade pip
         pip install -r requirements-dev.txt
         pip-licenses -uf json > onefuzz/data/licenses.json
         python setup.py sdist bdist_wheel


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_
pip-licenses fixed raimon49/pip-licenses#113

## PR Checklist
* [ ] Applies to work item: #xxx
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/onefuzz) and sign the CLI.
* [X] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_
Revert of the change introduced by PR #1346

## Validation Steps Performed

_How does someone test & validate?_
Run OneFuzz CLI in github CI pipeline
