### PR TITLE
[Bug Fix] Adding Check for SP During User Role Assignment.

### DIFF
--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -819,9 +819,9 @@ checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "futures"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12aa0eb539080d55c3f2d45a67c3b58b6b0773c1a3ca2dfec66d58c97fd66ca"
+checksum = "8cd0210d8c325c245ff06fd95a3b13689a1a276ac8cfa8e8720cb840bfb84b9e"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -834,9 +834,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5da6ba8c3bb3c165d3c7319fc1cc8304facf1fb8db99c5de877183c08a273888"
+checksum = "7fc8cd39e3dbf865f7340dce6a2d401d24fd37c6fe6c4f0ee0de8bfca2252d27"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -844,15 +844,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d1c26957f23603395cd326b0ffe64124b818f4449552f960d815cfba83a53d"
+checksum = "629316e42fe7c2a0b9a65b47d159ceaa5453ab14e8f0a3c5eedbb8cd55b4a445"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45025be030969d763025784f7f355043dc6bc74093e4ecc5000ca4dc50d8745c"
+checksum = "7b808bf53348a36cab739d7e04755909b9fcaaa69b7d7e588b37b6ec62704c97"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -861,9 +861,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "522de2a0fe3e380f1bc577ba0474108faf3f6b18321dbf60b3b9c39a75073377"
+checksum = "e481354db6b5c353246ccf6a728b0c5511d752c08da7260546fc0933869daa11"
 
 [[package]]
 name = "futures-lite"
@@ -882,12 +882,10 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e4a4b95cea4b4ccbcf1c5675ca7c4ee4e9e75eb79944d07defde18068f79bb"
+checksum = "a89f17b21645bc4ed773c69af9c9a0effd4a3f1a3876eadd453469f8854e7fdd"
 dependencies = [
- "autocfg",
- "proc-macro-hack",
  "proc-macro2 1.0.29",
  "quote 1.0.9",
  "syn 1.0.76",
@@ -895,15 +893,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36ea153c13024fe480590b3e3d4cad89a0cfacecc24577b68f86c6ced9c2bc11"
+checksum = "996c6442437b62d21a32cd9906f9c41e7dc1e19a9579843fad948696769305af"
 
 [[package]]
 name = "futures-task"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d3d00f4eddb73e498a54394f228cd55853bdf059259e8e7bc6e69d408892e99"
+checksum = "dabf1872aaab32c886832f2276d2f5399887e2bd613698a02359e4ea83f8de12"
 
 [[package]]
 name = "futures-timer"
@@ -913,11 +911,10 @@ checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36568465210a3a6ee45e1f165136d68671471a501e632e9a98d96872222b5481"
+checksum = "41d22213122356472061ac0f1ab2cee28d2bac8491410fd68c2af53d1cedb83e"
 dependencies = [
- "autocfg",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -927,8 +924,6 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "pin-utils",
- "proc-macro-hack",
- "proc-macro-nested",
  "slab",
 ]
 
@@ -1967,18 +1962,6 @@ dependencies = [
  "quote 1.0.9",
  "version_check",
 ]
-
-[[package]]
-name = "proc-macro-hack"
-version = "0.5.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
-
-[[package]]
-name = "proc-macro-nested"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"

--- a/src/deployment/deploy.py
+++ b/src/deployment/deploy.py
@@ -615,7 +615,7 @@ class Client:
     def assign_user_access(self) -> None:
         if self.upgrade:
             logger.info(
-                "Deploying w/ Service Principal. Skipping assignment of the user role."
+                "Upgrading: Skipping assignment of current user to app role"
             )
             return
         logger.info("assinging user access to service principal")

--- a/src/deployment/deploy.py
+++ b/src/deployment/deploy.py
@@ -45,6 +45,8 @@ from azure.storage.blob import (
     ContainerSasPermissions,
     generate_container_sas,
 )
+from msrest.serialization import TZ_UTC
+
 from deploylib.configuration import (
     InstanceConfigClient,
     NetworkSecurityConfig,
@@ -70,7 +72,6 @@ from deploylib.registration import (
     set_app_audience,
     update_pool_registration,
 )
-from msrest.serialization import TZ_UTC
 
 # Found by manually assigning the User.Read permission to application
 # registration in the admin portal. The values are in the manifest under

--- a/src/deployment/deploy.py
+++ b/src/deployment/deploy.py
@@ -614,9 +614,7 @@ class Client:
 
     def assign_user_access(self) -> None:
         if self.upgrade:
-            logger.info(
-                "Upgrading: Skipping assignment of current user to app role"
-            )
+            logger.info("Upgrading: Skipping assignment of current user to app role")
             return
         logger.info("assinging user access to service principal")
         app = get_application(

--- a/src/deployment/deploy.py
+++ b/src/deployment/deploy.py
@@ -613,7 +613,7 @@ class Client:
         )
 
     def assign_user_access(self) -> None:
-        if self.results["client_id"]:
+        if self.upgrade:
             logger.info(
                 "Deploying w/ Service Principal. Skipping assignment of the user role."
             )

--- a/src/deployment/deploy.py
+++ b/src/deployment/deploy.py
@@ -45,8 +45,6 @@ from azure.storage.blob import (
     ContainerSasPermissions,
     generate_container_sas,
 )
-from msrest.serialization import TZ_UTC
-
 from deploylib.configuration import (
     InstanceConfigClient,
     NetworkSecurityConfig,
@@ -72,6 +70,7 @@ from deploylib.registration import (
     set_app_audience,
     update_pool_registration,
 )
+from msrest.serialization import TZ_UTC
 
 # Found by manually assigning the User.Read permission to application
 # registration in the admin portal. The values are in the manifest under
@@ -613,6 +612,11 @@ class Client:
         )
 
     def assign_user_access(self) -> None:
+        if self.results["client_id"]:
+            logger.info(
+                "Deploying w/ Service Principal. Skipping assignment of the user role."
+            )
+            return
         logger.info("assinging user access to service principal")
         app = get_application(
             display_name=self.application_name,


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_
I introduced a bug when I implemented the new function for assigning user access. If a user tried upgrading an instance with an SP, then deployment would fail when this function was called due to lack of permissions.
 
## PR Checklist
* [ ] Applies to work item: #xxx
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/onefuzz) and sign the CLI.
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_
Changes to deploy.py assign_user_access()

## Validation Steps Performed
check-pr run. 

_How does someone test & validate?_
Deploy with a service principal. 