### PR TITLE
Add Compute Gallery images support

### DIFF
--- a/src/api-service/__app__/onefuzzlib/azure/image.py
+++ b/src/api-service/__app__/onefuzzlib/azure/image.py
@@ -19,6 +19,9 @@ from .compute import get_compute_client
 @cached(ttl=60)
 def get_os(region: Region, image: str) -> Union[Error, OS]:
     client = get_compute_client()
+    # The dict returned here may not have any defined keys.
+    # 
+    # See: https://github.com/Azure/msrestazure-for-python/blob/v0.6.3/msrestazure/tools.py#L134
     parsed = parse_resource_id(image)
     if "resource_group" in parsed:
         if parsed["type"] == "galleries":

--- a/src/api-service/__app__/onefuzzlib/azure/image.py
+++ b/src/api-service/__app__/onefuzzlib/azure/image.py
@@ -33,6 +33,7 @@ def get_os(region: Region, image: str) -> Union[Error, OS]:
                 return Error(code=ErrorCode.INVALID_IMAGE, errors=[str(err)])
         else:
             try:
+                # See: https://docs.microsoft.com/en-us/rest/api/compute/images/get
                 name = client.images.get(
                     parsed["resource_group"], parsed["name"]
                 ).storage_profile.os_disk.os_type.lower()

--- a/src/api-service/__app__/onefuzzlib/azure/image.py
+++ b/src/api-service/__app__/onefuzzlib/azure/image.py
@@ -21,12 +21,20 @@ def get_os(region: Region, image: str) -> Union[Error, OS]:
     client = get_compute_client()
     parsed = parse_resource_id(image)
     if "resource_group" in parsed:
-        try:
-            name = client.images.get(
-                parsed["resource_group"], parsed["name"]
-            ).storage_profile.os_disk.os_type.name
-        except (ResourceNotFoundError, CloudError) as err:
-            return Error(code=ErrorCode.INVALID_IMAGE, errors=[str(err)])
+        if parsed["type"] == "galleries":
+            try:
+                name = client.gallery_images.get(
+                    parsed["resource_group"], parsed["name"], parsed["child_name_1"]
+                ).os_type.lower()
+            except (ResourceNotFoundError, CloudError) as err:
+                return Error(code=ErrorCode.INVALID_IMAGE, errors=[str(err)])
+        else:
+            try:
+                name = client.images.get(
+                    parsed["resource_group"], parsed["name"]
+                ).storage_profile.os_disk.os_type.lower()
+            except (ResourceNotFoundError, CloudError) as err:
+                return Error(code=ErrorCode.INVALID_IMAGE, errors=[str(err)])
     else:
         publisher, offer, sku, version = image.split(":")
         try:

--- a/src/api-service/__app__/onefuzzlib/azure/image.py
+++ b/src/api-service/__app__/onefuzzlib/azure/image.py
@@ -20,13 +20,13 @@ from .compute import get_compute_client
 def get_os(region: Region, image: str) -> Union[Error, OS]:
     client = get_compute_client()
     # The dict returned here may not have any defined keys.
-    # 
-    # See: https://github.com/Azure/msrestazure-for-python/blob/v0.6.3/msrestazure/tools.py#L134
+    #
+    # See: https://github.com/Azure/msrestazure-for-python/blob/v0.6.3/msrestazure/tools.py#L134  # noqa: E501 
     parsed = parse_resource_id(image)
     if "resource_group" in parsed:
         if parsed["type"] == "galleries":
             try:
-                # See: https://docs.microsoft.com/en-us/rest/api/compute/gallery-images/get#galleryimage
+                # See: https://docs.microsoft.com/en-us/rest/api/compute/gallery-images/get#galleryimage  # noqa: E501 
                 name = client.gallery_images.get(
                     parsed["resource_group"], parsed["name"], parsed["child_name_1"]
                 ).os_type.lower()

--- a/src/api-service/__app__/onefuzzlib/azure/image.py
+++ b/src/api-service/__app__/onefuzzlib/azure/image.py
@@ -21,12 +21,12 @@ def get_os(region: Region, image: str) -> Union[Error, OS]:
     client = get_compute_client()
     # The dict returned here may not have any defined keys.
     #
-    # See: https://github.com/Azure/msrestazure-for-python/blob/v0.6.3/msrestazure/tools.py#L134  # noqa: E501 
+    # See: https://github.com/Azure/msrestazure-for-python/blob/v0.6.3/msrestazure/tools.py#L134  # noqa: E501
     parsed = parse_resource_id(image)
     if "resource_group" in parsed:
         if parsed["type"] == "galleries":
             try:
-                # See: https://docs.microsoft.com/en-us/rest/api/compute/gallery-images/get#galleryimage  # noqa: E501 
+                # See: https://docs.microsoft.com/en-us/rest/api/compute/gallery-images/get#galleryimage  # noqa: E501
                 name = client.gallery_images.get(
                     parsed["resource_group"], parsed["name"], parsed["child_name_1"]
                 ).os_type.lower()

--- a/src/api-service/__app__/onefuzzlib/azure/image.py
+++ b/src/api-service/__app__/onefuzzlib/azure/image.py
@@ -26,6 +26,7 @@ def get_os(region: Region, image: str) -> Union[Error, OS]:
     if "resource_group" in parsed:
         if parsed["type"] == "galleries":
             try:
+                # See: https://docs.microsoft.com/en-us/rest/api/compute/gallery-images/get#galleryimage
                 name = client.gallery_images.get(
                     parsed["resource_group"], parsed["name"], parsed["child_name_1"]
                 ).os_type.lower()


### PR DESCRIPTION
## Summary of the Pull Request

The documentation for using custom images while fuzzing states that Compute Gallery images are supported. However, the existing code for handling custom images does not properly address Compute Gallery resource IDs. The code only handles references to Azure Images. This pull request adds support for Compute Gallery resource IDs as discussed in issue #1443 .  In addition, it corrects an error within the existing code where an attempt to retrieve a "name" parameter is performed on the image "os_type". The "os_type" is a string and does not have a "name" parameter.  This pull request removes the invalid "name" reference and converts the string using ".lower()" similar to the default code path.

## PR Checklist
* [X] Applies to work item: #1443 
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/onefuzz) and sign the CLI.
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [X] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #1443 

## Info on Pull Request

This pull request includes a check to determine whether the resource ID refers to a "galleries" resource type. If the resource ID is confirmed to be a Compute Gallery reference, then it will use the corresponding ComputeManagementClient methods and properties to retrieve the OS type. If an Azure Image reference is provided, then the code has been changed to provide the lower case value of the OS type. Since it was unknown what existing dependencies relied on the previous behavior, the code defaults to the existing approach of assuming an Azure Image reference was given.

## Validation Steps Performed

This was tested locally within what is assumed to be a simple deployment environment. More robust testing is welcomed.
