### PR TITLE
Adding auto scale via cli

### DIFF
--- a/src/api-service/__app__/onefuzzlib/azure/auto_scale.py
+++ b/src/api-service/__app__/onefuzzlib/azure/auto_scale.py
@@ -192,11 +192,11 @@ def create_auto_scale_profile(
     )
 
 
-
 def default_auto_scale_profile(queue_uri: str, scaleset_size: int) -> AutoscaleProfile:
     return create_auto_scale_profile(
         queue_uri, 1, scaleset_size, scaleset_size, 1, 10, 1, 15
     )
+
 
 def setup_auto_scale_diagnostics(
     auto_scale_resource_uri: str,

--- a/src/api-service/__app__/onefuzzlib/workers/scalesets.py
+++ b/src/api-service/__app__/onefuzzlib/workers/scalesets.py
@@ -27,7 +27,6 @@ from onefuzztypes.models import Error
 from onefuzztypes.models import Scaleset as BASE_SCALESET
 from onefuzztypes.models import ScalesetNodeState
 from onefuzztypes.primitives import PoolName, Region
-from onefuzztypes.requests import AutoScaleOptions
 
 from ..__version__ import __version__
 from ..azure.auth import build_auth

--- a/src/api-service/__app__/onefuzzlib/workers/scalesets.py
+++ b/src/api-service/__app__/onefuzzlib/workers/scalesets.py
@@ -95,7 +95,6 @@ class Scaleset(BASE_SCALESET, ORMMixin):
         tags: Dict[str, str],
         client_id: Optional[UUID] = None,
         client_object_id: Optional[UUID] = None,
-        auto_scale_options: Optional[AutoScaleOptions] = None,
     ) -> "Scaleset":
         entry = cls(
             pool_name=pool_name,

--- a/src/api-service/__app__/onefuzzlib/workers/scalesets.py
+++ b/src/api-service/__app__/onefuzzlib/workers/scalesets.py
@@ -22,14 +22,20 @@ from onefuzztypes.events import (
     EventScalesetResizeScheduled,
     EventScalesetStateUpdated,
 )
+from onefuzztypes.models import AutoScale as BASE_AUTOSCALE
 from onefuzztypes.models import Error
 from onefuzztypes.models import Scaleset as BASE_SCALESET
 from onefuzztypes.models import ScalesetNodeState
 from onefuzztypes.primitives import PoolName, Region
+from onefuzztypes.requests import AutoScaleOptions
 
 from ..__version__ import __version__
 from ..azure.auth import build_auth
-from ..azure.auto_scale import add_auto_scale_to_vmss, create_auto_scale_profile
+from ..azure.auto_scale import (
+    add_auto_scale_to_vmss,
+    create_auto_scale_profile,
+    default_auto_scale_profile,
+)
 from ..azure.image import get_os
 from ..azure.network import Network
 from ..azure.queue import get_resource_id
@@ -89,6 +95,7 @@ class Scaleset(BASE_SCALESET, ORMMixin):
         tags: Dict[str, str],
         client_id: Optional[UUID] = None,
         client_object_id: Optional[UUID] = None,
+        auto_scale_options: Optional[AutoScaleOptions] = None,
     ) -> "Scaleset":
         entry = cls(
             pool_name=pool_name,
@@ -104,6 +111,7 @@ class Scaleset(BASE_SCALESET, ORMMixin):
             tags=tags,
         )
         entry.save()
+
         send_event(
             EventScalesetCreated(
                 scaleset_id=entry.scaleset_id,
@@ -874,8 +882,67 @@ class Scaleset(BASE_SCALESET, ORMMixin):
             logging.error(capacity_failed)
             return capacity_failed
 
-        auto_scale_profile = create_auto_scale_profile(
-            capacity, capacity, pool_queue_uri
-        )
+        auto_scale_config = AutoScale.get_settings_for_scaleset(self.scaleset_id)
+        if auto_scale_config is None:
+            auto_scale_profile = default_auto_scale_profile(pool_queue_uri, capacity)
+        else:
+            logging.error("Using existing auto scale settings from database")
+            auto_scale_profile = create_auto_scale_profile(
+                pool_queue_uri,
+                auto_scale_config.min,
+                auto_scale_config.max,
+                auto_scale_config.default,
+                auto_scale_config.scale_out_amount,
+                auto_scale_config.scale_out_cooldown,
+                auto_scale_config.scale_in_amount,
+                auto_scale_config.scale_in_cooldown,
+            )
         logging.info("Added auto scale resource to scaleset: %s" % self.scaleset_id)
         return add_auto_scale_to_vmss(self.scaleset_id, auto_scale_profile)
+
+
+class AutoScale(BASE_AUTOSCALE, ORMMixin):
+    @classmethod
+    def create(
+        cls,
+        *,
+        scaleset_id: UUID,
+        min: int,
+        max: int,
+        default: int,
+        scale_out_amount: int,
+        scale_out_cooldown: int,
+        scale_in_amount: int,
+        scale_in_cooldown: int,
+    ) -> "AutoScale":
+        entry = cls(
+            scaleset_id=scaleset_id,
+            min=min,
+            max=max,
+            default=default,
+            scale_out_amount=scale_out_amount,
+            scale_out_cooldown=scale_out_cooldown,
+            scale_in_amount=scale_in_amount,
+            scale_in_cooldown=scale_in_cooldown,
+        )
+        entry.save()
+        return entry
+
+    @classmethod
+    def get_settings_for_scaleset(cls, scaleset_id: UUID) -> Union["AutoScale", None]:
+        autoscale = cls.search(query={"scaleset_id": [scaleset_id]})
+        if not autoscale:
+            logging.info(
+                "Could not find any auto scale settings for scaleset %s" % scaleset_id
+            )
+            return None
+        if len(autoscale) != 1:
+            logging.info(
+                "Found more than one autoscaling setting for scaleset %s" % scaleset_id
+            )
+
+        return autoscale[0]
+
+    @classmethod
+    def key_fields(cls) -> Tuple[str, None]:
+        return ("scaleset_id", None)

--- a/src/api-service/__app__/scaleset/__init__.py
+++ b/src/api-service/__app__/scaleset/__init__.py
@@ -20,7 +20,7 @@ from ..onefuzzlib.config import InstanceConfig
 from ..onefuzzlib.endpoint_authorization import call_if_user, check_can_manage_pools
 from ..onefuzzlib.request import not_ok, ok, parse_request
 from ..onefuzzlib.workers.pools import Pool
-from ..onefuzzlib.workers.scalesets import Scaleset
+from ..onefuzzlib.workers.scalesets import AutoScale, Scaleset
 
 
 def get(req: func.HttpRequest) -> func.HttpResponse:
@@ -104,6 +104,19 @@ def post(req: func.HttpRequest) -> func.HttpResponse:
         ephemeral_os_disks=request.ephemeral_os_disks,
         tags=tags,
     )
+
+    if request.auto_scale:
+        AutoScale.create(
+            scaleset_id=scaleset.scaleset_id,
+            min=request.auto_scale.min,
+            max=request.auto_scale.max,
+            default=request.auto_scale.default,
+            scale_out_amount=request.auto_scale.scale_out_amount,
+            scale_out_cooldown=request.auto_scale.scale_out_cooldown,
+            scale_in_amount=request.auto_scale.scale_in_amount,
+            scale_in_cooldown=request.auto_scale.scale_in_cooldown,
+        )
+
     # don't return auths during create, only 'get' with include_auth
     scaleset.auth = None
     return ok(scaleset)

--- a/src/cli/onefuzz/api.py
+++ b/src/cli/onefuzz/api.py
@@ -1357,6 +1357,11 @@ class Scaleset(Endpoint):
         spot_instances: bool = False,
         ephemeral_os_disks: bool = False,
         tags: Optional[Dict[str, str]] = None,
+        min_instances: Optional[int] = 1,
+        scale_out_amount: Optional[int] = 1,
+        scale_out_cooldown: Optional[int] = 10,
+        scale_in_amount: Optional[int] = 1,
+        scale_in_cooldown: Optional[int] = 15,
     ) -> models.Scaleset:
         self.logger.debug("create scaleset")
 
@@ -1372,6 +1377,16 @@ class Scaleset(Endpoint):
             else:
                 raise NotImplementedError
 
+        auto_scale = requests.AutoScaleOptions(
+            min=min_instances,
+            max=size,
+            default=size,
+            scale_out_amount=scale_out_amount,
+            scale_out_cooldown=scale_out_cooldown,
+            scale_in_amount=scale_in_amount,
+            scale_in_cooldown=scale_in_cooldown,
+        )
+
         return self._req_model(
             "POST",
             models.Scaleset,
@@ -1384,6 +1399,7 @@ class Scaleset(Endpoint):
                 spot_instances=spot_instances,
                 ephemeral_os_disks=ephemeral_os_disks,
                 tags=tags,
+                auto_scale=auto_scale,
             ),
         )
 

--- a/src/pytypes/onefuzztypes/models.py
+++ b/src/pytypes/onefuzztypes/models.py
@@ -661,6 +661,17 @@ class Scaleset(BaseModel):
     tags: Dict[str, str] = Field(default_factory=lambda: {})
 
 
+class AutoScale(BaseModel):
+    scaleset_id: UUID
+    min: int = Field(ge=1)
+    max: int = Field(ge=1)
+    default: int = Field(ge=1)
+    scale_out_amount: int = Field(ge=1)
+    scale_out_cooldown: int = Field(ge=1)
+    scale_in_amount: int = Field(ge=1)
+    scale_in_cooldown: int = Field(ge=1)
+
+
 class NotificationConfig(BaseModel):
     config: NotificationTemplate
 

--- a/src/pytypes/onefuzztypes/requests.py
+++ b/src/pytypes/onefuzztypes/requests.py
@@ -169,6 +169,16 @@ class ScalesetUpdate(BaseRequest):
     size: Optional[int] = Field(ge=1)
 
 
+class AutoScaleOptions(BaseModel):
+    min: int = Field(ge=1)
+    max: int = Field(ge=1)
+    default: int = Field(ge=1)
+    scale_out_amount: int = Field(ge=1)
+    scale_out_cooldown: int = Field(ge=1)
+    scale_in_amount: int = Field(ge=1)
+    scale_in_cooldown: int = Field(ge=1)
+
+
 class ScalesetCreate(BaseRequest):
     pool_name: PoolName
     vm_sku: str
@@ -178,6 +188,7 @@ class ScalesetCreate(BaseRequest):
     spot_instances: bool
     ephemeral_os_disks: bool = Field(default=False)
     tags: Dict[str, str]
+    auto_scale: Optional[AutoScaleOptions]
 
 
 class ContainerGet(BaseRequest):


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_

This change introduces a few options related to auto scaling when creating a new scale set.

## PR Checklist
* [ ] Closes #1716 
* [ ] Tests added/passed
* [x] Requires documentation to be updated

## Info on Pull Request

_What does this include?_

* The following options are added to `onefuzz scalesets create`

```
  --min_instances MIN_INSTANCES
                        (default: 1)
  --scale_out_amount SCALE_OUT_AMOUNT
                        (default: 1)
  --scale_out_cooldown SCALE_OUT_COOLDOWN
                        (default: 10)
  --scale_in_amount SCALE_IN_AMOUNT
                        (default: 1)
  --scale_in_cooldown SCALE_IN_COOLDOWN
                        (default: 15)
```

* Added a new table `AutoScale`
* **Newly created auto scale resources are enabled by default**. This means after this PR is merged any newly created scale sets will have auto scale enabled by default

## Validation Steps Performed

_How does someone test & validate?_

### Default options work
* Create a new scale set from cli by doing `onefuzz scalesets create test 3`
* Verify the scaleset is correctly created
* Verify auto scale is enabled
* Verify Azure Table that the entry is present

### Custom options work
* Create a new scale set from cli using the same command as above but also with  `--min_instances 2 --scale_out_cooldown 30`
* Verify the scale set is correctly created
* Verify auto scale is enabled
* Verify the configuration values are correct for auto scale
* Verify the entry is Azure Table has the correct values

