### PR TITLE
Fix validation of `target_exe` blob name

### DIFF
--- a/src/api-service/__app__/onefuzzlib/tasks/config.py
+++ b/src/api-service/__app__/onefuzzlib/tasks/config.py
@@ -146,7 +146,7 @@ def is_valid_blob_name(blob_name: str) -> bool:
     if len(path.parts) > MAX_PATH_SEGMENTS:
         return False
 
-    # Reject relative paths to avoid confusion.
+    # Reject absolute paths to avoid confusion.
     if path.is_absolute():
         return False
 

--- a/src/api-service/__app__/onefuzzlib/tasks/config.py
+++ b/src/api-service/__app__/onefuzzlib/tasks/config.py
@@ -146,6 +146,11 @@ def is_valid_blob_name(blob_name: str) -> bool:
     if len(path.parts) > MAX_PATH_SEGMENTS:
         return False
 
+    # No path segment should end with a dot (`.`).
+    for part in path.parts:
+        if part.endswith("."):
+            return False
+
     # Reject absolute paths to avoid confusion.
     if path.is_absolute():
         return False

--- a/src/api-service/tests/test_task_config.py
+++ b/src/api-service/tests/test_task_config.py
@@ -31,6 +31,16 @@ BLOB_NAME_TEST_CASES = [
     ("  ", False),
     ("/".join("a" * 255), False),
     ("a" * 1025, False),
+    # Paths with invalid segments.
+    ("a.", False),
+    ("a..", False),
+    ("a./b", False),
+    ("a/b./c", False),
+    ("a./", False),
+    ("a../", False),
+    ("a./b/", False),
+    ("a/b./c/", False),
+    ("a//", False),
 ]
 
 

--- a/src/api-service/tests/test_task_config.py
+++ b/src/api-service/tests/test_task_config.py
@@ -7,7 +7,6 @@ import pytest
 
 from __app__.onefuzzlib.tasks.config import is_valid_blob_name
 
-
 BLOB_NAME_TEST_CASES = [
     # Valid
     ("fuzz.exe", True),

--- a/src/api-service/tests/test_task_config.py
+++ b/src/api-service/tests/test_task_config.py
@@ -3,9 +3,14 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+from typing import Tuple
+
 import pytest
 
 from __app__.onefuzzlib.tasks.config import is_valid_blob_name
+
+BlobNameTestCase = Tuple[str, bool]
+
 
 BLOB_NAME_TEST_CASES = [
     # Valid
@@ -44,7 +49,7 @@ BLOB_NAME_TEST_CASES = [
 
 
 @pytest.mark.parametrize("blob_name_test_case", BLOB_NAME_TEST_CASES)
-def test_is_valid_blob_name(blob_name_test_case):
+def test_is_valid_blob_name(blob_name_test_case: BlobNameTestCase) -> None:
     blob_name, expected = blob_name_test_case
 
     is_valid = is_valid_blob_name(blob_name)

--- a/src/api-service/tests/test_task_config.py
+++ b/src/api-service/tests/test_task_config.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+#
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+import pytest
+
+from __app__.onefuzzlib.tasks.config import is_valid_blob_name
+
+
+BLOB_NAME_TEST_CASES = [
+    # Valid
+    ("fuzz.exe", True),
+    ("bin/fuzz.exe", True),
+    ("/".join("a" * 254), True),
+    ("a" * 1024, True),
+
+    # Invalid (absolute)
+    ("/fuzz.exe", False),
+    ("/bin/fuzz.exe", False),
+
+    # Invalid (special dirs)
+    ("./fuzz.exe", False),
+    ("././fuzz.exe", False),
+    ("./bin/fuzz.exe", False),
+    ("./bin/./fuzz.exe", False),
+    ("../fuzz.exe", False),
+    ("../bin/fuzz.exe", False),
+    (".././fuzz.exe", False),
+    ("../bin/./fuzz.exe", False),
+
+    # Out of Azure size bounds
+    ("", False),
+    ("  ", False),
+    ("/".join("a" * 255), False),
+    ("a" * 1025, False),
+]
+
+
+@pytest.mark.parametrize("blob_name_test_case", BLOB_NAME_TEST_CASES)
+def test_is_valid_blob_name(blob_name_test_case):
+    blob_name, expected = blob_name_test_case
+
+    is_valid = is_valid_blob_name(blob_name)
+
+    assert is_valid == expected

--- a/src/api-service/tests/test_task_config.py
+++ b/src/api-service/tests/test_task_config.py
@@ -14,11 +14,9 @@ BLOB_NAME_TEST_CASES = [
     ("bin/fuzz.exe", True),
     ("/".join("a" * 254), True),
     ("a" * 1024, True),
-
     # Invalid (absolute)
     ("/fuzz.exe", False),
     ("/bin/fuzz.exe", False),
-
     # Invalid (special dirs)
     ("./fuzz.exe", False),
     ("././fuzz.exe", False),
@@ -28,7 +26,6 @@ BLOB_NAME_TEST_CASES = [
     ("../bin/fuzz.exe", False),
     (".././fuzz.exe", False),
     ("../bin/./fuzz.exe", False),
-
     # Out of Azure size bounds
     ("", False),
     ("  ", False),


### PR DESCRIPTION
### Summary
Our validation of `target_exe` blob names spuriously failed when the target was in a nested (virtual) directory. Fix validation to support this case, and check additional Azure blob storage naming criteria. Also, add unit tests.

Closes #1362.

### Explanation

A bug-witnessing `target_exe` value is `bin/fuzz.exe`. This should be accepted.

But consider:
```
>>> import ntpath, posixpath
>>> target_exe = 'bin/fuzz.exe'
>>> posixpath.relpath(target_exe)
'bin/fuzz.exe'
>>> ntpath.relpath(target_exe)
'bin\\fuzz.exe'
```
Our validation required that _each_ `relpath()` invocation above is equivalent to the identity function. But the output of the last `relpath()` call differs from the input.

### Testing

- [x] Can create a job whose `target_exe` is in the root of `setup_dir`
- [x] Can create a job whose `target_exe` is in a nested directory, like `{setup_dir}/bin/fuzz.exe` (from Linux, on Linux pool)
- [x] Can create a job whose `target_exe` is in a nested directory, like `{setup_dir}\\bin\\fuzz.exe` (from Windows, on Windows pool)

The last test case ~~ensures~~ [1] that the CLI normalizes relativized paths as POSIX-style, which is consistent with the Blob Storage Service's use of forward slash (`/`) as the virtual directory delimiter.

[1] It does not. This test passes, because the Windows-style paths still (happen to) work on Windows VMs. Linux jobs created from Windows with this path style fail at task runtime. Captured in #1373.