### PR TITLE
Add azcopy upload support and switch to the default max_concurrency

### DIFF
--- a/src/cli/onefuzz/azcopy.py
+++ b/src/cli/onefuzz/azcopy.py
@@ -21,9 +21,18 @@ def find_azcopy() -> str:
 
 
 def azcopy_sync(src: str, dst: str) -> None:
-    """Expose azcopy for uploading/downloading files"""
+    """Expose azcopy for syncing existing files"""
 
     azcopy = find_azcopy()
 
     # security note: callers need to understand the src/dst for this.
     subprocess.check_output([azcopy, "sync", src, dst, "--recursive=true"])  # nosec
+
+
+def azcopy_copy(src: str, dst: str) -> None:
+    """Expose azcopy for uploading/downloading files"""
+
+    azcopy = find_azcopy()
+
+    # security note: callers need to understand the src/dst for this.
+    subprocess.check_output([azcopy, "cp", src, dst, "--recursive=true"])  # nosec

--- a/src/cli/onefuzz/backend.py
+++ b/src/cli/onefuzz/backend.py
@@ -9,6 +9,7 @@ import json
 import logging
 import os
 import sys
+import tempfile
 import time
 from dataclasses import asdict, is_dataclass
 from enum import Enum
@@ -383,9 +384,13 @@ class ContainerWrapper:
         return None
 
     def upload_file_data(self, data: str, blob_name: str) -> None:
-        self.client.upload_blob(
-            name=blob_name, data=data, overwrite=True
-        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            filename = os.path.join(tmpdir, blob_name)
+
+            with open(filename, "w") as handle:
+                handle.write(data)
+
+            self.upload_file(filename, blob_name)
 
     def upload_dir(self, dir_path: str) -> None:
         # security note: the src for azcopy comes from the server which is


### PR DESCRIPTION
## Summary of the Pull Request

This pull request is to address issue #1477 where low bandwidth connections could not support multiple concurrent upload streams without encountering a timeout. To address this issue, two changes are being introduced.

The first change is to modify the `upload_file` method to use the azcopy command as its default approach. It was determined that azcopy has more robust code for handling different connection speeds than the Azure Python SDK. Therefore, the code will now attempt to use azcopy first. It is possible that the azcopy command could fail due to it not being present, an `azcopy login` step needing to be performed, or a similar scenario. If this occurs, then the code will fall back to using the Azure Python SDK. If they both fail, then the code will re-attempt both approaches up to the retry limit. In order to support this, a new method was added to azcopy.py for performing `azcopy copy` commands.

The second change is to modify `upload_file_data` method to use `upload_file`.  This change will ensure that both file upload approaches are consistent in their use of azcopy, `max_concurrency`, and retries.

## PR Checklist
* [X] Applies to work item: #1477
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/onefuzz) and sign the CLI.
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [X] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #1477

## Info on Pull Request

This pull request adds `azcopy copy` support. The existing azcopy code leveraged the `sync` functionality which is for coordinating two files or directories that already exist. When creating a new job, you may be uploading a new file to a new destination container. Therefore, the `azcopy_copy` method was created for copy operations.

The `max_concurrency` of 10 was removed from the Azure SDK `upload_blob` call within `upload_file` so that the default is used instead. This will help resolve an issue where low bandwidth connections could not support multiple concurrent uploads without encountering a timeout.

The `upload_file_data` function was converted to call `upload_file` rather than have its own upload code.  This approach ensures that both `upload_file` and `upload_file_data` have the same behavior as requested in the issue discussion. The data passed as a string to `upload_file_data` is now written to a temporary file for azcopy to access within `upload_file`. Testing for this approach is limited since `upload_file_data` is not currently used within onefuzz.

## Validation Steps Performed

Creating a fuzzing job will leverage the `upload_file` functionality. This was tested creating a job with that required both the target_exe and extra_files flags to upload files.

It was noted in the original discussion that low latency tests can be performed using:
```
# Create a big blob.
dd if=/dev/zero of=zeros.bin bs=300M count=1

# Create destination container.
onefuzz containers create big

# Simulate a low-bandwidth link.
sudo tc qdisc add dev eth0 root tbf rate 104kbit latency 50ms burst 1540

# Try to upload blob.
onefuzz containers files upload_file big -v zeros.bin
```