### PR TITLE
fix node serialization

### DIFF
--- a/src/api-service/__app__/node/__init__.py
+++ b/src/api-service/__app__/node/__init__.py
@@ -31,7 +31,7 @@ def get(req: func.HttpRequest) -> func.HttpResponse:
             return not_ok(node, context=request.machine_id)
 
         node_tasks = NodeTasks.get_by_machine_id(request.machine_id)
-        node.tasks = [(t.task_id, t.state) for t in node_tasks]
+        node.tasks = node_tasks
         node.messages = [
             x.message for x in NodeMessage.get_messages(request.machine_id)
         ]

--- a/src/api-service/__app__/node/__init__.py
+++ b/src/api-service/__app__/node/__init__.py
@@ -30,8 +30,7 @@ def get(req: func.HttpRequest) -> func.HttpResponse:
         if isinstance(node, Error):
             return not_ok(node, context=request.machine_id)
 
-        node_tasks = NodeTasks.get_by_machine_id(request.machine_id)
-        node.tasks = node_tasks
+        node.tasks = NodeTasks.get_by_machine_id(request.machine_id)
         node.messages = [
             x.message for x in NodeMessage.get_messages(request.machine_id)
         ]

--- a/src/api-service/__app__/node/__init__.py
+++ b/src/api-service/__app__/node/__init__.py
@@ -30,7 +30,7 @@ def get(req: func.HttpRequest) -> func.HttpResponse:
         if isinstance(node, Error):
             return not_ok(node, context=request.machine_id)
 
-        node.tasks = NodeTasks.get_by_machine_id(request.machine_id)
+        node.tasks = [n for n in NodeTasks.get_by_machine_id(request.machine_id)]
         node.messages = [
             x.message for x in NodeMessage.get_messages(request.machine_id)
         ]

--- a/src/pytypes/onefuzztypes/models.py
+++ b/src/pytypes/onefuzztypes/models.py
@@ -4,7 +4,7 @@
 # Licensed under the MIT License.
 
 from datetime import datetime
-from typing import Any, Dict, Generic, List, Optional, Tuple, TypeVar, Union
+from typing import Any, Dict, Generic, List, Optional, TypeVar, Union
 from uuid import UUID, uuid4
 
 from pydantic import BaseModel, Field, root_validator, validator
@@ -561,6 +561,12 @@ class NodeCommand(EnumModel):
     stop_if_free: Optional[NodeCommandStopIfFree]
 
 
+class NodeTasks(BaseModel):
+    machine_id: UUID
+    task_id: UUID
+    state: NodeTaskState = Field(default=NodeTaskState.init)
+
+
 class NodeCommandEnvelope(BaseModel):
     command: NodeCommand
     message_id: str
@@ -576,7 +582,7 @@ class Node(BaseModel):
     machine_id: UUID
     state: NodeState = Field(default=NodeState.init)
     scaleset_id: Optional[UUID] = None
-    tasks: Optional[List[Tuple[UUID, NodeTaskState]]] = None
+    tasks: Optional[List[NodeTasks]] = None
     messages: Optional[List[NodeCommand]] = None
     heartbeat: Optional[datetime]
     version: str = Field(default="1.0.0")
@@ -588,12 +594,6 @@ class Node(BaseModel):
 class ScalesetSummary(BaseModel):
     scaleset_id: UUID
     state: ScalesetState
-
-
-class NodeTasks(BaseModel):
-    machine_id: UUID
-    task_id: UUID
-    state: NodeTaskState = Field(default=NodeTaskState.init)
 
 
 class AutoScaleConfig(BaseModel):


### PR DESCRIPTION
## Summary of the Pull Request
The tuple type of Node.tasks is causing the following error when the field is deserialized 
```
WARNING:root:unable to normalize type f<class 'tuple'>
WARNING:root:unable to normalize type f<class 'tuple'>
WARNING:root:unable to normalize type f<class 'tuple'>
Traceback (most recent call last):
  File "C:\temp\onefuzz\venv\Scripts\onefuzz-script.py", line 11, in <module>
    load_entry_point('onefuzz', 'console_scripts', 'onefuzz')()
  File "c:\work\onefuzz\src\cli\onefuzz\__main__.py", line 16, in main
    return execute_api(Onefuzz(), [Endpoint, Command], __version__)
  File "c:\work\onefuzz\src\cli\onefuzz\cli.py", line 591, in execute_api
    output(result, args.format, expression)
  File "c:\work\onefuzz\src\cli\onefuzz\cli.py", line 532, in output
    result = json.dumps(result, indent=4, sort_keys=True)
  File "C:\Users\keita\AppData\Local\Programs\Python\Python38\lib\json\__init__.py", line 234, in dumps
    return cls(
  File "C:\Users\keita\AppData\Local\Programs\Python\Python38\lib\json\encoder.py", line 201, in encode
    chunks = list(chunks)
  File "C:\Users\keita\AppData\Local\Programs\Python\Python38\lib\json\encoder.py", line 431, in _iterencode
    yield from _iterencode_dict(o, _current_indent_level)
  File "C:\Users\keita\AppData\Local\Programs\Python\Python38\lib\json\encoder.py", line 405, in _iterencode_dict
    yield from chunks
  File "C:\Users\keita\AppData\Local\Programs\Python\Python38\lib\json\encoder.py", line 325, in _iterencode_list
    yield from chunks
  File "C:\Users\keita\AppData\Local\Programs\Python\Python38\lib\json\encoder.py", line 325, in _iterencode_list
    yield from chunks
  File "C:\Users\keita\AppData\Local\Programs\Python\Python38\lib\json\encoder.py", line 438, in _iterencode
    o = _default(o)
  File "C:\Users\keita\AppData\Local\Programs\Python\Python38\lib\json\encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type NodeTaskState is not JSON serializable
````

This PR changes the type of that field to NodeTask which is supported by our serialization layer.