### PR TITLE
Use symbol path when searching for PDBs for source coverage

### DIFF
--- a/src/agent/coverage/src/debuginfo.rs
+++ b/src/agent/coverage/src/debuginfo.rs
@@ -7,11 +7,13 @@ use std::io;
 use std::path::{Path, PathBuf};
 
 use anyhow::Result;
-use goblin::pe::PE;
 use symbolic::{
     debuginfo::Object,
     symcache::{SymCache, SymCacheWriter},
 };
+
+#[cfg(windows)]
+use goblin::pe::PE;
 
 #[cfg(windows)]
 use symbolic::debuginfo::pe;
@@ -80,6 +82,8 @@ impl ModuleDebugInfo {
     ///
     /// Leaks module and symbol data.
     fn load(module: &Path) -> Result<Option<Self>> {
+        // Used when `cfg(windows)`.
+        #[allow(unused_mut)]
         let mut data = fs::read(&module)?.into_boxed_slice();
 
         // Conditional so we can use `dbghelp`.

--- a/src/agent/coverage/src/debuginfo.rs
+++ b/src/agent/coverage/src/debuginfo.rs
@@ -7,10 +7,14 @@ use std::io;
 use std::path::{Path, PathBuf};
 
 use anyhow::Result;
+use goblin::pe::PE;
 use symbolic::{
-    debuginfo::{pe, Object},
+    debuginfo::Object,
     symcache::{SymCache, SymCacheWriter},
 };
+
+#[cfg(windows)]
+use symbolic::debuginfo::pe;
 
 /// Caching provider of debug info for executable code modules.
 #[derive(Default)]
@@ -78,16 +82,21 @@ impl ModuleDebugInfo {
     fn load(module: &Path) -> Result<Option<Self>> {
         let mut data = fs::read(&module)?.into_boxed_slice();
 
-        // If our module is a PE file, the debug info will be in the PDB.
-        //
-        // We will need a similar check to support split DWARF.
-        let is_pe = pe::PeObject::test(&data);
-        if is_pe {
-            // Assume a sibling PDB.
+        // Conditional so we can use `dbghelp`.
+        #[cfg(windows)]
+        {
+            // If our module is a PE file, the debug info will be in the PDB.
             //
-            // TODO: Find PDB using `dbghelp::`SymGetSymbolFile()`.
-            let pdb = module.with_extension("pdb");
-            data = fs::read(&pdb)?.into_boxed_slice();
+            // We will need a similar check to support split DWARF.
+            let is_pe = pe::PeObject::test(&data);
+            if is_pe {
+                let pe = PE::parse(&data)?;
+
+                // Search the symbol path for a PDB for this PE, which we'll use instead.
+                if let Some(pdb) = crate::pdb::find_pdb_path(module, &pe, None)? {
+                    data = fs::read(&pdb)?.into_boxed_slice();
+                }
+            }
         }
 
         // Now we're sure we want this data, so leak it.


### PR DESCRIPTION
On Windows, when we search for PDB debuginfo for PEs, use our existing `dbghelp`-based mechanism, which uses the symbol search path.

Also, if we don't find out, try to use the PE, instead of failing immediately. If it lacks debuginfo (it usually will), we'll now return `None` instead of failing, which is our intended semantics.

Tested locally using the `src-cov` example against a binary. I tested 4 cases:
1. No PDB available at all
2. PE-described absolute-path PDB in original compilation directory, no other copies
3. PDB in same dir as PDB (only)
4. PDB in non-PE dir, included in `_NT_SYMBOL_PATH`

As expected, the PDB is not found in (1), and is found in (2) - (4). Not-committed debug logging verified that the resolved PDB was the expected one in each case. When found, source coverage is correctly-generated.