### PR TITLE
Adding AutoConfig Properties to AzSecPack Extensions

### DIFF
--- a/src/api-service/__app__/onefuzzlib/extension.py
+++ b/src/api-service/__app__/onefuzzlib/extension.py
@@ -150,7 +150,7 @@ def azmon_extension(
         "type": "AzureMonitorLinuxAgent",
         "typeHandlerVersion": "1.9",
         "autoUpgradeMinorVersion": False,
-        "settings": {},
+        "settings": {"GCS_AUTO_CONFIG": True},
         "protectedsettings": {
             "configVersion": config_version,
             "moniker": moniker,
@@ -173,7 +173,7 @@ def azsec_extension(region: Region) -> Extension:
         "type": "AzureSecurityLinuxAgent",
         "typeHandlerVersion": "2.0",
         "autoUpgradeMinorVersion": True,
-        "settings": {"enableGenevaUpload": True},
+        "settings": {"enableGenevaUpload": True, "enableAutoConfig": True},
     }
 
 


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_
We are required to enable autoconfig for AzSecPack deployments. These changes included the addition of the relevant property. 

## PR Checklist
* [ ] Applies to work item: #xxx
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/onefuzz) and sign the CLI.
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_
Changes to the AzSecPack extensions in extension.py

## Validation Steps Performed

_How does someone test & validate?_
check-pr.py
manual deployments and tests. 