### PR TITLE
Integrate Cobertura format and output as file in coverage container

### DIFF
--- a/src/agent/onefuzz-agent/src/tasks/coverage/generic.rs
+++ b/src/agent/onefuzz-agent/src/tasks/coverage/generic.rs
@@ -370,8 +370,7 @@ impl<'a> TaskContext<'a> {
             .local_path
             .join(COBERTURA_COVERAGE_FILE);
         let cobertura_source_coverage = cobertura(src_coverage)?;
-        let text = &cobertura_source_coverage;
-        fs::write(&path, &text)
+        fs::write(&path, &cobertura_source_coverage)
             .await
             .with_context(|| format!("writing cobertura source coverage to {}", path.display()))?;
 

--- a/src/agent/onefuzz-agent/src/tasks/coverage/generic.rs
+++ b/src/agent/onefuzz-agent/src/tasks/coverage/generic.rs
@@ -31,7 +31,7 @@ use crate::tasks::heartbeat::{HeartbeatSender, TaskHeartbeatClient};
 const MAX_COVERAGE_RECORDING_ATTEMPTS: usize = 2;
 const COVERAGE_FILE: &str = "coverage.json";
 const SOURCE_COVERAGE_FILE: &str = "source-coverage.json";
-const COBERTURA_COVERAGE_FILE: &str = "cobertura-coverage.txt";
+const COBERTURA_COVERAGE_FILE: &str = "cobertura-coverage.xml";
 const MODULE_CACHE_FILE: &str = "module-cache.json";
 
 const DEFAULT_TARGET_TIMEOUT: Duration = Duration::from_secs(5);

--- a/src/agent/onefuzz-agent/src/tasks/coverage/generic.rs
+++ b/src/agent/onefuzz-agent/src/tasks/coverage/generic.rs
@@ -11,9 +11,9 @@ use anyhow::{Context, Result};
 use async_trait::async_trait;
 use coverage::block::CommandBlockCov;
 use coverage::cache::ModuleCache;
+use coverage::cobertura::cobertura;
 use coverage::code::{CmdFilter, CmdFilterDef};
 use coverage::debuginfo::DebugInfo;
-use coverage::cobertura::cobertura;
 use onefuzz::expand::{Expand, PlaceHolder};
 use onefuzz::syncdir::SyncedDir;
 use onefuzz_telemetry::{warn, Event::coverage_data, EventData};
@@ -364,12 +364,16 @@ impl<'a> TaskContext<'a> {
             .await
             .with_context(|| format!("writing source coverage to {}", path.display()))?;
 
-        let path = self.config.coverage.local_path.join(COBERTURA_COVERAGE_FILE);
+        let path = self
+            .config
+            .coverage
+            .local_path
+            .join(COBERTURA_COVERAGE_FILE);
         let cobertura_source_coverage = cobertura(src_coverage)?;
         let text = &cobertura_source_coverage;
         fs::write(&path, &text)
-        .await
-        .with_context(|| format!("writing cobertura source coverage to {}", path.display()))?;
+            .await
+            .with_context(|| format!("writing cobertura source coverage to {}", path.display()))?;
 
         self.config.coverage.sync_push().await?;
 

--- a/src/agent/onefuzz-agent/src/tasks/coverage/generic.rs
+++ b/src/agent/onefuzz-agent/src/tasks/coverage/generic.rs
@@ -31,7 +31,7 @@ use crate::tasks::heartbeat::{HeartbeatSender, TaskHeartbeatClient};
 const MAX_COVERAGE_RECORDING_ATTEMPTS: usize = 2;
 const COVERAGE_FILE: &str = "coverage.json";
 const SOURCE_COVERAGE_FILE: &str = "source-coverage.json";
-const COBERTURA_COVERAGE_FILE: &str = "cobertura-coverage.json";
+const COBERTURA_COVERAGE_FILE: &str = "cobertura-coverage.txt";
 const MODULE_CACHE_FILE: &str = "module-cache.json";
 
 const DEFAULT_TARGET_TIMEOUT: Duration = Duration::from_secs(5);
@@ -366,7 +366,7 @@ impl<'a> TaskContext<'a> {
 
         let path = self.config.coverage.local_path.join(COBERTURA_COVERAGE_FILE);
         let cobertura_source_coverage = cobertura(src_coverage)?;
-        let text = serde_json::to_string(&cobertura_source_coverage).context("serializing cobertura source coverage")?;
+        let text = &cobertura_source_coverage;
         fs::write(&path, &text)
         .await
         .with_context(|| format!("writing cobertura source coverage to {}", path.display()))?;


### PR DESCRIPTION
## Summary of the Pull Request

Outputs coverage file as Cobertura XML format.

## PR Checklist
* [X] Applies to work item: Related to these #1378, #1380.
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/onefuzz) and sign the CLI.
* [X] Tests added/passed: test in previous #1533 PR.
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

Continues work of outputting improved source coverage as file(s) alongside block coverage file. This work completes the integration of having a third file be outputted to the coverage container, this file being in Cobertura xml format. It calls the function that converts source coverage data to Cobertura format and outputs it as a file. This file will be able to be used as input in ReportGenerator tool.

## Validation Steps Performed

A cobertura-coverage.txt file should be created in coverage container in Cobertura XML format with same data as source-coverage.json file. 
