### PR TITLE
Add timeout to setup scripts

### DIFF
--- a/src/agent/onefuzz-supervisor/src/setup.rs
+++ b/src/agent/onefuzz-supervisor/src/setup.rs
@@ -204,7 +204,9 @@ impl SetupScript {
     pub async fn invoke(&self, timeout: impl Into<Option<Duration>>) -> Result<Output> {
         let timeout = timeout.into().unwrap_or(DEFAULT_SETUP_SCRIPT_TIMEOUT);
 
-        let timed = tokio::time::timeout(timeout, self.setup_command().output()).await?;
+        let timed = tokio::time::timeout(timeout, self.setup_command().output())
+            .await
+            .context("setup script timed out")?;
         let output = timed?.into();
 
         Ok(output)

--- a/src/agent/onefuzz-supervisor/src/setup.rs
+++ b/src/agent/onefuzz-supervisor/src/setup.rs
@@ -14,8 +14,8 @@ use tokio::process::Command;
 
 use crate::work::*;
 
-// Default to 4 hour timeout for user setup scripts.
-const DEFAULT_SETUP_SCRIPT_TIMEOUT: Duration = Duration::from_secs(4 * 60 * 60);
+// Default to 59 minutes, just under the service's `NODE_EXPIRATION_TIME` of 1 hour.
+const DEFAULT_SETUP_SCRIPT_TIMEOUT: Duration = Duration::from_secs(59 * 60);
 
 const SETUP_PATH_ENV: &str = "ONEFUZZ_TARGET_SETUP_PATH";
 


### PR DESCRIPTION
Add a setup script-specific timeout of 59 minutes. This is just shorter than the service-side `NODE_EXPIRATION_TIME` which otherwise garbage collects nodes whose setup scripts are stuck or taking too long.

Ideally, the timeout would be user-configurable within some range. As-is, we'd only ever want to increase it, and doing so would require dynamically updating the service-side limit (which we'd probably want to revert to something short, after the setup script is done.

With this change, the high-level cause of the timeout is clear, instead of the closest error being something indirect, like "node reimaged during task execution".

Tested by creating a Linux `libfuzzer basic` job with a `setup.sh` that invokes `yes >/dev/null`. All task VMs got stuck in `setting_up`, then failed with an explicit error of "setup script timed out".

Closes #1658.