### PR TITLE
Temporarily ignore non-actionable `cargo audit` errors

### DIFF
--- a/src/ci/agent.sh
+++ b/src/ci/agent.sh
@@ -39,8 +39,8 @@ cargo fmt -- --check
 # RUSTSEC-2020-0036: a dependency `failure` (pulled from proc-maps) is deprecated
 # RUSTSEC-2019-0036: a dependency `failure` (pulled from proc-maps) has type confusion vulnerability
 # RUSTSEC-2021-0065: a dependency `anymap` is no longer maintained
-# RUSTSEC-2020-0159: potential segfault in `time`, not yet patched
-# RUSTSEC-2020-0071: potential segfault in `chrono`, not yet patched
+# RUSTSEC-2020-0159: potential segfault in `time`, not yet patched (#1366)
+# RUSTSEC-2020-0071: potential segfault in `chrono`, not yet patched (#1366)
 cargo audit --deny warnings --deny unmaintained --deny unsound --deny yanked --ignore RUSTSEC-2020-0016 --ignore RUSTSEC-2020-0036 --ignore RUSTSEC-2019-0036 --ignore RUSTSEC-2021-0065 --ignore RUSTSEC-2020-0159 --ignore RUSTSEC-2020-0071
 cargo-license -j > data/licenses.json
 cargo build --release --locked

--- a/src/ci/proxy.sh
+++ b/src/ci/proxy.sh
@@ -14,8 +14,8 @@ cargo fmt -- --check
 cargo clippy --release -- -D warnings
 # RUSTSEC-2020-0016: a dependency `net2` (pulled in from `tokio`) is deprecated
 # RUSTSEC-2021-0065: a dependency `anymap` is no longer supported
-# RUSTSEC-2020-0159: potential segfault in `time`, not yet patched
-# RUSTSEC-2020-0071: potential segfault in `chrono`, not yet patched
+# RUSTSEC-2020-0159: potential segfault in `time`, not yet patched (#1366)
+# RUSTSEC-2020-0071: potential segfault in `chrono`, not yet patched (#1366)
 cargo audit --deny warnings --deny unmaintained --deny unsound --deny yanked --ignore RUSTSEC-2020-0016 --ignore RUSTSEC-2021-0065 --ignore RUSTSEC-2020-0159 --ignore RUSTSEC-2020-0071
 cargo-license -j > data/licenses.json
 cargo build --release --locked


### PR DESCRIPTION
Add (temporary) ignore directives for two RUSTSEC advisories:

- RUSTSEC-2020-0159: potential segfault in `time`
- RUSTSEC-2020-0071: potential segfault in `chrono`

These errors arise due to transitive dependencies. In the case of `chrono`, there is no available patch.

We will address these upstream or with forks. For now, unbreak the build to enable continued development.