### PR TITLE
Fix error regex when removing invalid application in add_preauthorized_app

### DIFF
--- a/src/deployment/registration.py
+++ b/src/deployment/registration.py
@@ -423,7 +423,7 @@ def authorize_application(
         except GraphQueryError as e:
             m = re.search(
                 "Property PreAuthorizedApplication references "
-                "applications (.*) that cannot be found.",
+                "applications (.*?) that cannot be found.",
                 e.message,
             )
             if m:


### PR DESCRIPTION
## Summary of the Pull Request
This fix an issue when `add_preauthorized_app` tries to remove an invalid application id.
The regex used did not correctly capture the object_id


To validate:
 - create a cli registration ` python .\registration.py create_cli_registration <instance> <subscription>`
 - in azure portal > Azure Active Directory > App registration > (select the application created) > Delete the application
 - create a second cli registration

The creation should be successful with at least one warning with the message `Property PreAuthorizedApplication references applications <application id> that cannot be found.`


