### PR TITLE
Create autoscale resources for scaleset

### DIFF
--- a/src/api-service/__app__/onefuzzlib/azure/auto_scale.py
+++ b/src/api-service/__app__/onefuzzlib/azure/auto_scale.py
@@ -47,7 +47,7 @@ from .creds import (
 
 @retry_on_auth_failure()
 def add_auto_scale_to_vmss(vmss: UUID, auto_scale_profile: AutoscaleProfile) -> Optional[Error]:
-    logging.error("Checking scaleset %s for existing auto scale resources" % vmss)
+    logging.info("Checking scaleset %s for existing auto scale resources" % vmss)
     client = get_monitor_client()
     resource_group = get_base_resource_group()
 
@@ -66,7 +66,7 @@ def add_auto_scale_to_vmss(vmss: UUID, auto_scale_profile: AutoscaleProfile) -> 
         )
 
     if auto_scale_resource_id is not None:
-        logging.error("Scaleset %s already has auto scale resource" % vmss)
+        logging.warning("Scaleset %s already has auto scale resource" % vmss)
         return None
 
     resource_creation = create_auto_scale_resource_for(vmss, get_base_region(), auto_scale_profile)
@@ -75,7 +75,7 @@ def add_auto_scale_to_vmss(vmss: UUID, auto_scale_profile: AutoscaleProfile) -> 
     return None
 
 def create_auto_scale_resource_for(resource_id: UUID, location: Region, profile: AutoscaleProfile) -> Union[AutoscaleSettingResource, Error]:
-    logging.error("Creating auto scale resource for: %s" % resource_id)
+    logging.info("Creating auto scale resource for: %s" % resource_id)
     client = get_monitor_client()
     resource_group = get_base_resource_group()
     subscription = get_subscription()
@@ -94,7 +94,7 @@ def create_auto_scale_resource_for(resource_id: UUID, location: Region, profile:
             str(uuid.uuid4()),
             params
         )
-        logging.error("Successfully created auto scale resource %s for %s" % (auto_scale_resource.id, resource_id))
+        logging.info("Successfully created auto scale resource %s for %s" % (auto_scale_resource.id, resource_id))
         return auto_scale_resource
     except (ResourceNotFoundError, CloudError):
         return Error(

--- a/src/api-service/__app__/onefuzzlib/azure/auto_scale.py
+++ b/src/api-service/__app__/onefuzzlib/azure/auto_scale.py
@@ -3,38 +3,30 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-from datetime import datetime, timedelta
-from enum import auto
 import logging
-from typing import Any, Dict, List, Optional, Set, Union, cast
-from uuid import UUID
 import uuid
-from onefuzztypes.enums import ErrorCode
+from datetime import timedelta
+from typing import Any, Dict, Optional, Union
+from uuid import UUID
 
-from onefuzztypes.models import Error
-from onefuzztypes.primitives import Region
-from .vmss import get_vmss_size
-from .monitor import get_monitor_client
-
+from azure.core.exceptions import ResourceNotFoundError
 from azure.mgmt.monitor.models import (
     AutoscaleProfile,
     AutoscaleSettingResource,
-    ScaleCapacity,
-    ScaleRule,
-    MetricTrigger,
-    ScaleAction,
-    TimeAggregationType,
     ComparisonOperationType,
     MetricStatisticType,
+    MetricTrigger,
+    ScaleAction,
+    ScaleCapacity,
     ScaleDirection,
+    ScaleRule,
     ScaleType,
-)
-from azure.core.exceptions import (
-    HttpResponseError,
-    ResourceExistsError,
-    ResourceNotFoundError,
+    TimeAggregationType,
 )
 from msrestazure.azure_exceptions import CloudError
+from onefuzztypes.enums import ErrorCode
+from onefuzztypes.models import Error
+from onefuzztypes.primitives import Region
 
 from .creds import (
     get_base_region,
@@ -42,8 +34,7 @@ from .creds import (
     get_subscription,
     retry_on_auth_failure,
 )
-
-# TODO: Look into deleting auto scale resource when deleting scaleset
+from .monitor import get_monitor_client
 
 
 @retry_on_auth_failure()
@@ -94,7 +85,7 @@ def create_auto_scale_resource_for(
     subscription = get_subscription()
 
     scaleset_uri = (
-        "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/virtualMachineScaleSets/%s"
+        "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/virtualMachineScaleSets/%s"  # noqa: E501
         % (subscription, resource_group, resource_id)
     )
 

--- a/src/api-service/__app__/onefuzzlib/azure/auto_scale.py
+++ b/src/api-service/__app__/onefuzzlib/azure/auto_scale.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+#
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+from datetime import datetime, timedelta
+import logging
+from typing import Any, Dict, List, Optional, Set, Union, cast
+from uuid import UUID
+import uuid
+
+from onefuzztypes.models import Error
+from .monitor import get_monitor_client
+
+from azure.mgmt.monitor.models import (
+    AutoscaleProfile,
+    AutoscaleSettingResource,
+    ScaleCapacity,
+    ScaleRule,
+    MetricTrigger,
+    ScaleAction,
+    TimeAggregationType,
+    ComparisonOperationType,
+    MetricStatisticType,
+    ScaleDirection,
+    ScaleType
+)
+
+from .creds import (
+    get_base_resource_group,
+    get_scaleset_identity_resource_path,
+    retry_on_auth_failure,
+)
+
+
+@retry_on_auth_failure()
+def add_auto_scale_to_vmss(vmss: UUID) -> Optional[Error]:
+    # TODO: Check if auto scale resource already exists in vmss
+    # TODO: If it doesn't exist, create it for the scaleset
+    return None
+
+def create_auto_scale_resource_for(resource_id: UUID, location: str, profile: AutoscaleProfile) -> Union[AutoscaleSettingResource, Error]:
+    client = get_monitor_client()
+    resource_group = get_base_resource_group()
+
+    params: Dict[str, Any] = {
+        "location": location,
+        "profiles": [profile]
+    }
+
+    client.autoscale_settings.create_or_update(
+        resource_group,
+        str(uuid.uuid4()),
+        params
+    )
+    return None
+
+def create_vmss_auto_scale_profile(min: int, max: int, pool_queue_uri: str) -> AutoscaleProfile:
+    return AutoscaleProfile(
+        name=str(uuid.uuid4()),
+        capacity=ScaleCapacity(
+            minimum=min,
+            maximum=max,
+            default=max
+        ),
+        rules=[
+            ScaleRule(
+                matric_trigger=MetricTrigger(
+                    metric_name="PoolQueueItemCount",
+                    metric_resource_uri=pool_queue_uri,
+
+                    # Check every minute
+                    time_grain=timedelta(minutes=1),
+
+                    # The average amount of messages there are in the pool queue
+                    time_aggregation= TimeAggregationType.AVERAGE,
+                    statistic=MetricStatisticType.COUNT,
+
+                    # Over the past 10 minutes
+                    time_window = timedelta(minutes=10),
+
+                    # When there's more than 1 message in the pool queue
+                    operator= ComparisonOperationType.GREATER_THAN,
+                    threshold=1,
+                ),
+                scale_action=ScaleAction(
+                    direction=ScaleDirection.INCREASE,
+                    type=ScaleType.CHANGE_COUNT,
+                    value = 1,
+                    cooldown = timedelta(minutes=5)
+                )
+            )
+        ])

--- a/src/api-service/__app__/onefuzzlib/azure/log_analytics.py
+++ b/src/api-service/__app__/onefuzzlib/azure/log_analytics.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+#
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+import os
+from typing import Dict
+
+from azure.mgmt.loganalytics import LogAnalyticsManagementClient
+from memoization import cached
+
+from .creds import get_base_resource_group, get_identity, get_subscription
+
+
+@cached
+def get_monitor_client() -> LogAnalyticsManagementClient:
+    return LogAnalyticsManagementClient(get_identity(), get_subscription())
+
+
+@cached(ttl=60)
+def get_monitor_settings() -> Dict[str, str]:
+    resource_group = get_base_resource_group()
+    workspace_name = os.environ["ONEFUZZ_MONITOR"]
+    client = get_monitor_client()
+    customer_id = client.workspaces.get(resource_group, workspace_name).customer_id
+    shared_key = client.shared_keys.get_shared_keys(
+        resource_group, workspace_name
+    ).primary_shared_key
+    return {"id": customer_id, "key": shared_key}

--- a/src/api-service/__app__/onefuzzlib/azure/monitor.py
+++ b/src/api-service/__app__/onefuzzlib/azure/monitor.py
@@ -1,29 +1,9 @@
-#!/usr/bin/env python
-#
-# Copyright (c) Microsoft Corporation.
-# Licensed under the MIT License.
-
-import os
-from typing import Dict
-
-from azure.mgmt.loganalytics import LogAnalyticsManagementClient
+from azure.mgmt.monitor import MonitorManagementClient
 from memoization import cached
 
-from .creds import get_base_resource_group, get_identity, get_subscription
+from .creds import get_identity, get_subscription
 
 
 @cached
-def get_monitor_client() -> LogAnalyticsManagementClient:
-    return LogAnalyticsManagementClient(get_identity(), get_subscription())
-
-
-@cached(ttl=60)
-def get_monitor_settings() -> Dict[str, str]:
-    resource_group = get_base_resource_group()
-    workspace_name = os.environ["ONEFUZZ_MONITOR"]
-    client = get_monitor_client()
-    customer_id = client.workspaces.get(resource_group, workspace_name).customer_id
-    shared_key = client.shared_keys.get_shared_keys(
-        resource_group, workspace_name
-    ).primary_shared_key
-    return {"id": customer_id, "key": shared_key}
+def get_monitor_client() -> MonitorManagementClient:
+    return MonitorManagementClient(get_identity(), get_subscription())

--- a/src/api-service/__app__/onefuzzlib/azure/queue.py
+++ b/src/api-service/__app__/onefuzzlib/azure/queue.py
@@ -5,7 +5,6 @@
 
 import base64
 import datetime
-from importlib.abc import ResourceReader
 import json
 import logging
 from typing import List, Optional, Type, TypeVar, Union
@@ -19,12 +18,9 @@ from azure.storage.queue import (
 )
 from memoization import cached
 from pydantic import BaseModel
-from onefuzztypes.enums import ErrorCode
 from onefuzztypes.models import Error
-from azure.mgmt.resource.resources import ResourceManagementClient
 
 from .storage import StorageType, get_primary_account, get_storage_account_name_key
-from .creds import get_base_resource_group, get_identity, get_subscription
 
 QueueNameType = Union[str, UUID]
 
@@ -203,16 +199,7 @@ def queue_object(
 def get_resource_id(
     queue_name: QueueNameType,
     storage_type: StorageType
-) -> Union[str, Error]:
+) -> str:
     account_id = get_primary_account(storage_type)
     resource_uri = "%s/services/queue/queues/%s" % (account_id, queue_name)
-    # logging.error("Calculated resource uri: %s" % resource_uri)
-    # rm_client = ResourceManagementClient(get_identity(), get_subscription())
-    
-    # try:
-    #     rm_client.resources.get_by_id(resource_uri, '2014-04-01')
-    # except (ResourceNotFoundError):
-    #     return Error(
-    #         code=ErrorCode.UNABLE_TO_FIND
-    #     )
     return resource_uri

--- a/src/api-service/__app__/onefuzzlib/azure/queue.py
+++ b/src/api-service/__app__/onefuzzlib/azure/queue.py
@@ -206,13 +206,13 @@ def get_resource_id(
 ) -> Union[str, Error]:
     account_id = get_primary_account(storage_type)
     resource_uri = "%s/services/queue/queues/%s" % (account_id, queue_name)
-
-    rm_client = ResourceManagementClient(get_identity(), get_subscription())
+    # logging.error("Calculated resource uri: %s" % resource_uri)
+    # rm_client = ResourceManagementClient(get_identity(), get_subscription())
     
-    try:
-        rm_client.resources.get_by_id(resource_uri)
-    except (ResourceNotFoundError):
-        return Error(
-            code=ErrorCode.UNABLE_TO_FIND
-        )
+    # try:
+    #     rm_client.resources.get_by_id(resource_uri, '2014-04-01')
+    # except (ResourceNotFoundError):
+    #     return Error(
+    #         code=ErrorCode.UNABLE_TO_FIND
+    #     )
     return resource_uri

--- a/src/api-service/__app__/onefuzzlib/azure/queue.py
+++ b/src/api-service/__app__/onefuzzlib/azure/queue.py
@@ -139,6 +139,7 @@ def remove_first_message(name: QueueNameType, storage_type: StorageType) -> bool
             return False
     return False
 
+
 A = TypeVar("A", bound=BaseModel)
 
 
@@ -196,10 +197,8 @@ def queue_object(
     except ResourceNotFoundError:
         return False
 
-def get_resource_id(
-    queue_name: QueueNameType,
-    storage_type: StorageType
-) -> str:
+
+def get_resource_id(queue_name: QueueNameType, storage_type: StorageType) -> str:
     account_id = get_primary_account(storage_type)
     resource_uri = "%s/services/queue/queues/%s" % (account_id, queue_name)
     return resource_uri

--- a/src/api-service/__app__/onefuzzlib/azure/queue.py
+++ b/src/api-service/__app__/onefuzzlib/azure/queue.py
@@ -18,7 +18,6 @@ from azure.storage.queue import (
 )
 from memoization import cached
 from pydantic import BaseModel
-from onefuzztypes.models import Error
 
 from .storage import StorageType, get_primary_account, get_storage_account_name_key
 

--- a/src/api-service/__app__/onefuzzlib/extension.py
+++ b/src/api-service/__app__/onefuzzlib/extension.py
@@ -25,7 +25,7 @@ from .azure.containers import (
     save_blob,
 )
 from .azure.creds import get_instance_id, get_instance_url
-from .azure.monitor import get_monitor_settings
+from .azure.log_analytics import get_monitor_settings
 from .azure.queue import get_queue_sas
 from .azure.storage import StorageType
 from .config import InstanceConfig

--- a/src/api-service/__app__/onefuzzlib/workers/scalesets.py
+++ b/src/api-service/__app__/onefuzzlib/workers/scalesets.py
@@ -211,6 +211,8 @@ class Scaleset(BASE_SCALESET, ORMMixin):
             return
 
         vmss = get_vmss(self.scaleset_id)
+        # TODO: Set up auto scale resource
+        # TODO: Link up auto scale resource with diagnostics
         if vmss is None:
             pool = Pool.get_by_name(self.pool_name)
             if isinstance(pool, Error):

--- a/src/api-service/__app__/onefuzzlib/workers/scalesets.py
+++ b/src/api-service/__app__/onefuzzlib/workers/scalesets.py
@@ -835,11 +835,14 @@ class Scaleset(BASE_SCALESET, ORMMixin):
 
     def try_to_enable_auto_scaling(self) -> Optional[Error]:
         from .pools import Pool
+
         logging.info("Trying to add auto scaling for scaleset %s" % self.scaleset_id)
 
         pool = Pool.get_by_name(self.pool_name)
         if isinstance(pool, Error):
-            logging.error("Failed to get pool by name: %s error: %s" % (self.pool_name, pool))
+            logging.error(
+                "Failed to get pool by name: %s error: %s" % (self.pool_name, pool)
+            )
             return pool
 
         pool_queue_id = pool.get_pool_queue()
@@ -847,13 +850,14 @@ class Scaleset(BASE_SCALESET, ORMMixin):
         capacity = get_vmss_size(self.scaleset_id)
         if capacity is None:
             capacity_failed = Error(
+                code=ErrorCode.ErrorCode.UNABLE_TO_FIND
                 errors=["Failed to get capacity for scaleset %s" % self.scaleset_id]
             )
             logging.error(capacity_failed)
             return capacity_failed
 
-        auto_scale_profile = create_auto_scale_profile(capacity, capacity, pool_queue_uri)
-        logging.info(
-            "Added auto scale resource to scaleset: %s" % self.scaleset_id
+        auto_scale_profile = create_auto_scale_profile(
+            capacity, capacity, pool_queue_uri
         )
+        logging.info("Added auto scale resource to scaleset: %s" % self.scaleset_id)
         return add_auto_scale_to_vmss(self.scaleset_id, auto_scale_profile)

--- a/src/api-service/__app__/onefuzzlib/workers/scalesets.py
+++ b/src/api-service/__app__/onefuzzlib/workers/scalesets.py
@@ -23,8 +23,11 @@ from onefuzztypes.primitives import PoolName, Region
 
 from ..__version__ import __version__
 from ..azure.auth import build_auth
+from ..azure.auto_scale import add_auto_scale_to_vmss, create_auto_scale_profile
 from ..azure.image import get_os
 from ..azure.network import Network
+from ..azure.queue import get_resource_id
+from ..azure.storage import StorageType
 from ..azure.vmss import (
     UnableToUpdate,
     create_vmss,
@@ -42,9 +45,6 @@ from ..extension import fuzz_extensions
 from ..orm import MappingIntStrAny, ORMMixin, QueryFilter
 from .nodes import Node
 from .shrink_queue import ShrinkQueue
-from ..azure.queue import get_queue, get_resource_id
-from ..azure.storage import StorageType
-from ..azure.auto_scale import create_auto_scale_profile, add_auto_scale_to_vmss
 
 NODE_EXPIRATION_TIME: datetime.timedelta = datetime.timedelta(hours=1)
 NODE_REIMAGE_TIME: datetime.timedelta = datetime.timedelta(days=7)
@@ -850,8 +850,8 @@ class Scaleset(BASE_SCALESET, ORMMixin):
         capacity = get_vmss_size(self.scaleset_id)
         if capacity is None:
             capacity_failed = Error(
-                code=ErrorCode.ErrorCode.UNABLE_TO_FIND
-                errors=["Failed to get capacity for scaleset %s" % self.scaleset_id]
+                code=ErrorCode.UNABLE_TO_FIND,
+                errors=["Failed to get capacity for scaleset %s" % self.scaleset_id],
             )
             logging.error(capacity_failed)
             return capacity_failed

--- a/src/api-service/__app__/requirements.txt
+++ b/src/api-service/__app__/requirements.txt
@@ -9,6 +9,7 @@ azure-keyvault-secrets~=4.3.0
 azure-mgmt-compute==24.0.1
 azure-mgmt-core==1.3.0
 azure-mgmt-loganalytics~=11.0.0
+azure-mgmt-monitor==3.0.0
 azure-mgmt-network==19.0.0
 azure-mgmt-storage~=18.0.0
 azure-mgmt-resource~=18.1.0
@@ -30,4 +31,4 @@ jsonpatch==1.32
 semver==2.13.0
 base58==2.1.0
 # onefuzz types version is set during build
-onefuzztypes==0.0.0
+onefuzztypes==5.0.0

--- a/src/api-service/__app__/requirements.txt
+++ b/src/api-service/__app__/requirements.txt
@@ -32,3 +32,4 @@ semver==2.13.0
 base58==2.1.0
 # onefuzz types version is set during build
 onefuzztypes==5.0.0
+

--- a/src/api-service/__app__/requirements.txt
+++ b/src/api-service/__app__/requirements.txt
@@ -31,5 +31,4 @@ jsonpatch==1.32
 semver==2.13.0
 base58==2.1.0
 # onefuzz types version is set during build
-onefuzztypes==5.0.0
-
+onefuzztypes==0.0.0

--- a/src/deployment/azuredeploy.json
+++ b/src/deployment/azuredeploy.json
@@ -67,6 +67,7 @@
         "Storage Account Contributor": "17d1049b-9a84-46fb-8f53-869881c3d3ab",
         "Virtual Machine Contributor": "9980e02c-c2be-4d73-94e8-173b1dc7cf3c",
         "Storage Blob Data Reader": "2a2b9908-6ea1-4ae2-8e65-a410df84e7d1",
+        "OneFuzz Deployment": "d4f7c2d9-6c1e-4caa-a39b-cba6d76bc647",
         "keyVaultName": "[concat('of-kv-', uniquestring(resourceGroup().id))]"
     },
     "functions": [
@@ -810,6 +811,21 @@
             "name": "[guid(concat(resourceGroup().id, '-user_managed_idenity'))]",
             "properties": {
                 "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', variables('Managed Identity Operator'))]",
+                "principalId": "[reference(resourceId('Microsoft.Web/sites', parameters('name')), '2018-02-01', 'Full').identity.principalId]"
+            },
+            "DependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('name'))]"
+            ],
+            "tags": {
+                "OWNER": "[parameters('owner')]"
+            }
+        },
+        {
+            "type": "Microsoft.Authorization/roleAssignments",
+            "apiVersion": "2017-09-01",
+            "name": "[guid(concat(resourceGroup().id, '-auto_scale'))]",
+            "properties": {
+                "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', variables('OneFuzz Deployment'))]",
                 "principalId": "[reference(resourceId('Microsoft.Web/sites', parameters('name')), '2018-02-01', 'Full').identity.principalId]"
             },
             "DependsOn": [


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_
This PR creates an auto scale resource for scalesets that uses the pool work queue as the tirgger metric.

## Info on Pull Request

_What does this include?_

* These changes only affect new scalesets, existing scalesets will not be modified
* Scalesets that already have an auto scale resource associated with them will not be modified
* The autoscaling resource is disabled meaning scaleset behavior won't change
* In the interest of keeping this reviewable, hooking up scaling event diagnostics will be a follow up PR

## Validation Steps Performed

_How does someone test & validate?_

1. Create a new scaleset
2. Find your new scaleset n azure portal
3. Under "Scaling", select the "JSON" tab
4. Verify there is 1 object under `.properties.profiles`
5. Verify `.properties.enabled == false`
