### PR TITLE
Adding new InstanceConfig value for VMSS & VM tags

### DIFF
--- a/docs/webhook_events.md
+++ b/docs/webhook_events.md
@@ -809,10 +809,24 @@ Each event will be submitted via HTTP POST to the user provided URL.
                 "proxy_nsg_config": {
                     "$ref": "#/definitions/NetworkSecurityGroupConfig"
                 },
+                "proxy_tags": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "title": "Proxy Tags",
+                    "type": "object"
+                },
                 "proxy_vm_sku": {
                     "default": "Standard_B2s",
                     "title": "Proxy Vm Sku",
                     "type": "string"
+                },
+                "vmss_tags": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "title": "Vmss Tags",
+                    "type": "object"
                 }
             },
             "required": [
@@ -5951,10 +5965,24 @@ Each event will be submitted via HTTP POST to the user provided URL.
                 "proxy_nsg_config": {
                     "$ref": "#/definitions/NetworkSecurityGroupConfig"
                 },
+                "proxy_tags": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "title": "Proxy Tags",
+                    "type": "object"
+                },
                 "proxy_vm_sku": {
                     "default": "Standard_B2s",
                     "title": "Proxy Vm Sku",
                     "type": "string"
+                },
+                "vmss_tags": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "title": "Vmss Tags",
+                    "type": "object"
                 }
             },
             "required": [

--- a/docs/webhook_events.md
+++ b/docs/webhook_events.md
@@ -809,17 +809,17 @@ Each event will be submitted via HTTP POST to the user provided URL.
                 "proxy_nsg_config": {
                     "$ref": "#/definitions/NetworkSecurityGroupConfig"
                 },
-                "proxy_tags": {
-                    "additionalProperties": {
-                        "type": "string"
-                    },
-                    "title": "Proxy Tags",
-                    "type": "object"
-                },
                 "proxy_vm_sku": {
                     "default": "Standard_B2s",
                     "title": "Proxy Vm Sku",
                     "type": "string"
+                },
+                "vm_tags": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "title": "Vm Tags",
+                    "type": "object"
                 },
                 "vmss_tags": {
                     "additionalProperties": {
@@ -5965,17 +5965,17 @@ Each event will be submitted via HTTP POST to the user provided URL.
                 "proxy_nsg_config": {
                     "$ref": "#/definitions/NetworkSecurityGroupConfig"
                 },
-                "proxy_tags": {
-                    "additionalProperties": {
-                        "type": "string"
-                    },
-                    "title": "Proxy Tags",
-                    "type": "object"
-                },
                 "proxy_vm_sku": {
                     "default": "Standard_B2s",
                     "title": "Proxy Vm Sku",
                     "type": "string"
+                },
+                "vm_tags": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "title": "Vm Tags",
+                    "type": "object"
                 },
                 "vmss_tags": {
                     "additionalProperties": {

--- a/src/api-service/__app__/onefuzzlib/azure/vm.py
+++ b/src/api-service/__app__/onefuzzlib/azure/vm.py
@@ -49,7 +49,7 @@ def create_vm(
     password: str,
     ssh_public_key: str,
     nsg: Optional[NSG],
-    tags: Dict[str, str],
+    tags: Optional[Dict[str, str]],
 ) -> Union[None, Error]:
 
     resource_group = get_base_resource_group()

--- a/src/api-service/__app__/onefuzzlib/azure/vm.py
+++ b/src/api-service/__app__/onefuzzlib/azure/vm.py
@@ -236,6 +236,7 @@ class VM(BaseModel):
     image: str
     auth: Authentication
     nsg: Optional[NSG]
+    tags: Dict[str, str]
 
     @validator("name", allow_reuse=True)
     def check_name(cls, value: Union[UUID, str]) -> Union[UUID, str]:
@@ -261,11 +262,6 @@ class VM(BaseModel):
         if self.get() is not None:
             return None
 
-        instance_config = InstanceConfig.fetch()
-        tags = None
-        if instance_config.vm_tags:
-            tags = instance_config.vm_tags
-
         logging.info("vm creating: %s", self.name)
         return create_vm(
             str(self.name),
@@ -275,7 +271,7 @@ class VM(BaseModel):
             self.auth.password,
             self.auth.public_key,
             self.nsg,
-            tags,
+            self.tags,
         )
 
     def delete(self) -> bool:

--- a/src/api-service/__app__/onefuzzlib/azure/vm.py
+++ b/src/api-service/__app__/onefuzzlib/azure/vm.py
@@ -12,7 +12,7 @@ from azure.core.exceptions import ResourceNotFoundError
 from azure.mgmt.compute.models import VirtualMachine
 from msrestazure.azure_exceptions import CloudError
 from onefuzztypes.enums import OS, ErrorCode
-from onefuzztypes.models import Authentication, Error, InstanceConfig
+from onefuzztypes.models import Authentication, Error
 from onefuzztypes.primitives import Extension, Region
 from pydantic import BaseModel, validator
 

--- a/src/api-service/__app__/onefuzzlib/azure/vm.py
+++ b/src/api-service/__app__/onefuzzlib/azure/vm.py
@@ -16,7 +16,6 @@ from onefuzztypes.models import Authentication, Error
 from onefuzztypes.primitives import Extension, Region
 from pydantic import BaseModel, validator
 
-from ..config import InstanceConfig
 from .compute import get_compute_client
 from .creds import get_base_resource_group
 from .disk import delete_disk, list_disks

--- a/src/api-service/__app__/onefuzzlib/azure/vm.py
+++ b/src/api-service/__app__/onefuzzlib/azure/vm.py
@@ -116,7 +116,8 @@ def create_vm(
             },
         }
 
-    params["tags"] = tags.copy()
+    if tags:
+        params["tags"] = tags.copy()
 
     owner = os.environ.get("ONEFUZZ_OWNER")
     if owner:

--- a/src/api-service/__app__/onefuzzlib/azure/vm.py
+++ b/src/api-service/__app__/onefuzzlib/azure/vm.py
@@ -119,8 +119,8 @@ def create_vm(
         }
 
     vm_tags = None
-    if instance_config.proxy_tags:
-        vm_tags = instance_config.proxy_tags
+    if instance_config.vm_tags:
+        vm_tags = instance_config.vm_tags
     params["tags"] = vm_tags
 
     owner = os.environ.get("ONEFUZZ_OWNER")

--- a/src/api-service/__app__/onefuzzlib/azure/vm.py
+++ b/src/api-service/__app__/onefuzzlib/azure/vm.py
@@ -235,7 +235,7 @@ class VM(BaseModel):
     image: str
     auth: Authentication
     nsg: Optional[NSG]
-    tags: Dict[str, str]
+    tags: Optional[Dict[str, str]]
 
     @validator("name", allow_reuse=True)
     def check_name(cls, value: Union[UUID, str]) -> Union[UUID, str]:

--- a/src/api-service/__app__/onefuzzlib/azure/vmss.py
+++ b/src/api-service/__app__/onefuzzlib/azure/vmss.py
@@ -25,7 +25,6 @@ from onefuzztypes.enums import OS, ErrorCode
 from onefuzztypes.models import Error
 from onefuzztypes.primitives import Region
 
-from ..config import InstanceConfig
 from .compute import get_compute_client
 from .creds import (
     get_base_resource_group,
@@ -247,8 +246,6 @@ def create_vmss(
     tags: Dict[str, str],
 ) -> Optional[Error]:
 
-    instance_config = InstanceConfig.fetch()
-
     vmss = get_vmss(name)
     if vmss is not None:
         return None
@@ -358,10 +355,7 @@ def create_vmss(
             }
         )
 
-    scaleset_tags = tags.copy()
-    if instance_config.vmss_tags:
-        scaleset_tags.update(instance_config.vmss_tags)
-    params["tags"] = scaleset_tags
+    params["tags"] = tags.copy()
 
     owner = os.environ.get("ONEFUZZ_OWNER")
     if owner:

--- a/src/api-service/__app__/onefuzzlib/azure/vmss.py
+++ b/src/api-service/__app__/onefuzzlib/azure/vmss.py
@@ -25,6 +25,7 @@ from onefuzztypes.enums import OS, ErrorCode
 from onefuzztypes.models import Error
 from onefuzztypes.primitives import Region
 
+from ..config import InstanceConfig
 from .compute import get_compute_client
 from .creds import (
     get_base_resource_group,
@@ -246,6 +247,8 @@ def create_vmss(
     tags: Dict[str, str],
 ) -> Optional[Error]:
 
+    instance_config = InstanceConfig.fetch()
+
     vmss = get_vmss(name)
     if vmss is not None:
         return None
@@ -355,7 +358,11 @@ def create_vmss(
             }
         )
 
-    params["tags"] = tags.copy()
+    scaleset_tags = tags.copy()
+    if instance_config.vmss_tags:
+        scaleset_tags.update(instance_config.vmss_tags)
+    params["tags"] = scaleset_tags
+
     owner = os.environ.get("ONEFUZZ_OWNER")
     if owner:
         params["tags"]["OWNER"] = owner

--- a/src/api-service/__app__/onefuzzlib/extension.py
+++ b/src/api-service/__app__/onefuzzlib/extension.py
@@ -148,8 +148,8 @@ def azmon_extension(
         "publisher": "Microsoft.Azure.Monitor",
         "location": region,
         "type": "AzureMonitorLinuxAgent",
-        "typeHandlerVersion": "1.9",
-        "autoUpgradeMinorVersion": False,
+        "typeHandlerVersion": "1.0",
+        "autoUpgradeMinorVersion": True,
         "settings": {"GCS_AUTO_CONFIG": True},
         "protectedsettings": {
             "configVersion": config_version,

--- a/src/api-service/__app__/onefuzzlib/proxy.py
+++ b/src/api-service/__app__/onefuzzlib/proxy.py
@@ -182,7 +182,8 @@ class Proxy(ORMMixin):
         self.save()
 
     def stopping(self) -> None:
-        vm = self.get_vm()
+        config = InstanceConfig.fetch()
+        vm = self.get_vm(config)
         if not vm.is_deleted():
             logging.info(PROXY_LOG_PREFIX + "stopping proxy: %s", self.region)
             vm.delete()

--- a/src/api-service/__app__/onefuzzlib/proxy.py
+++ b/src/api-service/__app__/onefuzzlib/proxy.py
@@ -149,7 +149,8 @@ class Proxy(ORMMixin):
         self.set_state(VmState.stopping)
 
     def extensions_launch(self) -> None:
-        vm = self.get_vm()
+        config = InstanceConfig.fetch()
+        vm = self.get_vm(config)
         vm_data = vm.get()
         if not vm_data:
             self.set_failed(

--- a/src/api-service/__app__/onefuzzlib/proxy.py
+++ b/src/api-service/__app__/onefuzzlib/proxy.py
@@ -70,13 +70,18 @@ class Proxy(ORMMixin):
         return ("region", "proxy_id")
 
     def get_vm(self) -> VM:
-        sku = InstanceConfig.fetch().proxy_vm_sku
+        instance_config = InstanceConfig.fetch()
+        sku = instance_config.proxy_vm_sku
+        tags = None
+        if instance_config.vm_tags:
+            tags = instance_config.vm_tags
         vm = VM(
             name="proxy-%s" % base58.b58encode(self.proxy_id.bytes).decode(),
             region=self.region,
             sku=sku,
             image=PROXY_IMAGE,
             auth=self.auth,
+            tags=tags,
         )
         return vm
 

--- a/src/api-service/__app__/onefuzzlib/repro.py
+++ b/src/api-service/__app__/onefuzzlib/repro.py
@@ -133,7 +133,8 @@ class Repro(BASE_REPRO, ORMMixin):
         return None
 
     def extensions_launch(self) -> None:
-        vm = self.get_vm()
+        config = InstanceConfig.fetch()
+        vm = self.get_vm(config)
         vm_data = vm.get()
         if not vm_data:
             self.set_error(

--- a/src/api-service/__app__/onefuzzlib/repro.py
+++ b/src/api-service/__app__/onefuzzlib/repro.py
@@ -165,7 +165,8 @@ class Repro(BASE_REPRO, ORMMixin):
         self.save()
 
     def stopping(self) -> None:
-        vm = self.get_vm()
+        config = InstanceConfig.fetch()
+        vm = self.get_vm(config)
         if not vm.is_deleted():
             logging.info("vm stopping: %s", self.vm_id)
             vm.delete()

--- a/src/api-service/__app__/onefuzzlib/repro.py
+++ b/src/api-service/__app__/onefuzzlib/repro.py
@@ -47,11 +47,10 @@ class Repro(BASE_REPRO, ORMMixin):
         self.state = VmState.stopping
         self.save()
 
-    def get_vm(self) -> VM:
-        instance_config = InstanceConfig.fetch()
+    def get_vm(self, config: InstanceConfig) -> VM:
         tags = None
-        if instance_config.vm_tags:
-            tags = instance_config.vm_tags
+        if config.vm_tags:
+            tags = config.vm_tags
 
         task = Task.get_by_task_id(self.task_id)
         if isinstance(task, Error):
@@ -80,7 +79,8 @@ class Repro(BASE_REPRO, ORMMixin):
         )
 
     def init(self) -> None:
-        vm = self.get_vm()
+        config = InstanceConfig.fetch()
+        vm = self.get_vm(config)
         vm_data = vm.get()
         if vm_data:
             if vm_data.provisioning_state == "Failed":
@@ -102,7 +102,6 @@ class Repro(BASE_REPRO, ORMMixin):
                 self.set_failed(result)
                 return
 
-            config = InstanceConfig.fetch()
             nsg_config = config.proxy_nsg_config
             result = nsg.set_allowed_sources(nsg_config)
             if isinstance(result, Error):

--- a/src/api-service/__app__/onefuzzlib/repro.py
+++ b/src/api-service/__app__/onefuzzlib/repro.py
@@ -48,6 +48,11 @@ class Repro(BASE_REPRO, ORMMixin):
         self.save()
 
     def get_vm(self) -> VM:
+        instance_config = InstanceConfig.fetch()
+        tags = None
+        if instance_config.vm_tags:
+            tags = instance_config.vm_tags
+
         task = Task.get_by_task_id(self.task_id)
         if isinstance(task, Error):
             raise Exception("previously existing task missing: %s" % self.task_id)
@@ -71,6 +76,7 @@ class Repro(BASE_REPRO, ORMMixin):
             sku=vm_config.sku,
             image=vm_config.image,
             auth=self.auth,
+            tags=tags,
         )
 
     def init(self) -> None:

--- a/src/api-service/__app__/onefuzzlib/workers/scalesets.py
+++ b/src/api-service/__app__/onefuzzlib/workers/scalesets.py
@@ -37,6 +37,7 @@ from ..azure.vmss import (
     resize_vmss,
     update_extensions,
 )
+from ..config import InstanceConfig
 from ..events import send_event
 from ..extension import fuzz_extensions
 from ..orm import MappingIntStrAny, ORMMixin, QueryFilter
@@ -221,7 +222,13 @@ class Scaleset(BASE_SCALESET, ORMMixin):
                 SCALESET_LOG_PREFIX + "creating scaleset. scaleset_id:%s",
                 self.scaleset_id,
             )
+
+            instance_config = InstanceConfig.fetch()
+            if instance_config.vmss_tags:
+                self.tags.update(instance_config.vmss_tags)
+
             extensions = fuzz_extensions(pool, self)
+
             result = create_vmss(
                 self.region,
                 self.scaleset_id,

--- a/src/api-service/__app__/onefuzzlib/workers/scalesets.py
+++ b/src/api-service/__app__/onefuzzlib/workers/scalesets.py
@@ -37,7 +37,6 @@ from ..azure.vmss import (
     resize_vmss,
     update_extensions,
 )
-from ..config import InstanceConfig
 from ..events import send_event
 from ..extension import fuzz_extensions
 from ..orm import MappingIntStrAny, ORMMixin, QueryFilter
@@ -222,10 +221,6 @@ class Scaleset(BASE_SCALESET, ORMMixin):
                 SCALESET_LOG_PREFIX + "creating scaleset. scaleset_id:%s",
                 self.scaleset_id,
             )
-
-            instance_config = InstanceConfig.fetch()
-            if instance_config.vmss_tags:
-                self.tags.update(instance_config.vmss_tags)
 
             extensions = fuzz_extensions(pool, self)
 

--- a/src/api-service/__app__/scaleset/__init__.py
+++ b/src/api-service/__app__/scaleset/__init__.py
@@ -92,7 +92,7 @@ def post(req: func.HttpRequest) -> func.HttpResponse:
 
     tags = request.tags
     if instance_config.vmss_tags:
-        tags = tags.update(instance_config.vmss_tags)
+        tags.update(instance_config.vmss_tags)
 
     scaleset = Scaleset.create(
         pool_name=request.pool_name,
@@ -102,7 +102,7 @@ def post(req: func.HttpRequest) -> func.HttpResponse:
         size=request.size,
         spot_instances=request.spot_instances,
         ephemeral_os_disks=request.ephemeral_os_disks,
-        tags=request.tags,
+        tags=tags,
     )
     # don't return auths during create, only 'get' with include_auth
     scaleset.auth = None

--- a/src/pytypes/onefuzztypes/models.py
+++ b/src/pytypes/onefuzztypes/models.py
@@ -864,7 +864,7 @@ class InstanceConfig(BaseModel):
     proxy_vm_sku: str = Field(default="Standard_B2s")
     api_access_rules: Optional[Dict[Endpoint, ApiAccessRule]] = None
     group_membership: Optional[Dict[PrincipalID, List[GroupId]]] = None
-    proxy_tags: Optional[Dict[str, str]] = None
+    vm_tags: Optional[Dict[str, str]] = None
     vmss_tags: Optional[Dict[str, str]] = None
 
     def update(self, config: "InstanceConfig") -> None:

--- a/src/pytypes/onefuzztypes/models.py
+++ b/src/pytypes/onefuzztypes/models.py
@@ -864,6 +864,8 @@ class InstanceConfig(BaseModel):
     proxy_vm_sku: str = Field(default="Standard_B2s")
     api_access_rules: Optional[Dict[Endpoint, ApiAccessRule]] = None
     group_membership: Optional[Dict[PrincipalID, List[GroupId]]] = None
+    proxy_tags: Optional[Dict[str, str]] = None
+    vmss_tags: Optional[Dict[str, str]] = None
 
     def update(self, config: "InstanceConfig") -> None:
         for field in config.__fields__:


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_
For our prod instance to run the most up-to-date version of AzSecPack, we need to be able to add tags to the VMSS and VMs running in an instance. I've added two new instance_config fields that allow instance operators to specify vmss and vm tags. 

## PR Checklist
* [ ] Applies to work item: #xxx
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/onefuzz) and sign the CLI.
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_
Changes to: 
- vm.py
- vmss.py
- models.py

## Validation Steps Performed

_How does someone test & validate?_
Running check-pr and manual tests that include new instance_config tags. 