### PR TITLE
Add autoscaling diagnostics

### DIFF
--- a/src/api-service/__app__/onefuzzlib/azure/log_analytics.py
+++ b/src/api-service/__app__/onefuzzlib/azure/log_analytics.py
@@ -27,3 +27,8 @@ def get_monitor_settings() -> Dict[str, str]:
         resource_group, workspace_name
     ).primary_shared_key
     return {"id": customer_id, "key": shared_key}
+
+def get_workspace_id() -> str:
+    # TODO: Once #1679 merges, we can use ONEFUZZ_MONITOR instead of ONEFUZZ_INSTANCE_NAME
+    workspace_id = "/subscriptions/%s/resourceGroups/%s/providers/microsoft.operationalinsights/workspaces/%s" % (get_subscription(), get_base_resource_group(), os.environ["ONEFUZZ_INSTANCE_NAME"])
+    return workspace_id

--- a/src/api-service/__app__/onefuzzlib/azure/log_analytics.py
+++ b/src/api-service/__app__/onefuzzlib/azure/log_analytics.py
@@ -28,7 +28,15 @@ def get_monitor_settings() -> Dict[str, str]:
     ).primary_shared_key
     return {"id": customer_id, "key": shared_key}
 
+
 def get_workspace_id() -> str:
     # TODO: Once #1679 merges, we can use ONEFUZZ_MONITOR instead of ONEFUZZ_INSTANCE_NAME
-    workspace_id = "/subscriptions/%s/resourceGroups/%s/providers/microsoft.operationalinsights/workspaces/%s" % (get_subscription(), get_base_resource_group(), os.environ["ONEFUZZ_INSTANCE_NAME"])
+    workspace_id = (
+        "/subscriptions/%s/resourceGroups/%s/providers/microsoft.operationalinsights/workspaces/%s"
+        % (
+            get_subscription(),
+            get_base_resource_group(),
+            os.environ["ONEFUZZ_INSTANCE_NAME"],
+        )
+    )
     return workspace_id


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_

This PR connects autoscaling diagnostics for our scale sets to our log analytics workspace. We will collect all autoscaling related logs.

## PR Checklist
* [ ] Closes #1707 
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_

Creates a diagnostic setting when the autoscale resource is created.

## Validation Steps Performed

_How does someone test & validate?_

* Create a new scale set and wait for it to be in "running" state
* Under the "Settings" section, select the "Scaling" button
* Click the "Diagnostic Settings" tab
* Verify there is one entry present
* Click "Edit setting"
* Verify "allLogs" is checked
* Verify "Send to Log Analytics workspace" is checked and the workspace with the instance name is selected
* Query the Log Analytics workspace to verify data is being sent from the right resources

Example query:

```kql
AutoscaleEvaluationsLog
| take 10
```