### PR TITLE
Don't cache debuginfo sessions

### DIFF
--- a/src/agent/coverage/src/debuginfo.rs
+++ b/src/agent/coverage/src/debuginfo.rs
@@ -8,7 +8,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::Result;
 use symbolic::{
-    debuginfo::{pe, Object, ObjectDebugSession},
+    debuginfo::{pe, Object},
     symcache::{SymCache, SymCacheWriter},
 };
 
@@ -64,9 +64,6 @@ pub struct ModuleDebugInfo {
     /// May not include the actual executable code.
     pub object: Object<'static>,
 
-    /// Interface and caching structures for general debug info querying.
-    pub session: ObjectDebugSession<'static>,
-
     /// Cache which allows efficient source line lookups.
     pub source: SymCache<'static>,
 }
@@ -102,17 +99,11 @@ impl ModuleDebugInfo {
             return Ok(None);
         }
 
-        let session = object.debug_session()?;
-
         let cursor = io::Cursor::new(vec![]);
         let cursor = SymCacheWriter::write_object(&object, cursor)?;
         let cache_data = Box::leak(cursor.into_inner().into_boxed_slice());
         let source = SymCache::parse(cache_data)?;
 
-        Ok(Some(Self {
-            object,
-            session,
-            source,
-        }))
+        Ok(Some(Self { object, source }))
     }
 }


### PR DESCRIPTION
Remove the currently-unused `DebugInfo.session` field to ease `async` usage.

The removed field has type [`ObjectDebugSession`](https://docs.rs/symbolic/latest/symbolic/debuginfo/enum.ObjectDebugSession.html), which is not `Send`. This is problematic in an `async` context. We could work around it, and probably even craft a `Send` wrapper type (which would require judicious use of `unsafe`). However, in our coverage task, we don't actually use debug sessions at all. In the future, we can still easily get them on-demand from `Object` values (which we do cache). So, just remove the cached session field until we actually need it.