### PR TITLE
Fix clippy

### DIFF
--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -408,6 +408,7 @@ dependencies = [
  "uuid",
  "win-util",
  "winapi 0.3.9",
+ "xml-rs",
 ]
 
 [[package]]

--- a/src/agent/srcview/src/srcview.rs
+++ b/src/agent/srcview/src/srcview.rs
@@ -196,7 +196,7 @@ impl SrcView {
         for (module, cache) in self.0.iter() {
             if let Some(symbols) = cache.path_symbols(path.as_ref()) {
                 for sym in symbols {
-                    r.insert(format!("{}!{}", module, sym.to_string()));
+                    r.insert(format!("{}!{}", module, sym));
                 }
             }
         }


### PR DESCRIPTION
## Summary of the Pull Request

Fix clippy error message

```
error: `to_string` applied to a type that implements `Display` in `format!` args
   --> srcview/src/srcview.rs:199:58
    |
199 |                     r.insert(format!("{}!{}", module, sym.to_string()));
    |                                                          ^^^^^^^^^^^^ help: remove this
    |
    = note: `-D clippy::to-string-in-format-args` implied by `-D warnings`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#to_string_in_format_args
```