### PR TITLE
suspend process before killing it

### DIFF
--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -1729,6 +1729,7 @@ dependencies = [
  "url",
  "users",
  "uuid",
+ "winapi 0.3.9",
 ]
 
 [[package]]

--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -1717,6 +1717,7 @@ dependencies = [
  "env_logger 0.9.0",
  "futures",
  "log",
+ "nix",
  "onefuzz",
  "onefuzz-telemetry",
  "reqwest",

--- a/src/agent/onefuzz-supervisor/Cargo.toml
+++ b/src/agent/onefuzz-supervisor/Cargo.toml
@@ -29,6 +29,7 @@ backtrace = "0.3"
 
 [target.'cfg(target_family = "unix")'.dependencies]
 users = "0.11"
+nix = "0.23"
 
 [target.'cfg(target_family = "windows")'.dependencies]
 winapi = "0.3"

--- a/src/agent/onefuzz-supervisor/Cargo.toml
+++ b/src/agent/onefuzz-supervisor/Cargo.toml
@@ -29,3 +29,6 @@ backtrace = "0.3"
 
 [target.'cfg(target_family = "unix")'.dependencies]
 users = "0.11"
+
+[target.'cfg(target_family = "windows")'.dependencies]
+winapi = "0.3"

--- a/src/agent/onefuzz-supervisor/src/worker.rs
+++ b/src/agent/onefuzz-supervisor/src/worker.rs
@@ -254,7 +254,7 @@ impl SuspendableChild for Child {
     }
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 impl SuspendableChild for Child {
     fn suspend(&mut self) -> Result<()> {
         use nix::sys::signal;

--- a/src/agent/onefuzz-supervisor/src/worker.rs
+++ b/src/agent/onefuzz-supervisor/src/worker.rs
@@ -243,7 +243,6 @@ trait SuspendableChild {
     fn suspend(&mut self) -> Result<()>;
 }
 
-
 #[cfg(target_os = "windows")]
 impl SuspendableChild for Child {
     fn suspend(&mut self) -> Result<()> {

--- a/src/agent/onefuzz-supervisor/src/worker.rs
+++ b/src/agent/onefuzz-supervisor/src/worker.rs
@@ -246,6 +246,8 @@ trait SuspendableChild {
 #[cfg(target_os = "windows")]
 impl SuspendableChild for Child {
     fn suspend(&mut self) -> Result<()> {
+        // DebugActiveProcess suspends all threads in the process.
+        // https://docs.microsoft.com/en-us/windows/win32/api/debugapi/nf-debugapi-debugactiveprocess#remarks
         let result = unsafe { winapi::um::debugapi::DebugActiveProcess(self.id() as u32) };
         if result == 0 {
             bail!("unable to suspend child process");

--- a/src/agent/onefuzz-supervisor/src/worker.rs
+++ b/src/agent/onefuzz-supervisor/src/worker.rs
@@ -386,7 +386,7 @@ impl IWorkerChild for RedirectedChild {
         use std::io::ErrorKind;
 
         // trying to gracefully kill the child process.
-        // we ignore the error if it's because the process will be killed anyway
+        // we ignore the error here because the process will be killed anyway
         if let Err(suspend_error) = self.child.suspend() {
             log::info!("error while suspending process: {}", suspend_error);
         }

--- a/src/agent/onefuzz-supervisor/src/worker.rs
+++ b/src/agent/onefuzz-supervisor/src/worker.rs
@@ -257,8 +257,11 @@ impl SuspendableChild for Child {
 #[cfg(target_os = "linux")]
 impl SuspendableChild for Child {
     fn suspend(&mut self) -> Result<()> {
-        use nix::sys::signal::{self, Signal};
-        signal::kill(Pid::from_raw(child.id()), Signal::SIGSTOP)?;
+        use nix::sys::signal;
+        signal::kill(
+            nix::unistd::Pid::from_raw(self.id() as _),
+            signal::Signal::SIGSTOP,
+        )?;
         Ok(())
     }
 }

--- a/src/agent/onefuzz-supervisor/src/worker.rs
+++ b/src/agent/onefuzz-supervisor/src/worker.rs
@@ -388,7 +388,7 @@ impl IWorkerChild for RedirectedChild {
         // trying to gracefully kill the child process.
         // we ignore the error if it's because the process will be killed anyway
         if let Err(suspend_error) = self.child.suspend() {
-            log::error!("error while suspending process: {}", suspend_error);
+            log::info!("error while suspending process: {}", suspend_error);
         }
 
         let killed = self.child.kill();

--- a/src/agent/onefuzz-supervisor/src/worker.rs
+++ b/src/agent/onefuzz-supervisor/src/worker.rs
@@ -385,7 +385,7 @@ impl IWorkerChild for RedirectedChild {
     fn kill(&mut self) -> Result<()> {
         use std::io::ErrorKind;
 
-        // trying to gracefully kill the child process.
+        // Try to gracefully kill the child process to avoid spurious error telemetry;
         // we ignore the error here because the process will be killed anyway
         if let Err(suspend_error) = self.child.suspend() {
             log::info!("error while suspending process: {}", suspend_error);

--- a/src/agent/onefuzz-supervisor/src/worker.rs
+++ b/src/agent/onefuzz-supervisor/src/worker.rs
@@ -387,7 +387,9 @@ impl IWorkerChild for RedirectedChild {
 
         // trying to gracefully kill the child process.
         // we ignore the error if it's because the process will be killed anyway
-        let _ = self.child.suspend();
+        if let Err(suspend_error) = self.child.suspend() {
+            log::error!("error while suspending process: {}", suspend_error);
+        }
 
         let killed = self.child.kill();
 

--- a/src/integration-tests/integration-test.py
+++ b/src/integration-tests/integration-test.py
@@ -503,6 +503,8 @@ class TestOnefuzz:
                     to_remove.add(job.job_id)
 
             for job_id in to_remove:
+                # send the stop marker here to ignore errors after the jobs stops
+                self.inject_log(self.stop_log_marker)
                 if stop_on_complete_check:
                     self.stop_job(jobs[job_id])
                 del jobs[job_id]

--- a/src/integration-tests/integration-test.py
+++ b/src/integration-tests/integration-test.py
@@ -504,9 +504,6 @@ class TestOnefuzz:
 
             for job_id in to_remove:
                 if stop_on_complete_check:
-                    # send the stop marker here to ignore errors after the jobs stops
-                    self.inject_log(self.stop_log_marker)
-                    wait(self.check_log_end_marker, frequency=5.0)
                     self.stop_job(jobs[job_id])
                 del jobs[job_id]
 
@@ -781,11 +778,6 @@ class TestOnefuzz:
             if not seen_stop:
                 if self.stop_log_marker in message:
                     seen_stop = True
-                continue
-
-            # ignore any errors after any the stop marker
-            if self.stop_log_marker in message:
-                seen_errors = False
                 continue
 
             if self.start_log_marker in message:

--- a/src/integration-tests/integration-test.py
+++ b/src/integration-tests/integration-test.py
@@ -506,6 +506,7 @@ class TestOnefuzz:
                 if stop_on_complete_check:
                     # send the stop marker here to ignore errors after the jobs stops
                     self.inject_log(self.stop_log_marker)
+                    wait(self.check_log_end_marker, frequency=5.0)
                     self.stop_job(jobs[job_id])
                 del jobs[job_id]
 

--- a/src/integration-tests/integration-test.py
+++ b/src/integration-tests/integration-test.py
@@ -503,9 +503,9 @@ class TestOnefuzz:
                     to_remove.add(job.job_id)
 
             for job_id in to_remove:
-                # send the stop marker here to ignore errors after the jobs stops
-                self.inject_log(self.stop_log_marker)
                 if stop_on_complete_check:
+                    # send the stop marker here to ignore errors after the jobs stops
+                    self.inject_log(self.stop_log_marker)
                     self.stop_job(jobs[job_id])
                 del jobs[job_id]
 

--- a/src/integration-tests/integration-test.py
+++ b/src/integration-tests/integration-test.py
@@ -783,6 +783,11 @@ class TestOnefuzz:
                     seen_stop = True
                 continue
 
+            # ignore any errors after any the stop marker
+            if self.stop_log_marker in message:
+                seen_errors = False
+                continue
+
             if self.start_log_marker in message:
                 break
 


### PR DESCRIPTION
## Summary of the Pull Request
This is a fix for #1411. The error was caused by the handling of the stop message. The task seems to log an error after the being killed by the supervisor. These errors are cause the integration test to fail.
the fix is to suspend the child process before killing it so that no error messages gets forwarded to appinsight

How to test:
run check-pr.py 
