### PR TITLE
Remove use of deprecated `warn()` method on logger object

### DIFF
--- a/src/deployment/deploy.py
+++ b/src/deployment/deploy.py
@@ -176,7 +176,7 @@ class Client:
             if not azcopy:
                 raise Exception(AZCOPY_MISSING_ERROR)
             else:
-                logger.warn("unable to use built-in azcopy, using system install")
+                logger.warning("unable to use built-in azcopy, using system install")
                 self.azcopy = azcopy
 
         with open(workbook_data) as f:


### PR DESCRIPTION
Remove use of deprecated `warn()` method on logger object.

Stops this warning on deployment:

```
/Users/anthonyshaw/projects/deploy.py:179: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
  logger.warn("unable to use built-in azcopy, using system install")
```