### PR TITLE
Upgrade to sha2 0.10.1

### DIFF
--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -2584,9 +2584,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900d964dd36bb15bcf2f2b35694c072feab74969a54f2bbeec7a2d725d2bdcb6"
+checksum = "99c3bd8169c58782adad9290a9af5939994036b76187f7b4f0e6de91dbbfc0ec"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",

--- a/src/agent/input-tester/Cargo.toml
+++ b/src/agent/input-tester/Cargo.toml
@@ -15,7 +15,7 @@ hex = "0.4"
 log = "0.4"
 num_cpus = "1.13"
 rayon = "1.5"
-sha2 = "0.10"
+sha2 = "0.10.1"
 win-util = { path = "../win-util" }
 
 [dependencies.winapi]

--- a/src/agent/onefuzz/Cargo.toml
+++ b/src/agent/onefuzz/Cargo.toml
@@ -20,7 +20,7 @@ log = "0.4"
 notify = "4.0"
 regex = "1.4"
 reqwest = { version = "0.11", features = ["json", "stream", "rustls-tls"], default-features=false }
-sha2 = "0.10"
+sha2 = "0.10.1"
 url = { version = "2.2", features = ["serde"] }
 serde = "1.0"
 serde_json = "1.0"

--- a/src/agent/stacktrace-parser/Cargo.toml
+++ b/src/agent/stacktrace-parser/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 anyhow = "1.0"
 hex = "0.4"
 regex = "1.4"
-sha2 = "0.10"
+sha2 = "0.10.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 libclusterfuzz = { path = "../libclusterfuzz" }


### PR DESCRIPTION
Fixes cargo audit warning on sha2 0.10.0