### PR TITLE
Give function app resource group scoped contributor role

### DIFF
--- a/src/deployment/azuredeploy.json
+++ b/src/deployment/azuredeploy.json
@@ -67,6 +67,7 @@
         "Storage Account Contributor": "17d1049b-9a84-46fb-8f53-869881c3d3ab",
         "Virtual Machine Contributor": "9980e02c-c2be-4d73-94e8-173b1dc7cf3c",
         "Storage Blob Data Reader": "2a2b9908-6ea1-4ae2-8e65-a410df84e7d1",
+        "Contributor": "b24988ac-6180-42a0-ab88-20f7382dd24c",
         "keyVaultName": "[concat('of-kv-', uniquestring(resourceGroup().id))]"
     },
     "functions": [
@@ -810,6 +811,21 @@
             "name": "[guid(concat(resourceGroup().id, '-user_managed_idenity'))]",
             "properties": {
                 "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', variables('Managed Identity Operator'))]",
+                "principalId": "[reference(resourceId('Microsoft.Web/sites', parameters('name')), '2018-02-01', 'Full').identity.principalId]"
+            },
+            "DependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('name'))]"
+            ],
+            "tags": {
+                "OWNER": "[parameters('owner')]"
+            }
+        },
+        {
+            "type": "Microsoft.Authorization/roleAssignments",
+            "apiVersion": "2017-09-01",
+            "name": "[guid(concat(resourceGroup().id, '-contributor'))]",
+            "properties": {
+                "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', variables('Contributor'))]",
                 "principalId": "[reference(resourceId('Microsoft.Web/sites', parameters('name')), '2018-02-01', 'Full').identity.principalId]"
             },
             "DependsOn": [


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_

In #1693, we removed the Onefuzz Deployment custom role since we can't rely on it being in any arbitrary azure tenant. In order to give the Functions App permissions to create the auto scale resources, we're giving it Contributor access to the resource group. Unfortunately, we can't scope down the permissions further since there's no other built-in roles that provide `Microsoft.Insights/autoscalesettings/Write` permission.

Docs used for resource scoped role assignment: https://docs.microsoft.com/en-us/azure/role-based-access-control/role-assignments-template#resource-group-scope-without-parameters

## PR Checklist
* [ ] Closes #1697
* [ ] Tests added/passed
* [x] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_

* ARM template change to add the `Contributor` role to the Function App
* Contributor role id: [b24988ac-6180-42a0-ab88-20f7382dd24c](https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#all)

## Validation Steps Performed

_How does someone test & validate?_

* Ran dev deployment and validated the Function App now has `Contributor` role
