### PR TITLE
Allow authority to be specified in check-pr

### DIFF
--- a/src/integration-tests/integration-test.py
+++ b/src/integration-tests/integration-test.py
@@ -873,7 +873,7 @@ class Run(Command):
         test_id: UUID,
         *,
         endpoint: Optional[str],
-        tenant_domain: Optional[str] = None,
+        authority: Optional[str] = None,
         client_id: Optional[str],
         client_secret: Optional[str],
         poll: bool = False,
@@ -883,7 +883,7 @@ class Run(Command):
             endpoint=endpoint,
             client_id=client_id,
             client_secret=client_secret,
-            tenant_domain=tenant_domain,
+            authority=authority,
         )
         tester = TestOnefuzz(self.onefuzz, self.logger, test_id)
         result = tester.check_jobs(
@@ -899,13 +899,13 @@ class Run(Command):
         endpoint: Optional[str],
         client_id: Optional[str],
         client_secret: Optional[str],
-        tenant_domain: Optional[str] = None,
+        authority: Optional[str] = None,
     ) -> None:
         self.onefuzz.__setup__(
             endpoint=endpoint,
             client_id=client_id,
             client_secret=client_secret,
-            tenant_domain=tenant_domain,
+            authority=authority,
         )
         tester = TestOnefuzz(self.onefuzz, self.logger, test_id)
         launch_result, repros = tester.launch_repro()
@@ -918,7 +918,7 @@ class Run(Command):
         samples: Directory,
         *,
         endpoint: Optional[str] = None,
-        tenant_domain: Optional[str] = None,
+        authority: Optional[str] = None,
         client_id: Optional[str] = None,
         client_secret: Optional[str] = None,
         pool_size: int = 10,
@@ -937,7 +937,7 @@ class Run(Command):
                 endpoint=endpoint,
                 client_id=client_id,
                 client_secret=client_secret,
-                tenant_domain=tenant_domain,
+                authority=authority,
             )
 
         retry(try_setup, "trying to configure")
@@ -952,7 +952,7 @@ class Run(Command):
         test_id: UUID,
         *,
         endpoint: Optional[str],
-        tenant_domain: Optional[str],
+        authority: Optional[str],
         client_id: Optional[str],
         client_secret: Optional[str],
     ) -> None:
@@ -960,7 +960,7 @@ class Run(Command):
             endpoint=endpoint,
             client_id=client_id,
             client_secret=client_secret,
-            tenant_domain=tenant_domain,
+            authority=authority,
         )
         tester = TestOnefuzz(self.onefuzz, self.logger, test_id=test_id)
         tester.cleanup()
@@ -970,7 +970,7 @@ class Run(Command):
         test_id: UUID,
         *,
         endpoint: Optional[str],
-        tenant_domain: Optional[str] = None,
+        authority: Optional[str] = None,
         client_id: Optional[str],
         client_secret: Optional[str],
     ) -> None:
@@ -978,7 +978,7 @@ class Run(Command):
             endpoint=endpoint,
             client_id=client_id,
             client_secret=client_secret,
-            tenant_domain=tenant_domain,
+            authority=authority,
         )
         tester = TestOnefuzz(self.onefuzz, self.logger, test_id=test_id)
         tester.check_logs_for_errors()
@@ -988,7 +988,7 @@ class Run(Command):
         samples: Directory,
         *,
         endpoint: Optional[str] = None,
-        tenant: Optional[str] = None,
+        authority: Optional[str] = None,
         client_id: Optional[str] = None,
         client_secret: Optional[str] = None,
         pool_size: int = 15,
@@ -1006,7 +1006,7 @@ class Run(Command):
             self.launch(
                 samples,
                 endpoint=endpoint,
-                tenant_domain=tenant,
+                authority=authority,
                 client_id=client_id,
                 client_secret=client_secret,
                 pool_size=pool_size,
@@ -1019,7 +1019,7 @@ class Run(Command):
             self.check_jobs(
                 test_id,
                 endpoint=endpoint,
-                tenant_domain=tenant,
+                authority=authority,
                 client_id=client_id,
                 client_secret=client_secret,
                 poll=True,
@@ -1032,7 +1032,7 @@ class Run(Command):
                 self.check_repros(
                     test_id,
                     endpoint=endpoint,
-                    tenant_domain=tenant,
+                    authority=authority,
                     client_id=client_id,
                     client_secret=client_secret,
                 )
@@ -1042,7 +1042,7 @@ class Run(Command):
                 endpoint=endpoint,
                 client_id=client_id,
                 client_secret=client_secret,
-                tenant_domain=tenant,
+                authority=authority,
             )
 
         except Exception as e:
@@ -1059,7 +1059,7 @@ class Run(Command):
                 endpoint=endpoint,
                 client_id=client_id,
                 client_secret=client_secret,
-                tenant_domain=tenant,
+                authority=authority,
             )
         except Exception as e:
             self.logger.error("testing failed: %s", repr(e))

--- a/src/integration-tests/integration-test.py
+++ b/src/integration-tests/integration-test.py
@@ -873,13 +873,17 @@ class Run(Command):
         test_id: UUID,
         *,
         endpoint: Optional[str],
+        tenant_domain: Optional[str] = None,
         client_id: Optional[str],
         client_secret: Optional[str],
         poll: bool = False,
         stop_on_complete_check: bool = False,
     ) -> None:
         self.onefuzz.__setup__(
-            endpoint=endpoint, client_id=client_id, client_secret=client_secret
+            endpoint=endpoint,
+            client_id=client_id,
+            client_secret=client_secret,
+            tenant_domain=tenant_domain,
         )
         tester = TestOnefuzz(self.onefuzz, self.logger, test_id)
         result = tester.check_jobs(
@@ -895,9 +899,13 @@ class Run(Command):
         endpoint: Optional[str],
         client_id: Optional[str],
         client_secret: Optional[str],
+        tenant_domain: Optional[str] = None,
     ) -> None:
         self.onefuzz.__setup__(
-            endpoint=endpoint, client_id=client_id, client_secret=client_secret
+            endpoint=endpoint,
+            client_id=client_id,
+            client_secret=client_secret,
+            tenant_domain=tenant_domain,
         )
         tester = TestOnefuzz(self.onefuzz, self.logger, test_id)
         launch_result, repros = tester.launch_repro()
@@ -910,6 +918,7 @@ class Run(Command):
         samples: Directory,
         *,
         endpoint: Optional[str] = None,
+        tenant_domain: Optional[str] = None,
         client_id: Optional[str] = None,
         client_secret: Optional[str] = None,
         pool_size: int = 10,
@@ -925,7 +934,10 @@ class Run(Command):
 
         def try_setup(data: Any) -> None:
             self.onefuzz.__setup__(
-                endpoint=endpoint, client_id=client_id, client_secret=client_secret
+                endpoint=endpoint,
+                client_id=client_id,
+                client_secret=client_secret,
+                tenant_domain=tenant_domain,
             )
 
         retry(try_setup, "trying to configure")
@@ -940,11 +952,15 @@ class Run(Command):
         test_id: UUID,
         *,
         endpoint: Optional[str],
+        tenant_domain: Optional[str],
         client_id: Optional[str],
         client_secret: Optional[str],
     ) -> None:
         self.onefuzz.__setup__(
-            endpoint=endpoint, client_id=client_id, client_secret=client_secret
+            endpoint=endpoint,
+            client_id=client_id,
+            client_secret=client_secret,
+            tenant_domain=tenant_domain,
         )
         tester = TestOnefuzz(self.onefuzz, self.logger, test_id=test_id)
         tester.cleanup()
@@ -954,11 +970,15 @@ class Run(Command):
         test_id: UUID,
         *,
         endpoint: Optional[str],
+        tenant_domain: Optional[str] = None,
         client_id: Optional[str],
         client_secret: Optional[str],
     ) -> None:
         self.onefuzz.__setup__(
-            endpoint=endpoint, client_id=client_id, client_secret=client_secret
+            endpoint=endpoint,
+            client_id=client_id,
+            client_secret=client_secret,
+            tenant_domain=tenant_domain,
         )
         tester = TestOnefuzz(self.onefuzz, self.logger, test_id=test_id)
         tester.check_logs_for_errors()
@@ -968,6 +988,7 @@ class Run(Command):
         samples: Directory,
         *,
         endpoint: Optional[str] = None,
+        tenant: Optional[str] = None,
         client_id: Optional[str] = None,
         client_secret: Optional[str] = None,
         pool_size: int = 15,
@@ -985,6 +1006,7 @@ class Run(Command):
             self.launch(
                 samples,
                 endpoint=endpoint,
+                tenant_domain=tenant,
                 client_id=client_id,
                 client_secret=client_secret,
                 pool_size=pool_size,
@@ -997,6 +1019,7 @@ class Run(Command):
             self.check_jobs(
                 test_id,
                 endpoint=endpoint,
+                tenant_domain=tenant,
                 client_id=client_id,
                 client_secret=client_secret,
                 poll=True,
@@ -1009,6 +1032,7 @@ class Run(Command):
                 self.check_repros(
                     test_id,
                     endpoint=endpoint,
+                    tenant_domain=tenant,
                     client_id=client_id,
                     client_secret=client_secret,
                 )
@@ -1018,6 +1042,7 @@ class Run(Command):
                 endpoint=endpoint,
                 client_id=client_id,
                 client_secret=client_secret,
+                tenant_domain=tenant,
             )
 
         except Exception as e:
@@ -1034,6 +1059,7 @@ class Run(Command):
                 endpoint=endpoint,
                 client_id=client_id,
                 client_secret=client_secret,
+                tenant_domain=tenant,
             )
         except Exception as e:
             self.logger.error("testing failed: %s", repr(e))

--- a/src/utils/check-pr/check-pr.py
+++ b/src/utils/check-pr/check-pr.py
@@ -167,7 +167,7 @@ class Deployer:
         instance: str,
         region: str,
         subscription_id: Optional[str],
-        tenant_domain: Optional[str],
+        authority: Optional[str],
         skip_tests: bool,
         test_args: List[str],
         repo: str,
@@ -185,7 +185,7 @@ class Deployer:
         self.unattended = unattended
         self.client_id: Optional[str] = None
         self.client_secret: Optional[str] = None
-        self.tenant_domain = tenant_domain
+        self.authority = authority
 
     def merge(self) -> None:
         if self.pr:
@@ -274,7 +274,7 @@ class Deployer:
             if self.unattended
             else ""
         )
-        tenant_args = f"--tenant {self.tenant_domain}" if self.tenant_domain else ""
+        authority_args = f"--authority {self.authority}" if self.authority else ""
 
         commands = [
             (
@@ -289,7 +289,7 @@ class Deployer:
                 (
                     f"{py} {test_dir}/{script} test {test_dir} "
                     f"--region {self.region} --endpoint {endpoint} "
-                    f"{tenant_args} "
+                    f"{authority_args} "
                     f"{unattended_args} {test_args}"
                 ),
             ),
@@ -365,7 +365,7 @@ def main() -> None:
     parser.add_argument("--skip-cleanup-on-failure", action="store_true")
     parser.add_argument("--merge-on-success", action="store_true")
     parser.add_argument("--subscription_id")
-    parser.add_argument("--tenant", default=None)
+    parser.add_argument("--authority", default=None)
     parser.add_argument("--test_args", nargs=argparse.REMAINDER)
     parser.add_argument("--unattended", action="store_true")
     args = parser.parse_args()
@@ -383,7 +383,7 @@ def main() -> None:
         test_args=args.test_args,
         repo=args.repo,
         unattended=args.unattended,
-        tenant_domain=args.tenant,
+        authority=args.authority,
     )
     with tempfile.TemporaryDirectory() as directory:
         os.chdir(directory)

--- a/src/utils/check-pr/check-pr.py
+++ b/src/utils/check-pr/check-pr.py
@@ -182,8 +182,8 @@ class Deployer:
         self.test_args = test_args or []
         self.repo = repo
         self.unattended = unattended
-        self.client_id = ""
-        self.client_secret = ""
+        self.client_id = None
+        self.client_secret = None
 
     def merge(self) -> None:
         if self.pr:

--- a/src/utils/check-pr/check-pr.py
+++ b/src/utils/check-pr/check-pr.py
@@ -167,6 +167,7 @@ class Deployer:
         instance: str,
         region: str,
         subscription_id: Optional[str],
+        tenant_domain: Optional[str],
         skip_tests: bool,
         test_args: List[str],
         repo: str,
@@ -182,8 +183,9 @@ class Deployer:
         self.test_args = test_args or []
         self.repo = repo
         self.unattended = unattended
-        self.client_id = None
-        self.client_secret = None
+        self.client_id: Optional[str] = None
+        self.client_secret: Optional[str] = None
+        self.tenant_domain = tenant_domain
 
     def merge(self) -> None:
         if self.pr:
@@ -272,6 +274,7 @@ class Deployer:
             if self.unattended
             else ""
         )
+        tenant_args = f"--tenant {self.tenant_domain}" if self.tenant_domain else ""
 
         commands = [
             (
@@ -286,6 +289,7 @@ class Deployer:
                 (
                     f"{py} {test_dir}/{script} test {test_dir} "
                     f"--region {self.region} --endpoint {endpoint} "
+                    f"{tenant_args} "
                     f"{unattended_args} {test_args}"
                 ),
             ),
@@ -361,6 +365,7 @@ def main() -> None:
     parser.add_argument("--skip-cleanup-on-failure", action="store_true")
     parser.add_argument("--merge-on-success", action="store_true")
     parser.add_argument("--subscription_id")
+    parser.add_argument("--tenant")
     parser.add_argument("--test_args", nargs=argparse.REMAINDER)
     parser.add_argument("--unattended", action="store_true")
     args = parser.parse_args()

--- a/src/utils/check-pr/check-pr.py
+++ b/src/utils/check-pr/check-pr.py
@@ -365,7 +365,7 @@ def main() -> None:
     parser.add_argument("--skip-cleanup-on-failure", action="store_true")
     parser.add_argument("--merge-on-success", action="store_true")
     parser.add_argument("--subscription_id")
-    parser.add_argument("--tenant")
+    parser.add_argument("--tenant", default=None)
     parser.add_argument("--test_args", nargs=argparse.REMAINDER)
     parser.add_argument("--unattended", action="store_true")
     args = parser.parse_args()
@@ -383,6 +383,7 @@ def main() -> None:
         test_args=args.test_args,
         repo=args.repo,
         unattended=args.unattended,
+        tenant_domain=args.tenant,
     )
     with tempfile.TemporaryDirectory() as directory:
         os.chdir(directory)


### PR DESCRIPTION
Allow authority to be specified in check-pr.

This fixes the following error:
```
ERROR:integration:testing failed: Exception("error: invalid_request\n'AADSTS50059: No tenant-identifying information found in either the request or implied by any provided credentials.\r\nTrace ID: 26e81640-56cf-4300-bb04-7e19085dce00\r\nCorrelation ID: 456be707-73f0-4f0c-939d-98ef6bafa9e6\r\nTimestamp: 2022-02-02 21:13:06Z'")
ERROR:integration:traceback: Traceback (most recent call last):
ERROR:integration:traceback:   File "integration-test-artifacts/integration-test.py", line 1071, in test
ERROR:integration:traceback:     raise error
ERROR:integration:traceback:   File "integration-test-artifacts/integration-test.py", line 1057, in test
ERROR:integration:traceback:     self.cleanup(
ERROR:integration:traceback:   File "integration-test-artifacts/integration-test.py", line 966, in cleanup
ERROR:integration:traceback:     tester.cleanup()
ERROR:integration:traceback:   File "integration-test-artifacts/integration-test.py", line 719, in cleanup
ERROR:integration:traceback:     jobs = self.get_jobs()
ERROR:integration:traceback:   File "integration-test-artifacts/integration-test.py", line 696, in get_jobs
ERROR:integration:traceback:     jobs = self.of.jobs.list(job_state=None)
ERROR:integration:traceback:   File "/tmp/tmp9d9np2bl/test-venv/lib/python3.8/site-packages/onefuzz/api.py", line 1114, in list
ERROR:integration:traceback:     return self._req_model_list(
ERROR:integration:traceback:   File "/tmp/tmp9d9np2bl/test-venv/lib/python3.8/site-packages/onefuzz/api.py", line 127, in _req_model_list
ERROR:integration:traceback:     response = self.onefuzz._backend.request(method, endpoint, json_data=data)
ERROR:integration:traceback:   File "/tmp/tmp9d9np2bl/test-venv/lib/python3.8/site-packages/onefuzz/backend.py", line 285, in request
ERROR:integration:traceback:     headers = self.headers()
ERROR:integration:traceback:   File "/tmp/tmp9d9np2bl/test-venv/lib/python3.8/site-packages/onefuzz/backend.py", line 166, in headers
ERROR:integration:traceback:     access_token = self.get_access_token()
ERROR:integration:traceback:   File "/tmp/tmp9d9np2bl/test-venv/lib/python3.8/site-packages/onefuzz/backend.py", line 191, in get_access_token
ERROR:integration:traceback:     return self.client_secret(scopes)
ERROR:integration:traceback:   File "/tmp/tmp9d9np2bl/test-venv/lib/python3.8/site-packages/onefuzz/backend.py", line 218, in client_secret
ERROR:integration:traceback:     raise Exception(
ERROR:integration:traceback: Exception: error: invalid_request
ERROR:integration:traceback: 'AADSTS50059: No tenant-identifying information found in either the request or implied by any provided credentials.
ERROR:integration:traceback: Trace ID: 26e81640-56cf-4300-bb04-7e19085dce00

ERROR:integration:traceback: Correlation ID: 456be707-73f0-4f0c-939d-98ef6bafa9e6
ERROR:integration:traceback: Timestamp: 2022-02-02 21:13:06Z'
ERROR:integration:traceback:
```