### PR TITLE
Bump `z3-sys` to 0.7.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Linux Prereqs
       run: |
         sudo apt-get -y update
-        sudo apt-get -y install libssl1.0-dev libunwind-dev
+        sudo apt-get -y install libssl1.0-dev libunwind-dev libz3-dev
       if: "${{ runner.os == 'Linux' }}"
     - run: src/ci/agent.sh
       shell: bash

--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -171,12 +171,35 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
+version = "0.58.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f8523b410d7187a43085e7e064416ea32ded16bd0a4e6fc025e21616d01258f"
+dependencies = [
+ "bitflags",
+ "cexpr 0.4.0",
+ "clang-sys",
+ "clap",
+ "env_logger 0.8.4",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "peeking_take_while",
+ "proc-macro2 1.0.29",
+ "quote 1.0.9",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "which",
+]
+
+[[package]]
+name = "bindgen"
 version = "0.59.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "453c49e5950bb0eb63bb3df640e31618846c89d5b7faa54040d76e98e0134375"
 dependencies = [
  "bitflags",
- "cexpr",
+ "cexpr 0.5.0",
  "clang-sys",
  "clap",
  "env_logger 0.8.4",
@@ -293,6 +316,15 @@ name = "cc"
 version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26a6ce4b6a484fa3edb70f7efa6fc430fd2b87285fe8b84304fd0936faa0dc0"
+
+[[package]]
+name = "cexpr"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4aedb84272dbe89af497cf81375129abda4fc0a9e7c5d317498c15cc30c0d27"
+dependencies = [
+ "nom 5.1.2",
+]
 
 [[package]]
 name = "cexpr"
@@ -2116,7 +2148,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d01e71493938bee4c460ec61aabbf0801e08cd2714d1677365b4d7f81475353"
 dependencies = [
  "anyhow",
- "bindgen",
+ "bindgen 0.59.1",
  "libc",
  "libproc",
  "mach",
@@ -3559,9 +3591,12 @@ checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
 
 [[package]]
 name = "z3-sys"
-version = "0.6.3"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afa18ba5fbd4933e41ffb440c3fd91f91fe9cdb7310cce3ddfb6648563811de0"
+checksum = "1c82dcbc58be4bf1994c520066cb2bd6c3d36aed0fdc57244f34d277421986a6"
+dependencies = [
+ "bindgen 0.58.1",
+]
 
 [[package]]
 name = "zip"

--- a/src/agent/onefuzz-telemetry/Cargo.toml
+++ b/src/agent/onefuzz-telemetry/Cargo.toml
@@ -19,9 +19,7 @@ appinsights = { git = "https://github.com/dmolokanov/appinsights-rs", rev = "0af
 log = "0.4"
 uuid = { version = "0.8", features = ["serde", "v4"] }
 serde = { version = "1.0", features = ["derive"] }
-z3-sys = { version = "0.6", optional = true}
+z3-sys = { version = "0.7", optional = true}
 iced-x86 = { version = "1.15", optional = true}
 tokio = { version = "1.14", features = ["full"] }
 lazy_static = "1.4"
-
-


### PR DESCRIPTION
- Update to latest release of `z3-sys`
- Install Z3 headers on build machines, as is now required

The `z3-sys` crate used to vendor pre-generated modules from Z3 headers. Now, the Z3 header to use can be chosen by library users, but it almost must be available at compile-time, as of https://github.com/prove-rs/z3.rs/commit/d0fc517d8eaf7242bb3e89e413b4c97d64d346db.