### PR TITLE
Add `test-input` example

### DIFF
--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -1792,6 +1792,7 @@ dependencies = [
  "sha2",
  "stacktrace-parser",
  "storage-queue",
+ "structopt",
  "strum",
  "strum_macros",
  "tempfile",

--- a/src/agent/onefuzz/Cargo.toml
+++ b/src/agent/onefuzz/Cargo.toml
@@ -55,3 +55,6 @@ nix = "0.23"
 pete = "0.8"
 rstack = "0.3"
 proc-maps = "0.2"
+
+[dev-dependencies]
+structopt = "0.3"

--- a/src/agent/onefuzz/examples/test-input.rs
+++ b/src/agent/onefuzz/examples/test-input.rs
@@ -31,7 +31,7 @@ struct Opt {
     pub no_check_debugger: bool,
 
     #[structopt(short, long, long_help = "Timeout (seconds)", default_value = "5")]
-    timeout: u64,
+    pub timeout: u64,
 }
 
 #[tokio::main]

--- a/src/agent/onefuzz/examples/test-input.rs
+++ b/src/agent/onefuzz/examples/test-input.rs
@@ -8,6 +8,7 @@ use onefuzz::input_tester::Tester;
 use structopt::StructOpt;
 
 #[derive(Debug, PartialEq, StructOpt)]
+#[structopt(name = "test-input")]
 struct Opt {
     #[structopt(short, long)]
     pub exe: PathBuf,

--- a/src/agent/onefuzz/examples/test-input.rs
+++ b/src/agent/onefuzz/examples/test-input.rs
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use std::path::PathBuf;
+
+use anyhow::Result;
+use onefuzz::input_tester::Tester;
+use structopt::StructOpt;
+
+#[derive(Debug, PartialEq, StructOpt)]
+struct Opt {
+    #[structopt(short, long)]
+    pub exe: PathBuf,
+
+    #[structopt(short, long)]
+    pub options: Vec<String>,
+
+    #[structopt(short, long)]
+    pub setup_dir: PathBuf,
+
+    #[structopt(short, long)]
+    pub input: PathBuf,
+
+    #[structopt(long)]
+    pub check_asan_log: bool,
+
+    #[structopt(long)]
+    pub check_asan_stderr: bool,
+
+    #[structopt(long)]
+    pub no_check_debugger: bool,
+
+    #[structopt(short, long, long_help = "Timeout (seconds)", default_value = "5")]
+    timeout: u64,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let opt = Opt::from_args();
+
+    let env = Default::default();
+    let tester = Tester::new(&opt.setup_dir, &opt.exe, &opt.options, &env);
+
+    let check_debugger = !opt.no_check_debugger;
+    let tester = tester
+        .timeout(opt.timeout)
+        .check_debugger(check_debugger)
+        .check_asan_log(opt.check_asan_log)
+        .check_asan_stderr(opt.check_asan_stderr);
+
+    let test_result = tester.test_input(&opt.input).await?;
+
+    if let Some(crash) = test_result.crash_log.as_ref() {
+        println!("[+] crash detected!");
+        println!();
+        let text: &str = crash.text.as_ref().map(|s| s.as_str()).unwrap_or_default();
+        println!("    sanitizer = {}", crash.sanitizer);
+        println!("    summary = {}", crash.summary);
+        println!("    text = {}", text);
+    } else {
+        println!("[-] no crash detected.");
+    }
+
+    println!();
+    println!("[+] verbose test result:");
+    println!();
+    println!("{:?}", test_result);
+
+    Ok(())
+}

--- a/src/agent/onefuzz/examples/test-input.rs
+++ b/src/agent/onefuzz/examples/test-input.rs
@@ -16,7 +16,7 @@ struct Opt {
     pub options: Vec<String>,
 
     #[structopt(short, long)]
-    pub setup_dir: PathBuf,
+    pub setup_dir: Option<PathBuf>,
 
     #[structopt(short, long)]
     pub input: PathBuf,
@@ -38,8 +38,13 @@ struct Opt {
 async fn main() -> Result<()> {
     let opt = Opt::from_args();
 
+    // Default `setup_dir` to base dir of
+    let setup_dir = opt.setup_dir
+        .clone()
+        .unwrap_or_else(|| opt.exe.parent().expect("target exe missing file component").to_owned());
+
     let env = Default::default();
-    let tester = Tester::new(&opt.setup_dir, &opt.exe, &opt.options, &env);
+    let tester = Tester::new(&setup_dir, &opt.exe, &opt.options, &env);
 
     let check_debugger = !opt.no_check_debugger;
     let tester = tester

--- a/src/agent/onefuzz/examples/test-input.rs
+++ b/src/agent/onefuzz/examples/test-input.rs
@@ -12,7 +12,7 @@ struct Opt {
     #[structopt(short, long)]
     pub exe: PathBuf,
 
-    #[structopt(short, long)]
+    #[structopt(short, long, long_help = "Defaults to `{input}`")]
     pub options: Vec<String>,
 
     #[structopt(short, long, long_help = "Defaults to dir of `exe`")]
@@ -46,8 +46,13 @@ async fn main() -> Result<()> {
             .to_owned()
     });
 
+    let mut target_options = opt.options.clone();
+    if target_options.is_empty() {
+        target_options.push("{input}".into());
+    }
+
     let env = Default::default();
-    let tester = Tester::new(&setup_dir, &opt.exe, &opt.options, &env);
+    let tester = Tester::new(&setup_dir, &opt.exe, &target_options, &env);
 
     let check_debugger = !opt.no_check_debugger;
     let tester = tester

--- a/src/agent/onefuzz/examples/test-input.rs
+++ b/src/agent/onefuzz/examples/test-input.rs
@@ -15,7 +15,7 @@ struct Opt {
     #[structopt(short, long)]
     pub options: Vec<String>,
 
-    #[structopt(short, long)]
+    #[structopt(short, long, long_help = "Defaults to dir of `exe`")]
     pub setup_dir: Option<PathBuf>,
 
     #[structopt(short, long)]

--- a/src/agent/onefuzz/examples/test-input.rs
+++ b/src/agent/onefuzz/examples/test-input.rs
@@ -39,9 +39,12 @@ async fn main() -> Result<()> {
     let opt = Opt::from_args();
 
     // Default `setup_dir` to base dir of
-    let setup_dir = opt.setup_dir
-        .clone()
-        .unwrap_or_else(|| opt.exe.parent().expect("target exe missing file component").to_owned());
+    let setup_dir = opt.setup_dir.clone().unwrap_or_else(|| {
+        opt.exe
+            .parent()
+            .expect("target exe missing file component")
+            .to_owned()
+    });
 
     let env = Default::default();
     let tester = Tester::new(&setup_dir, &opt.exe, &opt.options, &env);


### PR DESCRIPTION
Add a new example binary ( `test-input`) to the `onefuzz` crate. This exercises the same code used in the `generic_generator` and `crash_report` tasks. It is useful for local validation of expected behavior of a target exe against an input.

This binary is not built by default, and does not need to be. It can be built locally from the `src/agent/onefuzz` directory via:
```
cargo build --examples
```

### Usage examples

#### Help / usage
```
./test-input -h
```
```
onefuzz 0.1.0

USAGE:
    test-input [FLAGS] [OPTIONS] --exe <exe> --input <input> --setup-dir <setup-dir>

FLAGS:
        --check-asan-log
        --check-asan-stderr
    -h, --help                 Prints help information
        --no-check-debugger
    -V, --version              Prints version information

OPTIONS:
    -e, --exe <exe>
    -i, --input <input>
    -o, --options <options>...
    -s, --setup-dir <setup-dir>
    -t, --timeout <timeout>        Timeout (seconds) [default: 5]
```

#### Uninstrumented file-reading exe
```
./test-input -s . -e ./main.exe -o '{input}' -i bad.txt
```
```
[+] crash detected!

    sanitizer = SIGSEGV
    summary = 0x400707 in LLVMFuzzerTestOneInput+0xa7 (/home/joe/fuzz-targets/main.exe+0x707)
    text =

[+] verbose test result:

TestResult { <redacted> }
```

#### ASAN-instrumented libFuzzer in repro mode
```
./test-input --check-asan-log -s . -e ./fuzz.exe -o '{input}' -i bad.txt
```

```
[+] crash detected!

    sanitizer = SIGSEGV
    summary = 0x526e4c in LLVMFuzzerTestOneInput+0x34c (/home/joe/fuzz-targets/fuzz.exe+0x126e4c)
    text =

[+] verbose test result:

TestResult { <redacted> }
```