### PR TITLE
Adding a class to store and retrieve rules associated with an api

### DIFF
--- a/src/api-service/__app__/onefuzzlib/request_access.py
+++ b/src/api-service/__app__/onefuzzlib/request_access.py
@@ -2,7 +2,7 @@ from typing import Dict, List
 from uuid import UUID
 
 from onefuzztypes.models import ApiAccessRule
-from pydantic import BaseModel, parse_raw_as
+from pydantic import parse_raw_as
 
 
 class RuleConflictError(Exception):

--- a/src/api-service/__app__/onefuzzlib/request_access.py
+++ b/src/api-service/__app__/onefuzzlib/request_access.py
@@ -1,0 +1,115 @@
+from typing import Dict, List
+from uuid import UUID
+
+from onefuzztypes.models import ApiAccessRule
+from pydantic import BaseModel, parse_raw_as
+
+
+class RuleConflictError(Exception):
+    def __init__(self, message: str) -> None:
+        super(RuleConflictError, self).__init__(message)
+        self.message = message
+
+
+class RequestAccess:
+    """
+    Stores the rules associated with a the request paths
+    """
+
+    class Rules:
+        allowed_groups_ids: List[UUID]
+
+        def __init__(self, allowed_groups_ids: List[UUID] = []) -> None:
+            self.allowed_groups_ids = allowed_groups_ids
+
+    class Node:
+        # http method -> rules
+        rules: Dict[str, "RequestAccess.Rules"]
+        # path -> node
+        children: Dict[str, "RequestAccess.Node"]
+
+        def __init__(self) -> None:
+            self.rules = {}
+            self.children = {}
+            pass
+
+    root: Node
+
+    def __init__(self) -> None:
+        self.root = RequestAccess.Node()
+
+    def __add_url__(self, methods: List[str], path: str, rules: Rules) -> None:
+        methods = list(map(lambda m: m.upper(), methods))
+
+        segments = path.split("/")
+        if len(segments) == 0:
+            return
+
+        current_node = self.root
+        current_segment_index = 0
+
+        while current_segment_index < len(segments):
+            current_segment = segments[current_segment_index]
+            if current_segment in current_node.children:
+                current_node = current_node.children[current_segment]
+                current_segment_index = current_segment_index + 1
+            else:
+                break
+        # we found a node matching this exact path
+        # This means that there is an existing rule causing a conflict
+        if current_segment_index == len(segments):
+            for method in methods:
+                if method in current_node.rules:
+                    raise RuleConflictError(f"Conflicting rules on {method} {path}")
+
+        while current_segment_index < len(segments):
+            current_segment = segments[current_segment_index]
+            current_node.children[current_segment] = RequestAccess.Node()
+            current_node = current_node.children[current_segment]
+            current_segment_index = current_segment_index + 1
+
+        for method in methods:
+            current_node.rules[method] = rules
+
+    def get_matching_rules(self, method: str, path: str) -> Rules:
+        method = method.upper()
+        segments = path.split("/")
+        current_node = self.root
+
+        if method in current_node.rules:
+            current_rule = current_node.rules[method]
+        else:
+            current_rule = RequestAccess.Rules()
+
+        current_segment_index = 0
+
+        while current_segment_index < len(segments):
+            current_segment = segments[current_segment_index]
+            if current_segment in current_node.children:
+                current_node = current_node.children[current_segment]
+            elif "*" in current_node.children:
+                current_node = current_node.children["*"]
+            else:
+                break
+
+            if method in current_node.rules:
+                current_rule = current_node.rules[method]
+            current_segment_index = current_segment_index + 1
+        return current_rule
+
+    @classmethod
+    def parse_rules(cls, rules_data: str) -> "RequestAccess":
+        rules = parse_raw_as(List[ApiAccessRule], rules_data)
+        return cls.build(rules)
+
+    @classmethod
+    def build(cls, rules: List[ApiAccessRule]) -> "RequestAccess":
+        request_access = RequestAccess()
+        for rule in rules:
+            request_access.__add_url__(
+                rule.methods,
+                rule.endpoint,
+                RequestAccess.Rules(allowed_groups_ids=rule.allowed_groups),
+            )
+
+        return request_access

--- a/src/api-service/tests/test_request_access.py
+++ b/src/api-service/tests/test_request_access.py
@@ -1,0 +1,173 @@
+import unittest
+import uuid
+
+from __app__.onefuzzlib.request_access import (
+    ApiAccessRule,
+    RequestAccess,
+    RuleConflictError,
+)
+
+
+class TestRequestAccess(unittest.TestCase):
+    def test_exact_match(self) -> None:
+
+        guid1 = uuid.uuid4()
+
+        request_access = RequestAccess.build(
+            [
+                ApiAccessRule(
+                    methods=["get"],
+                    endpoint="a/b/c",
+                    allowed_groups=[guid1],
+                )
+            ]
+        )
+
+        rules1 = request_access.get_matching_rules("get", "a/b/c")
+        rules2 = request_access.get_matching_rules("get", "b/b/e")
+
+        self.assertNotEqual(len(rules1.allowed_groups_ids), 0, "empty allowed groups")
+        self.assertEqual(rules1.allowed_groups_ids[0], guid1)
+
+        self.assertEqual(len(rules2.allowed_groups_ids), 0, "expected nothing")
+
+    def test_wildcard(self) -> None:
+        guid1 = uuid.uuid4()
+
+        request_access = RequestAccess.build(
+            [
+                ApiAccessRule(
+                    methods=["get"],
+                    endpoint="b/*/c",
+                    allowed_groups=[guid1],
+                )
+            ]
+        )
+
+        rules = request_access.get_matching_rules("get", "b/b/c")
+
+        self.assertNotEqual(len(rules.allowed_groups_ids), 0, "empty allowed groups")
+        self.assertEqual(rules.allowed_groups_ids[0], guid1)
+
+    def test_adding_rule_on_same_path(self) -> None:
+        guid1 = uuid.uuid4()
+
+        try:
+            RequestAccess.build(
+                [
+                    ApiAccessRule(
+                        methods=["get"],
+                        endpoint="a/b/c",
+                        allowed_groups=[guid1],
+                    ),
+                    ApiAccessRule(
+                        methods=["get"],
+                        endpoint="a/b/c",
+                        allowed_groups=[],
+                    ),
+                ]
+            )
+
+            self.fail("this is expected to fail")
+        except RuleConflictError:
+            pass
+
+    # The most specific rules takes priority over the ones containing a wildcard
+    def test_priority(self) -> None:
+        guid1 = uuid.uuid4()
+        guid2 = uuid.uuid4()
+
+        request_access = RequestAccess.build(
+            [
+                ApiAccessRule(
+                    methods=["get"],
+                    endpoint="a/*/c",
+                    allowed_groups=[guid1],
+                ),
+                ApiAccessRule(
+                    methods=["get"],
+                    endpoint="a/b/c",
+                    allowed_groups=[guid2],
+                ),
+            ]
+        )
+
+        rules = request_access.get_matching_rules("get", "a/b/c")
+
+        self.assertEqual(
+            rules.allowed_groups_ids[0],
+            guid2,
+            "expected to match the most specific rule",
+        )
+
+    # if a path has no specific rule. it inherits from the parents
+    # /a/b/c inherit from a/b
+    def test_inherit_rule(self) -> None:
+        guid1 = uuid.uuid4()
+        guid2 = uuid.uuid4()
+        guid3 = uuid.uuid4()
+
+        request_access = RequestAccess.build(
+            [
+                ApiAccessRule(
+                    methods=["get"],
+                    endpoint="a/b/c",
+                    allowed_groups=[guid1],
+                ),
+                ApiAccessRule(
+                    methods=["get"],
+                    endpoint="f/*/c",
+                    allowed_groups=[guid2],
+                ),
+                ApiAccessRule(
+                    methods=["post"],
+                    endpoint="a/b",
+                    allowed_groups=[guid3],
+                ),
+            ]
+        )
+
+        rules1 = request_access.get_matching_rules("get", "a/b/c/d")
+        self.assertEqual(
+            rules1.allowed_groups_ids[0], guid1, "expected to inherit rule of a/b/c"
+        )
+
+        rules2 = request_access.get_matching_rules("get", "f/b/c/d")
+        self.assertEqual(
+            rules2.allowed_groups_ids[0], guid2, "expected to inherit rule of f/*/c"
+        )
+
+        rules3 = request_access.get_matching_rules("post", "a/b/c/d")
+        self.assertEqual(
+            rules3.allowed_groups_ids[0], guid3, "expected to inherit rule of post a/b"
+        )
+
+    # the lowest level rule override the parent rules
+    def test_override_rule(self) -> None:
+        guid1 = uuid.uuid4()
+        guid2 = uuid.uuid4()
+
+        request_access = RequestAccess.build(
+            [
+                ApiAccessRule(
+                    methods=["get"],
+                    endpoint="a/b/c",
+                    allowed_groups=[guid1],
+                ),
+                ApiAccessRule(
+                    methods=["get"],
+                    endpoint="a/b/c/d",
+                    allowed_groups=[guid2],
+                ),
+            ]
+        )
+
+        rules1 = request_access.get_matching_rules("get", "a/b/c")
+        self.assertEqual(
+            rules1.allowed_groups_ids[0], guid1, "expected to inherit rule of a/b/c"
+        )
+
+        rules2 = request_access.get_matching_rules("get", "a/b/c/d")
+        self.assertEqual(
+            rules2.allowed_groups_ids[0], guid2, "expected to inherit rule of a/b/c/d"
+        )

--- a/src/api-service/tests/test_request_access.py
+++ b/src/api-service/tests/test_request_access.py
@@ -9,6 +9,25 @@ from __app__.onefuzzlib.request_access import (
 
 
 class TestRequestAccess(unittest.TestCase):
+    def test_empty(self) -> None:
+        request_access1 = RequestAccess.build([])
+        rules1 = request_access1.get_matching_rules("get", "a/b/c")
+
+        self.assertEqual(len(rules1.allowed_groups_ids), 0, "expected nothing")
+
+        guid2 = uuid.uuid4()
+        request_access1 = RequestAccess.build(
+            [
+                ApiAccessRule(
+                    methods=["get"],
+                    endpoint="a/b/c",
+                    allowed_groups=[guid2],
+                )
+            ]
+        )
+        rules1 = request_access1.get_matching_rules("get", "")
+        self.assertEqual(len(rules1.allowed_groups_ids), 0, "expected nothing")
+
     def test_exact_match(self) -> None:
 
         guid1 = uuid.uuid4()

--- a/src/api-service/tests/test_request_access.py
+++ b/src/api-service/tests/test_request_access.py
@@ -1,11 +1,9 @@
 import unittest
 import uuid
 
-from __app__.onefuzzlib.request_access import (
-    ApiAccessRule,
-    RequestAccess,
-    RuleConflictError,
-)
+from onefuzztypes.models import ApiAccessRule
+
+from __app__.onefuzzlib.request_access import RequestAccess, RuleConflictError
 
 
 class TestRequestAccess(unittest.TestCase):

--- a/src/pytypes/onefuzztypes/models.py
+++ b/src/pytypes/onefuzztypes/models.py
@@ -831,6 +831,11 @@ class AzureVmExtensionConfig(BaseModel):
     geneva: Optional[GenevaExtensionConfig]
 
 
+class ApiAccessRule(BaseModel):
+    methods: List[str]
+    endpoint: str
+    allowed_groups: List[UUID]
+
 class InstanceConfig(BaseModel):
     # initial set of admins can only be set during deployment.
     # if admins are set, only admins can update instance configs.

--- a/src/pytypes/onefuzztypes/models.py
+++ b/src/pytypes/onefuzztypes/models.py
@@ -836,6 +836,7 @@ class ApiAccessRule(BaseModel):
     endpoint: str
     allowed_groups: List[UUID]
 
+
 class InstanceConfig(BaseModel):
     # initial set of admins can only be set during deployment.
     # if admins are set, only admins can update instance configs.


### PR DESCRIPTION
This PR introduce a new class to store and retrieve rules associated with an api endpoint.
This code will be used as part of the work to enable access control at the api level(#1074 )