### PR TITLE
Refresh the internal `sysinfo` process list

### DIFF
--- a/src/agent/onefuzz-agent/src/tasks/fuzz/libfuzzer_fuzz.rs
+++ b/src/agent/onefuzz-agent/src/tasks/fuzz/libfuzzer_fuzz.rs
@@ -355,6 +355,9 @@ async fn report_fuzzer_sys_info(
             _ = period.tick() => (),
         }
 
+        // Refresh the list of known processes.
+        system::refresh()?;
+
         // process doesn't exist
         if !system::refresh_process(fuzzer_pid)? {
             break;


### PR DESCRIPTION
We use the `sysinfo` crate via our `onefuzz::system` wrapper module. In the `libfuzzer_fuzz` task (only), we query performance numbers on PIDs that we know to belong to fuzzer child processes. We then emit their resource usage metrics as custom events for easy "in-band" consumption and measurement of fuzzer process health.

Before this PR, two things were true:
1. We never explicitly refreshed the _entire_ process list
2. We queried it somewhat infrequently, and only with specific fuzzer PIDs

Together with libfuzzers that exit quickly (or are perhaps configured to do so, via `-runs=N`), this can cause our process metadata to grow unboundedly, until we OOM. Additionally, the `onefuzz-agent` process consumes more and more handles, which remain unclosed as fields of the `Process` structs that act as the values of the `sysinfo` process list.

This Pr adds a call to our `system::refresh()` wrapper. This will prune the `sysinfo` process list. When a process is pruned (its entry is removed from the hashmap), its `Process` data will be dropped, which will result in a call to `CloseHandle` (as one would expect).

Our code _expected_ this to happen in the existing call to `system::refresh_process(fuzzer_pid)`. However, fast-exiting libfuzzer targets cause us to only call `report_fuzzer_sys_info()` perhaps once, on fuzzer child process creation, so we'd never observe its death with `refresh_process()` (and would thus never prune it from the `sysinfo` process list). Since the new call is not scoped to the current process PID, it is less efficient, but guaranteed to prune any dead processes. This is desirable, since the process list might also shrink and grow due to other system processes that we can't control.