### PR TITLE
Used fixed Windows image for integration test build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -414,7 +414,7 @@ jobs:
         name: integration-test-artifacts
         path: src/integration-tests/artifacts
   build-integration-tests-windows:
-    runs-on: windows-latest
+    runs-on: windows-2019
     steps:
     - uses: actions/checkout@v2
     - run: |


### PR DESCRIPTION
When `windows-latest` changes over to `windows-2019`, it will break the `build-integration-tests-windows` CI task.

Set the build image to a fixed version. When we update to `windows-2022`, we'll want to do so explicitly, and it will require updating the generated PowerShell script, which assumes certain Visual Studio versions and paths.