### PR TITLE
Add newline to correct Markdown format

### DIFF
--- a/src/api-service/__app__/onefuzzlib/notifications/teams.py
+++ b/src/api-service/__app__/onefuzzlib/notifications/teams.py
@@ -26,7 +26,7 @@ def markdown_escape(data: str) -> str:
 
 def code_block(data: str) -> str:
     data = data.replace("`", "``")
-    return "\n```%s\n```\n" % data
+    return "\n```\n%s\n```\n" % data
 
 
 def send_teams_webhook(


### PR DESCRIPTION
## Summary of the Pull Request

This pull request is to address issue #1260. The existing code currently produces invalid Markdown which causes rendering issues in the Teams notifications. A picture of the rendering issue is included within the issue report. This code change will convert the output into a valid Markdown code block which properly renders in Microsoft Teams.

## PR Checklist
* [x] Applies to work item: #1260 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/onefuzz) and sign the CLI.
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #1260

## Info on Pull Request

The _code_block_ function should include a newline after the first three back ticks in order to properly start the code block section. Without the newline, the existing code produces three back ticks followed immediately by the data. In Markdown, a word adjacent to the initial three back ticks is assumed to be a language value for the purposes of syntax highlighting. Therefore, the Markdown parser will ignore the invalid data and produces an empty code block. The proposed change adds a single new line so that the produced output is a valid Markdown code block. 

## Validation Steps Performed

The Markdown spec was used to confirm that data following the first three back ticks is not allowed. This code was tested with Microsoft Teams within our environments.  The flaw can also be reproduced if you attempt to use the original function output within GitHub's Markdown preview feature. 