### PR TITLE
Add crate to debug missing dynamic libraries on Windows

### DIFF
--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -127,14 +127,14 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backoff"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fe17f59a06fe8b87a6fc8bf53bb70b3aba76d7685f432487a68cd5552853625"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
 dependencies = [
  "futures-core",
  "getrandom 0.2.3",
  "instant",
- "pin-project",
+ "pin-project-lite",
  "rand 0.8.4",
  "tokio",
 ]
@@ -655,6 +655,20 @@ name = "dunce"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "453440c271cf5577fd2a40e4942540cb7d0d2f85e27c8d07dd0023c925a67541"
+
+[[package]]
+name = "dynamic-library"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "debugger",
+ "lazy_static",
+ "regex",
+ "structopt",
+ "thiserror",
+ "winapi 0.3.9",
+ "winreg 0.10.1",
+]
 
 [[package]]
 name = "either"

--- a/src/agent/Cargo.toml
+++ b/src/agent/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "atexit",
     "coverage",
     "debugger",
+    "dynamic-library",
     "input-tester",
     "onefuzz",
     "onefuzz-agent",

--- a/src/agent/dynamic-library/Cargo.toml
+++ b/src/agent/dynamic-library/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "dynamic-library"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+anyhow = "1.0"
+lazy_static = "1.4"
+regex = "1.5"
+structopt = "0.3"
+thiserror = "1.0"
+
+[target.'cfg(windows)'.dependencies]
+debugger = { path = "../debugger" }
+winreg = "0.10"
+
+[dependencies.winapi]
+version = "0.3"
+features = [
+    "dbghelp",
+    "debugapi",
+    "handleapi",
+    "memoryapi",
+    "processthreadsapi",
+    "securitybaseapi",
+    "shellapi",
+    "werapi",
+    "winbase",
+    "winerror"
+]
+
+[[bin]]
+name = "dynamic-library"

--- a/src/agent/dynamic-library/src/bin/dynamic-library.rs
+++ b/src/agent/dynamic-library/src/bin/dynamic-library.rs
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#![allow(unused, warnings)]
+
+use std::process::{Command, Stdio};
+
+use anyhow::Result;
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+struct Opt {
+    #[structopt(min_values = 1)]
+    argv: Vec<String>,
+
+    #[structopt(short, long)]
+    quiet: bool,
+}
+
+#[cfg(target_os = "windows")]
+fn main() -> Result<()> {
+    let opt = Opt::from_args();
+
+    let exe = &opt.argv[0];
+    let mut cmd = Command::new(exe);
+
+    if let Some(args) = opt.argv.get(1..) {
+        cmd.args(args);
+    }
+
+    if opt.quiet {
+        cmd.stdout(Stdio::null());
+        cmd.stderr(Stdio::null());
+    }
+
+    let missing = dynamic_library::windows::find_missing(cmd)?;
+
+    if missing.is_empty() {
+        println!("no missing libraries");
+    } else {
+        for lib in missing {
+            println!("missing library: {:x?}", lib);
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn main() -> Result<()> {
+    todo!()
+}

--- a/src/agent/dynamic-library/src/bin/dynamic-library.rs
+++ b/src/agent/dynamic-library/src/bin/dynamic-library.rs
@@ -50,3 +50,8 @@ fn main() -> Result<()> {
 fn main() -> Result<()> {
     todo!()
 }
+
+#[cfg(target_os = "macos")]
+fn main() -> Result<()> {
+    todo!()
+}

--- a/src/agent/dynamic-library/src/lib.rs
+++ b/src/agent/dynamic-library/src/lib.rs
@@ -1,0 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#[cfg(target_os = "windows")]
+pub mod windows;

--- a/src/agent/dynamic-library/src/windows.rs
+++ b/src/agent/dynamic-library/src/windows.rs
@@ -1,0 +1,298 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use std::convert::TryFrom;
+use std::fmt;
+use std::io;
+use std::path::Path;
+use std::process::Command;
+
+use debugger::{DebugEventHandler, Debugger};
+use lazy_static::lazy_static;
+use regex::Regex;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum CheckDynamicLibrariesError {
+    #[error("invalid image file name")]
+    ImageFile(#[from] ImageFileError),
+
+    #[error("error accessing image global flags")]
+    ImageGlobalFlags(#[from] ImageGlobalFlagsError),
+
+    #[error("debugger error")]
+    Debugger(anyhow::Error),
+}
+
+pub fn find_missing(
+    cmd: Command,
+) -> Result<Vec<MissingDynamicLibrary>, CheckDynamicLibrariesError> {
+    let image_file = ImageFile::new(cmd.get_program())?;
+    let _sls = image_file.show_loader_snaps()?;
+
+    let mut handler = LoaderSnapsHandler::default();
+
+    let (mut dbg, _child) =
+        Debugger::init(cmd, &mut handler).map_err(CheckDynamicLibrariesError::Debugger)?;
+
+    while !dbg.target().exited() {
+        if !dbg
+            .process_event(&mut handler, 1000)
+            .map_err(CheckDynamicLibrariesError::Debugger)?
+        {
+            break;
+        }
+
+        dbg.continue_debugging()
+            .map_err(CheckDynamicLibrariesError::Debugger)?;
+    }
+
+    Ok(handler.missing_libraries())
+}
+
+#[derive(Debug, Error)]
+pub enum ImageFileError {
+    #[error("image file name is not valid utf-8")]
+    InvalidEncoding,
+
+    #[error("path to image file missing file name")]
+    MissingFileName,
+}
+
+/// Name of an image file, for setting global flags.
+#[derive(Clone, Debug)]
+pub struct ImageFile {
+    name: String,
+}
+
+impl ImageFile {
+    /// Construct a validated image file name from its name or path.
+    pub fn new(path: impl AsRef<Path>) -> Result<Self, ImageFileError> {
+        Self::try_from(path.as_ref())
+    }
+
+    /// Enable loader snap for the image file.
+    ///
+    /// Requires elevation.
+    ///
+    /// See: https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/show-loader-snaps
+    pub fn show_loader_snaps(&self) -> Result<ImageLoaderSnapsGuard, ImageGlobalFlagsError> {
+        Ok(ImageLoaderSnapsGuard::new(self.clone())?)
+    }
+}
+
+// Cannot impl for all `AsRef<Path>` due to overlapping blanket impl.
+//
+// See: rust-lang/rust#50133
+impl TryFrom<&Path> for ImageFile {
+    type Error = ImageFileError;
+
+    fn try_from(path: &Path) -> Result<Self, Self::Error> {
+        let name = path.file_name().ok_or(ImageFileError::MissingFileName)?;
+        let name = name
+            .to_str()
+            .ok_or(ImageFileError::InvalidEncoding)?
+            .to_owned();
+
+        Ok(ImageFile { name })
+    }
+}
+
+impl fmt::Display for ImageFile {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.name)
+    }
+}
+
+#[derive(Debug, Error)]
+#[error("error ")]
+pub enum ImageGlobalFlagsError {
+    #[error("could not create registry key for `{image}`")]
+    CreateKey { image: ImageFile, source: io::Error },
+
+    #[error("could not access `GlobalFlag` value of registry key for `{image}`")]
+    AccessValue { image: ImageFile, source: io::Error },
+}
+
+const GFLAGS_KEY_NAME: &str = "GlobalFlag"; // Singular
+const GFLAGS_SHOW_LOADER_SNAPS: u32 = 0x2;
+
+/// The global flags for an image file.
+///
+/// See: https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/gflags-overview
+struct ImageGlobalFlags {
+    image: ImageFile,
+}
+
+impl ImageGlobalFlags {
+    pub fn new(image: ImageFile) -> Self {
+        Self { image }
+    }
+
+    pub fn get_value(&self) -> Result<u32, ImageGlobalFlagsError> {
+        let value = self
+            .create_key()?
+            .get_value(GFLAGS_KEY_NAME)
+            .map_err(|source| ImageGlobalFlagsError::AccessValue {
+                source,
+                image: self.image.clone(),
+            })?;
+
+        Ok(value)
+    }
+
+    pub fn set_value(&self, value: u32) -> Result<(), ImageGlobalFlagsError> {
+        self.create_key()?
+            .set_value(GFLAGS_KEY_NAME, &value)
+            .map_err(|source| ImageGlobalFlagsError::AccessValue {
+                source,
+                image: self.image.clone(),
+            })?;
+
+        Ok(())
+    }
+
+    /// Create a registry key to set global flags for the image file.
+    fn create_key(&self) -> Result<winreg::RegKey, ImageGlobalFlagsError> {
+        use winreg::enums::HKEY_LOCAL_MACHINE;
+        use winreg::RegKey;
+
+        let key_name = {
+            let mut name = String::from(
+                r"SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\",
+            );
+            name.push_str(&self.image.name);
+            name
+        };
+
+        let hklm = RegKey::predef(HKEY_LOCAL_MACHINE);
+        let (key, _key_disposition) =
+            hklm.create_subkey(&key_name)
+                .map_err(|source| ImageGlobalFlagsError::CreateKey {
+                    source,
+                    image: self.image.clone(),
+                })?;
+
+        Ok(key)
+    }
+}
+
+pub struct ImageLoaderSnapsGuard {
+    /// Image file for which loader snaps should be enabled.
+    gflags: ImageGlobalFlags,
+}
+
+impl ImageLoaderSnapsGuard {
+    pub fn new(image: ImageFile) -> Result<Self, ImageGlobalFlagsError> {
+        let gflags = ImageGlobalFlags::new(image);
+        let guard = Self { gflags };
+
+        guard.enable()?;
+
+        Ok(guard)
+    }
+
+    fn enable(&self) -> Result<(), ImageGlobalFlagsError> {
+        let mut value = self.gflags.get_value()?;
+        value |= GFLAGS_SHOW_LOADER_SNAPS;
+        self.gflags.set_value(value)?;
+
+        Ok(())
+    }
+
+    fn disable(&self) -> Result<(), ImageGlobalFlagsError> {
+        let mut value = self.gflags.get_value()?;
+        value &= !GFLAGS_SHOW_LOADER_SNAPS;
+        self.gflags.set_value(value)?;
+
+        Ok(())
+    }
+}
+
+impl Drop for ImageLoaderSnapsGuard {
+    fn drop(&mut self) {
+        let _ = self.disable();
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MissingDynamicLibrary {
+    name: String,
+    parent: String,
+    status: u32,
+}
+
+impl MissingDynamicLibrary {
+    pub fn parse(text: &str) -> Option<Self> {
+        let captures = MISSING_DLL_RE.captures(text)?;
+
+        let name = captures.get(1)?.as_str().to_owned();
+        let parent = captures.get(2)?.as_str().to_owned();
+        let status = u32::from_str_radix(captures.get(3)?.as_str(), 16).ok()?;
+
+        Some(Self {
+            name,
+            parent,
+            status,
+        })
+    }
+}
+
+#[derive(Default)]
+pub struct LoaderSnapsHandler {
+    pub debug_strings: Vec<String>,
+}
+
+impl LoaderSnapsHandler {
+    pub fn missing_libraries(&self) -> Vec<MissingDynamicLibrary> {
+        let mut missing = vec![];
+
+        for text in &self.debug_strings {
+            if let Some(lib) = MissingDynamicLibrary::parse(text) {
+                missing.push(lib);
+            }
+        }
+
+        missing
+    }
+}
+
+impl DebugEventHandler for LoaderSnapsHandler {
+    fn on_output_debug_string(&mut self, _debugger: &mut Debugger, message: String) {
+        self.debug_strings.push(message.clone());
+    }
+}
+
+lazy_static! {
+    static ref MISSING_DLL_RE: Regex = Regex::new(
+        r#"[0-9a-f]+:[0-9a-f]+ @ [0-9a-f]+ - LdrpProcessWork - ERROR: Unable to load DLL: "(.+)", Parent Module: "(.+)", Status: 0x([0-9a-f]+)"#
+    ).unwrap();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_missing_dynamic_library_parse_none() {
+        // Broad error message about failed process init.
+        const NOT_MISSING_TEXT: &str = "7c48:2ac4 @ 371984000 - LdrpInitializationFailure - ERROR: Process initialization failed with status 0xc0000135";
+
+        let not_missing = MissingDynamicLibrary::parse(NOT_MISSING_TEXT);
+
+        assert!(not_missing.is_none());
+    }
+
+    #[test]
+    fn test_missing_dynamic_library_parse_some() {
+        // Specific error message that tells us the missing library.
+        const MISSING_TEXT: &str = r#"7c48:57c8 @ 371984000 - LdrpProcessWork - ERROR: Unable to load DLL: "lost.dll", Parent Module: "C:\my\project\fuzz.exe", Status: 0xc0000135"#;
+
+        let missing =
+            MissingDynamicLibrary::parse(MISSING_TEXT).expect("failed to parse missing DLL");
+
+        assert_eq!(missing.name, "lost.dll");
+        assert_eq!(missing.parent, r"C:\my\project\fuzz.exe");
+        assert_eq!(missing.status, 0xc0000135);
+    }
+}

--- a/src/agent/dynamic-library/src/windows.rs
+++ b/src/agent/dynamic-library/src/windows.rs
@@ -77,7 +77,7 @@ impl ImageFile {
     ///
     /// See: https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/show-loader-snaps
     pub fn show_loader_snaps(&self) -> Result<ImageLoaderSnapsGuard, ImageGlobalFlagsError> {
-        Ok(ImageLoaderSnapsGuard::new(self.clone())?)
+        ImageLoaderSnapsGuard::new(self.clone())
     }
 }
 
@@ -259,7 +259,7 @@ impl LoaderSnapsHandler {
 
 impl DebugEventHandler for LoaderSnapsHandler {
     fn on_output_debug_string(&mut self, _debugger: &mut Debugger, message: String) {
-        self.debug_strings.push(message.clone());
+        self.debug_strings.push(message);
     }
 }
 


### PR DESCRIPTION
Add a CLI tool and library code to debug missing dynamic library errors on Windows.

The implementation manually edits the registry [global flags for an image file](https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/gflags-overview) to temporarily enable [loader snaps](https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/show-loader-snaps), runs the target under our custom debugger to collect the debug output strings, then parses them for informative loading errors. It does not depend on the presence of `gflags.exe`.

This detects both dynamic linking (and thus process startup) errors, as well as dynamic loading (`LoadLibrary`) errors. It can report multiple missing dynamically-linked libraries.

Towards #1706.