### PR TITLE
Bump python version of the function app to 3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         key: rust-${{ runner.os }}-${{ env.ACTIONS_CACHE_KEY_DATE }}
     - name: Install Rust Prereqs
       if: steps.cache-rust-prereqs.outputs.cache-hit != 'true'
-      shell: bash 
+      shell: bash
       run: src/ci/rust-prereqs.sh
     - name: Rust Compile Cache
       uses: actions/cache@v2
@@ -183,7 +183,7 @@ jobs:
         key: rust-${{ runner.os }}-${{ env.ACTIONS_CACHE_KEY_DATE }}
     - name: Install Rust Prereqs
       if: steps.cache-rust-prereqs.outputs.cache-hit != 'true'
-      shell: bash 
+      shell: bash
       run: src/ci/rust-prereqs.sh
     - name: Rust Compile Cache
       uses: actions/cache@v2
@@ -206,7 +206,7 @@ jobs:
     - run: src/ci/set-versions.sh
     - uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: 3.8
     - uses: actions/download-artifact@v2.0.8
       with:
         name: build-artifacts
@@ -241,7 +241,7 @@ jobs:
         mypy __app__ ./tests
 
         # set a minimum confidence to ignore known false positives
-        vulture --min-confidence 61 __app__ 
+        vulture --min-confidence 61 __app__
 
         ../ci/disable-py-cache.sh
         mypy __app__ ./tests
@@ -415,7 +415,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - run: |
-          Set-ExecutionPolicy Bypass -Scope Process -Force 
+          Set-ExecutionPolicy Bypass -Scope Process -Force
           $ProgressPreference = 'SilentlyContinue'
           Invoke-Expression (Invoke-RestMethod 'https://chocolatey.org/install.ps1')
           choco install llvm
@@ -450,7 +450,7 @@ jobs:
           $env:LIB = $env:LIBRARY_PATH
 
           cd src/integration-tests
-          
+
           mkdir artifacts/windows-libfuzzer
           cd libfuzzer
           make
@@ -468,7 +468,7 @@ jobs:
           make -f Makefile.windows
           cp fuzz.exe,fuzz.pdb,bad1.dll,bad1.pdb,bad2.dll,bad2.pdb,seeds ../artifacts/windows-libfuzzer-linked-library -Recurse
           cd ../
-          
+
           mkdir artifacts/windows-libfuzzer-load-library
           cd libfuzzer-load-library
           make


### PR DESCRIPTION
## Summary of the Pull Request

Update the version of the azure function version to 3.8. This is currently the [highest version](https://docs.microsoft.com/en-us/azure/azure-functions/functions-reference-python?tabs=azurecli-linux%2Capplication-level#python-version) supported.
And is necessary to use the [protocol feature](https://www.python.org/dev/peps/pep-0544/) used in #1074


_How does someone test & validate?_
run check-pr
