### PR TITLE
Remove dependency on onefuzz deployment role to unblock

### DIFF
--- a/src/api-service/__app__/onefuzzlib/workers/scalesets.py
+++ b/src/api-service/__app__/onefuzzlib/workers/scalesets.py
@@ -261,10 +261,6 @@ class Scaleset(BASE_SCALESET, ORMMixin):
                 SCALESET_LOG_PREFIX + "scaleset running scaleset_id:%s",
                 self.scaleset_id,
             )
-            auto_scaling = self.try_to_enable_auto_scaling()
-            if isinstance(auto_scaling, Error):
-                self.set_failed(auto_scaling)
-                return
 
             identity_result = self.try_set_identity(vmss)
             if identity_result:

--- a/src/deployment/azuredeploy.json
+++ b/src/deployment/azuredeploy.json
@@ -67,7 +67,6 @@
         "Storage Account Contributor": "17d1049b-9a84-46fb-8f53-869881c3d3ab",
         "Virtual Machine Contributor": "9980e02c-c2be-4d73-94e8-173b1dc7cf3c",
         "Storage Blob Data Reader": "2a2b9908-6ea1-4ae2-8e65-a410df84e7d1",
-        "OneFuzz Deployment": "d4f7c2d9-6c1e-4caa-a39b-cba6d76bc647",
         "keyVaultName": "[concat('of-kv-', uniquestring(resourceGroup().id))]"
     },
     "functions": [
@@ -811,21 +810,6 @@
             "name": "[guid(concat(resourceGroup().id, '-user_managed_idenity'))]",
             "properties": {
                 "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', variables('Managed Identity Operator'))]",
-                "principalId": "[reference(resourceId('Microsoft.Web/sites', parameters('name')), '2018-02-01', 'Full').identity.principalId]"
-            },
-            "DependsOn": [
-                "[resourceId('Microsoft.Web/sites', parameters('name'))]"
-            ],
-            "tags": {
-                "OWNER": "[parameters('owner')]"
-            }
-        },
-        {
-            "type": "Microsoft.Authorization/roleAssignments",
-            "apiVersion": "2017-09-01",
-            "name": "[guid(concat(resourceGroup().id, '-auto_scale'))]",
-            "properties": {
-                "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', variables('OneFuzz Deployment'))]",
                 "principalId": "[reference(resourceId('Microsoft.Web/sites', parameters('name')), '2018-02-01', 'Full').identity.principalId]"
             },
             "DependsOn": [


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_
Onefuzz Deployment role is not available in every tenant. We need to find a 'portable' role with the permissions we need to add auto-scale resources.

## Validation Steps Performed

_How does someone test & validate?_
