### PR TITLE
Add Linux dynamic library checks using `ldd`/`LD_DEBUG`

### DIFF
--- a/src/agent/dynamic-library/src/bin/dynamic-library.rs
+++ b/src/agent/dynamic-library/src/bin/dynamic-library.rs
@@ -60,11 +60,6 @@ fn find_missing(cmd: Command) -> Result<Vec<String>> {
 }
 
 #[cfg(target_os = "macos")]
-fn main() -> Result<()> {
-    todo!()
-}
-
-#[cfg(target_os = "macos")]
 fn find_missing(cmd: Command) -> Result<Vec<String>> {
     todo!()
 }

--- a/src/agent/dynamic-library/src/bin/dynamic-library.rs
+++ b/src/agent/dynamic-library/src/bin/dynamic-library.rs
@@ -55,6 +55,7 @@ fn find_missing(cmd: Command) -> Result<Vec<String>> {
 #[cfg(target_os = "windows")]
 fn find_missing(cmd: Command) -> Result<Vec<String>> {
     Ok(dynamic_library::windows::find_missing(cmd)?
+        .into_iter()
         .map(|m| m.name)
         .collect())
 }

--- a/src/agent/dynamic-library/src/bin/dynamic-library.rs
+++ b/src/agent/dynamic-library/src/bin/dynamic-library.rs
@@ -65,6 +65,6 @@ fn main() -> Result<()> {
 }
 
 #[cfg(target_os = "macos")]
-fn main() -> Result<()> {
+fn find_missing(cmd: Command) -> Result<Vec<String>> {
     todo!()
 }

--- a/src/agent/dynamic-library/src/bin/dynamic-library.rs
+++ b/src/agent/dynamic-library/src/bin/dynamic-library.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-
-#![allow(unused, warnings)]
+#![cfg_attr(target_os = "macos", allow(unused, warnings))]
 
 use std::process::{Command, Stdio};
 
@@ -17,7 +16,6 @@ struct Opt {
     quiet: bool,
 }
 
-#[cfg(target_os = "windows")]
 fn main() -> Result<()> {
     let opt = Opt::from_args();
 
@@ -33,7 +31,7 @@ fn main() -> Result<()> {
         cmd.stderr(Stdio::null());
     }
 
-    let missing = dynamic_library::windows::find_missing(cmd)?;
+    let missing = find_missing(cmd)?;
 
     if missing.is_empty() {
         println!("no missing libraries");
@@ -47,6 +45,21 @@ fn main() -> Result<()> {
 }
 
 #[cfg(target_os = "linux")]
+fn find_missing(cmd: Command) -> Result<Vec<String>> {
+    Ok(dynamic_library::linux::find_missing(cmd)?
+        .drain()
+        .map(|m| m.name)
+        .collect())
+}
+
+#[cfg(target_os = "windows")]
+fn find_missing(cmd: Command) -> Result<Vec<String>> {
+    Ok(dynamic_library::windows::find_missing(cmd)?
+        .map(|m| m.name)
+        .collect())
+}
+
+#[cfg(target_os = "macos")]
 fn main() -> Result<()> {
     todo!()
 }

--- a/src/agent/dynamic-library/src/lib.rs
+++ b/src/agent/dynamic-library/src/lib.rs
@@ -1,5 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#[cfg(target_os = "linux")]
+pub mod linux;
+
 #[cfg(target_os = "windows")]
 pub mod windows;

--- a/src/agent/dynamic-library/src/linux.rs
+++ b/src/agent/dynamic-library/src/linux.rs
@@ -41,6 +41,8 @@ pub struct MissingDynamicLibrary {
 
 /// Dynamic library searches, as extracted from the dynamic linker debug log output
 /// obtained by setting `LD_DEBUG=libs`.
+///
+/// For more info about `LD_DEBUG`, see the docs for ld.so(8).
 pub struct LdDebugLogs {
     pub searches: HashMap<LdDebugSearchQuery, LdDebugSearchResult>,
 }

--- a/src/agent/dynamic-library/src/linux.rs
+++ b/src/agent/dynamic-library/src/linux.rs
@@ -1,0 +1,278 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#![allow(clippy::manual_flatten)]
+
+use std::collections::{HashMap, HashSet};
+use std::ffi::OsStr;
+use std::io;
+use std::path::Path;
+use std::process::Command;
+
+use lazy_static::lazy_static;
+use regex::Regex;
+
+pub fn find_missing(mut cmd: Command) -> Result<HashSet<MissingDynamicLibrary>, io::Error> {
+    // Check for missing _linked_ dynamic libraries.
+    //
+    // We must do this first to avoid false positives or negatives when parsing `LD_DEBUG`
+    // output. The debug output gets truncated when a linked shared library is not found,
+    // since any in-progress searches are aborted.
+    let linked = LinkedDynamicLibraries::search(cmd.get_program())?;
+    let missing_linked = linked.not_found();
+
+    if !missing_linked.is_empty() {
+        return Ok(missing_linked);
+    }
+
+    // Check for missing _loaded_ dynamic libraries.
+    //
+    // Invoke the command with `LD_DEBUG` set, and parse the debug output.
+    cmd.env("LD_DEBUG", "libs");
+    let output = cmd.output()?;
+    let logs = LdDebugLogs::parse(&*output.stderr);
+
+    Ok(logs.missing())
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct MissingDynamicLibrary {
+    pub name: String,
+}
+
+/// Dynamic library searches, as extracted from the dynamic linker debug log output
+/// obtained by setting `LD_DEBUGS=libs`.
+pub struct LdDebugLogs {
+    pub searches: HashMap<LdDebugSearchQuery, LdDebugSearchResult>,
+}
+
+impl LdDebugLogs {
+    /// Extract attempted library searches from the debug logs.
+    ///
+    /// A search query is detected on a thread if we find message like `find
+    /// library=libmycode.so`.
+    ///
+    /// We mark a library as found if and only if we find a matching log message like
+    /// `calling init: /path/to/libmycode.so`, on the same thread.
+    ///
+    /// This is only really useful for detecting `dlopen()` failures, when dynamic linking
+    /// succeeds. If process startup fails due to a missing linked library dependency,
+    /// then the dynamic linker's search will stop early, and debug logs will be logically
+    /// truncated. When that happens, we can get both false negatives (we'll only see the
+    /// _first_ missing library) and false positives (we won't see evidence of module
+    /// initialization for libraries that _were_ found).
+    pub fn parse<R: io::Read>(readable: R) -> Self {
+        use std::io::prelude::*;
+
+        let mut searches = HashMap::default();
+
+        let reader = io::BufReader::new(readable);
+
+        for line in reader.lines() {
+            // If ok, line is valid UTF-8.
+            if let Ok(line) = line {
+                if let Some(query) = LdDebugSearchQuery::parse(&line) {
+                    searches.insert(query, LdDebugSearchResult::NotFound);
+                    continue;
+                }
+
+                if let Some(found) = FoundLibrary::parse(&line) {
+                    let query = found.query();
+                    let result = LdDebugSearchResult::Found(found);
+                    searches.insert(query, result);
+                    continue;
+                }
+            }
+        }
+
+        Self { searches }
+    }
+
+    pub fn missing(&self) -> HashSet<MissingDynamicLibrary> {
+        let mut missing = HashSet::default();
+
+        for (query, result) in &self.searches {
+            if *result == LdDebugSearchResult::NotFound {
+                let lib = MissingDynamicLibrary {
+                    name: query.name.clone(),
+                };
+                missing.insert(lib);
+            }
+        }
+
+        missing
+    }
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct LdDebugSearchQuery {
+    /// PID of the thread where the search query occurred.
+    pub pid: u32,
+
+    /// Name of the shared library that was searched for.
+    pub name: String,
+}
+
+impl LdDebugSearchQuery {
+    pub fn parse(text: &str) -> Option<Self> {
+        let captures = FIND_LIBRARY_RE.captures(text)?;
+
+        let pid = captures.get(1)?.as_str().parse().ok()?;
+        let name = captures.get(2)?.as_str().to_owned();
+
+        Some(Self { pid, name })
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum LdDebugSearchResult {
+    NotFound,
+    Found(FoundLibrary),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FoundLibrary {
+    /// PID of the thread where the satisfied search query occurred.
+    pub pid: u32,
+
+    /// Absolute path of the found shared library.
+    ///
+    /// Guaranteed to have a file name (as a `Path`).
+    pub path: String,
+}
+
+impl FoundLibrary {
+    pub fn name(&self) -> String {
+        // Can't panic due to check in `parse_found()`.
+        let name = Path::new(&self.path).file_name().unwrap();
+
+        // Can't panic because `self.path` is a `String`.
+        let name = name.to_str().unwrap();
+
+        name.to_owned()
+    }
+
+    pub fn query(&self) -> LdDebugSearchQuery {
+        LdDebugSearchQuery {
+            pid: self.pid,
+            name: self.name(),
+        }
+    }
+}
+
+impl FoundLibrary {
+    pub fn parse(text: &str) -> Option<Self> {
+        let captures = INIT_LIBRARY_RE.captures(text)?;
+
+        let pid = captures.get(1)?.as_str().parse().ok()?;
+        let path = captures.get(2)?.as_str().to_owned();
+
+        // Ensure `path` is a file path, and has a file name.
+        Path::new(&path).file_name()?;
+
+        Some(Self { pid, path })
+    }
+}
+
+lazy_static! {
+    // Captures thread PID, file name of requested library.
+    static ref FIND_LIBRARY_RE: Regex =
+        Regex::new(r"(\d+):\s+find library=(.+) \[\d+\]; searching").unwrap();
+
+    // Captures thread PID, absolute path of found library.
+    static ref INIT_LIBRARY_RE: Regex =
+        Regex::new(r"(\d+):\s+calling init: (.+)").unwrap();
+
+    // Captures shared library name, absolute path of found library.
+    static ref LDD_FOUND: Regex =
+        Regex::new(r"([^\s]+) => (.+) \(0x[0-9a-f]+\)").unwrap();
+
+    // Captures shared library name.
+    static ref LDD_NOT_FOUND: Regex =
+        Regex::new(r"([^\s]+) => not found").unwrap();
+}
+
+struct LddFound {
+    name: String,
+    path: String,
+}
+
+impl LddFound {
+    pub fn parse(text: &str) -> Option<Self> {
+        let captures = LDD_FOUND.captures(text)?;
+
+        let name = captures.get(1)?.as_str().to_owned();
+        let path = captures.get(2)?.as_str().to_owned();
+
+        Some(Self { name, path })
+    }
+}
+
+struct LddNotFound {
+    name: String,
+}
+
+impl LddNotFound {
+    pub fn parse(text: &str) -> Option<Self> {
+        let captures = LDD_NOT_FOUND.captures(text)?;
+
+        let name = captures.get(1)?.as_str().to_owned();
+
+        Some(Self { name })
+    }
+}
+
+#[derive(Debug)]
+pub struct LinkedDynamicLibraries {
+    pub libraries: HashMap<String, Option<String>>,
+}
+
+impl LinkedDynamicLibraries {
+    pub fn search(module: impl AsRef<OsStr>) -> Result<Self, io::Error> {
+        let mut cmd = Command::new("ldd");
+        cmd.arg(module);
+
+        let output = cmd.output()?;
+        let linked = Self::parse(&*output.stdout);
+
+        Ok(linked)
+    }
+
+    pub fn parse<R: io::Read>(readable: R) -> Self {
+        use std::io::prelude::*;
+
+        let mut libraries = HashMap::default();
+
+        let reader = io::BufReader::new(readable);
+
+        for line in reader.lines() {
+            if let Ok(line) = line {
+                if let Some(not_found) = LddNotFound::parse(&line) {
+                    libraries.insert(not_found.name, None);
+                }
+
+                if let Some(found) = LddFound::parse(&line) {
+                    libraries.insert(found.name, Some(found.path));
+                }
+            }
+        }
+
+        Self { libraries }
+    }
+
+    pub fn not_found(&self) -> HashSet<MissingDynamicLibrary> {
+        let mut missing = HashSet::default();
+
+        for linked in &self.libraries {
+            if let (name, None) = linked {
+                let name = name.clone();
+                let lib = MissingDynamicLibrary { name };
+                missing.insert(lib);
+            }
+        }
+
+        missing
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/agent/dynamic-library/src/linux.rs
+++ b/src/agent/dynamic-library/src/linux.rs
@@ -40,7 +40,7 @@ pub struct MissingDynamicLibrary {
 }
 
 /// Dynamic library searches, as extracted from the dynamic linker debug log output
-/// obtained by setting `LD_DEBUGS=libs`.
+/// obtained by setting `LD_DEBUG=libs`.
 pub struct LdDebugLogs {
     pub searches: HashMap<LdDebugSearchQuery, LdDebugSearchResult>,
 }

--- a/src/agent/dynamic-library/src/linux/ld_debug_output_missing.txt
+++ b/src/agent/dynamic-library/src/linux/ld_debug_output_missing.txt
@@ -1,0 +1,446 @@
+      8579:	find library=libstdc++.so.6 [0]; searching
+      8579:	 search path=./tls/haswell/x86_64:./tls/haswell:./tls/x86_64:./tls:./haswell/x86_64:./haswell:./x86_64:.		(LD_LIBRARY_PATH)
+      8579:	  trying file=./tls/haswell/x86_64/libstdc++.so.6
+      8579:	  trying file=./tls/haswell/libstdc++.so.6
+      8579:	  trying file=./tls/x86_64/libstdc++.so.6
+      8579:	  trying file=./tls/libstdc++.so.6
+      8579:	  trying file=./haswell/x86_64/libstdc++.so.6
+      8579:	  trying file=./haswell/libstdc++.so.6
+      8579:	  trying file=./x86_64/libstdc++.so.6
+      8579:	  trying file=./libstdc++.so.6
+      8579:	 search cache=/etc/ld.so.cache
+      8579:	  trying file=/usr/lib/x86_64-linux-gnu/libstdc++.so.6
+      8579:
+      8579:	find library=libpthread.so.0 [0]; searching
+      8579:	 search path=./tls/haswell/x86_64:./tls/haswell:./tls/x86_64:./tls:./haswell/x86_64:./haswell:./x86_64:.		(LD_LIBRARY_PATH)
+      8579:	  trying file=./tls/haswell/x86_64/libpthread.so.0
+      8579:	  trying file=./tls/haswell/libpthread.so.0
+      8579:	  trying file=./tls/x86_64/libpthread.so.0
+      8579:	  trying file=./tls/libpthread.so.0
+      8579:	  trying file=./haswell/x86_64/libpthread.so.0
+      8579:	  trying file=./haswell/libpthread.so.0
+      8579:	  trying file=./x86_64/libpthread.so.0
+      8579:	  trying file=./libpthread.so.0
+      8579:	 search cache=/etc/ld.so.cache
+      8579:	  trying file=/lib/x86_64-linux-gnu/libpthread.so.0
+      8579:
+      8579:	find library=librt.so.1 [0]; searching
+      8579:	 search path=./tls/haswell/x86_64:./tls/haswell:./tls/x86_64:./tls:./haswell/x86_64:./haswell:./x86_64:.		(LD_LIBRARY_PATH)
+      8579:	  trying file=./tls/haswell/x86_64/librt.so.1
+      8579:	  trying file=./tls/haswell/librt.so.1
+      8579:	  trying file=./tls/x86_64/librt.so.1
+      8579:	  trying file=./tls/librt.so.1
+      8579:	  trying file=./haswell/x86_64/librt.so.1
+      8579:	  trying file=./haswell/librt.so.1
+      8579:	  trying file=./x86_64/librt.so.1
+      8579:	  trying file=./librt.so.1
+      8579:	 search cache=/etc/ld.so.cache
+      8579:	  trying file=/lib/x86_64-linux-gnu/librt.so.1
+      8579:
+      8579:	find library=libm.so.6 [0]; searching
+      8579:	 search path=./tls/haswell/x86_64:./tls/haswell:./tls/x86_64:./tls:./haswell/x86_64:./haswell:./x86_64:.		(LD_LIBRARY_PATH)
+      8579:	  trying file=./tls/haswell/x86_64/libm.so.6
+      8579:	  trying file=./tls/haswell/libm.so.6
+      8579:	  trying file=./tls/x86_64/libm.so.6
+      8579:	  trying file=./tls/libm.so.6
+      8579:	  trying file=./haswell/x86_64/libm.so.6
+      8579:	  trying file=./haswell/libm.so.6
+      8579:	  trying file=./x86_64/libm.so.6
+      8579:	  trying file=./libm.so.6
+      8579:	 search cache=/etc/ld.so.cache
+      8579:	  trying file=/lib/x86_64-linux-gnu/libm.so.6
+      8579:
+      8579:	find library=libdl.so.2 [0]; searching
+      8579:	 search path=./tls/haswell/x86_64:./tls/haswell:./tls/x86_64:./tls:./haswell/x86_64:./haswell:./x86_64:.		(LD_LIBRARY_PATH)
+      8579:	  trying file=./tls/haswell/x86_64/libdl.so.2
+      8579:	  trying file=./tls/haswell/libdl.so.2
+      8579:	  trying file=./tls/x86_64/libdl.so.2
+      8579:	  trying file=./tls/libdl.so.2
+      8579:	  trying file=./haswell/x86_64/libdl.so.2
+      8579:	  trying file=./haswell/libdl.so.2
+      8579:	  trying file=./x86_64/libdl.so.2
+      8579:	  trying file=./libdl.so.2
+      8579:	 search cache=/etc/ld.so.cache
+      8579:	  trying file=/lib/x86_64-linux-gnu/libdl.so.2
+      8579:
+      8579:	find library=libgcc_s.so.1 [0]; searching
+      8579:	 search path=./tls/haswell/x86_64:./tls/haswell:./tls/x86_64:./tls:./haswell/x86_64:./haswell:./x86_64:.		(LD_LIBRARY_PATH)
+      8579:	  trying file=./tls/haswell/x86_64/libgcc_s.so.1
+      8579:	  trying file=./tls/haswell/libgcc_s.so.1
+      8579:	  trying file=./tls/x86_64/libgcc_s.so.1
+      8579:	  trying file=./tls/libgcc_s.so.1
+      8579:	  trying file=./haswell/x86_64/libgcc_s.so.1
+      8579:	  trying file=./haswell/libgcc_s.so.1
+      8579:	  trying file=./x86_64/libgcc_s.so.1
+      8579:	  trying file=./libgcc_s.so.1
+      8579:	 search cache=/etc/ld.so.cache
+      8579:	  trying file=/lib/x86_64-linux-gnu/libgcc_s.so.1
+      8579:
+      8579:	find library=libc.so.6 [0]; searching
+      8579:	 search path=./tls/haswell/x86_64:./tls/haswell:./tls/x86_64:./tls:./haswell/x86_64:./haswell:./x86_64:.		(LD_LIBRARY_PATH)
+      8579:	  trying file=./tls/haswell/x86_64/libc.so.6
+      8579:	  trying file=./tls/haswell/libc.so.6
+      8579:	  trying file=./tls/x86_64/libc.so.6
+      8579:	  trying file=./tls/libc.so.6
+      8579:	  trying file=./haswell/x86_64/libc.so.6
+      8579:	  trying file=./haswell/libc.so.6
+      8579:	  trying file=./x86_64/libc.so.6
+      8579:	  trying file=./libc.so.6
+      8579:	 search cache=/etc/ld.so.cache
+      8579:	  trying file=/lib/x86_64-linux-gnu/libc.so.6
+      8579:
+      8579:
+      8579:	calling init: /lib/x86_64-linux-gnu/libpthread.so.0
+      8579:
+      8579:
+      8579:	calling preinit: ./fuzz.exe
+      8579:
+      8579:	./fuzz.exe: error: symbol lookup error: undefined symbol: __isoc99_printf (fatal)
+      8579:	./fuzz.exe: error: symbol lookup error: undefined symbol: __isoc99_sprintf (fatal)
+      8579:	./fuzz.exe: error: symbol lookup error: undefined symbol: __isoc99_snprintf (fatal)
+      8579:	./fuzz.exe: error: symbol lookup error: undefined symbol: __isoc99_fprintf (fatal)
+      8579:	./fuzz.exe: error: symbol lookup error: undefined symbol: __isoc99_vprintf (fatal)
+      8579:	./fuzz.exe: error: symbol lookup error: undefined symbol: __isoc99_vsprintf (fatal)
+      8579:	./fuzz.exe: error: symbol lookup error: undefined symbol: __isoc99_vsnprintf (fatal)
+      8579:	./fuzz.exe: error: symbol lookup error: undefined symbol: __isoc99_vfprintf (fatal)
+      8579:	./fuzz.exe: error: symbol lookup error: undefined symbol: __cxa_rethrow_primary_exception (fatal)
+      8579:	./fuzz.exe: error: symbol lookup error: undefined symbol: swift_demangle (fatal)
+      8579:
+      8579:	calling init: /lib/x86_64-linux-gnu/libc.so.6
+      8579:
+      8579:
+      8579:	calling init: /lib/x86_64-linux-gnu/libgcc_s.so.1
+      8579:
+      8579:
+      8579:	calling init: /lib/x86_64-linux-gnu/libdl.so.2
+      8579:
+      8579:
+      8579:	calling init: /lib/x86_64-linux-gnu/libm.so.6
+      8579:
+      8579:
+      8579:	calling init: /lib/x86_64-linux-gnu/librt.so.1
+      8579:
+      8579:
+      8579:	calling init: /usr/lib/x86_64-linux-gnu/libstdc++.so.6
+      8579:
+      8579:
+      8579:	initialize program: ./fuzz.exe
+      8579:
+      8579:
+      8579:	transferring control: ./fuzz.exe
+      8579:
+      8579:	find library=libmycode.so [0]; searching
+      8579:	 search path=./tls/haswell/x86_64:./tls/haswell:./tls/x86_64:./tls:./haswell/x86_64:./haswell:./x86_64:.		(LD_LIBRARY_PATH)
+      8579:	  trying file=./tls/haswell/x86_64/libmycode.so
+      8579:	  trying file=./tls/haswell/libmycode.so
+      8579:	  trying file=./tls/x86_64/libmycode.so
+      8579:	  trying file=./tls/libmycode.so
+      8579:	  trying file=./haswell/x86_64/libmycode.so
+      8579:	  trying file=./haswell/libmycode.so
+      8579:	  trying file=./x86_64/libmycode.so
+      8579:	  trying file=./libmycode.so
+      8579:	 search cache=/etc/ld.so.cache
+      8579:	 search path=/lib/x86_64-linux-gnu/tls/haswell/x86_64:/lib/x86_64-linux-gnu/tls/haswell:/lib/x86_64-linux-gnu/tls/x86_64:/lib/x86_64-linux-gnu/tls:/lib/x86_64-linux-gnu/haswell/x86_64:/lib/x86_64-linux-gnu/haswell:/lib/x86_64-linux-gnu/x86_64:/lib/x86_64-linux-gnu:/usr/lib/x86_64-linux-gnu/tls/haswell/x86_64:/usr/lib/x86_64-linux-gnu/tls/haswell:/usr/lib/x86_64-linux-gnu/tls/x86_64:/usr/lib/x86_64-linux-gnu/tls:/usr/lib/x86_64-linux-gnu/haswell/x86_64:/usr/lib/x86_64-linux-gnu/haswell:/usr/lib/x86_64-linux-gnu/x86_64:/usr/lib/x86_64-linux-gnu:/lib/tls/haswell/x86_64:/lib/tls/haswell:/lib/tls/x86_64:/lib/tls:/lib/haswell/x86_64:/lib/haswell:/lib/x86_64:/lib:/usr/lib/tls/haswell/x86_64:/usr/lib/tls/haswell:/usr/lib/tls/x86_64:/usr/lib/tls:/usr/lib/haswell/x86_64:/usr/lib/haswell:/usr/lib/x86_64:/usr/lib		(system search path)
+      8579:	  trying file=/lib/x86_64-linux-gnu/tls/haswell/x86_64/libmycode.so
+      8579:	  trying file=/lib/x86_64-linux-gnu/tls/haswell/libmycode.so
+      8579:	  trying file=/lib/x86_64-linux-gnu/tls/x86_64/libmycode.so
+      8579:	  trying file=/lib/x86_64-linux-gnu/tls/libmycode.so
+      8579:	  trying file=/lib/x86_64-linux-gnu/haswell/x86_64/libmycode.so
+      8579:	  trying file=/lib/x86_64-linux-gnu/haswell/libmycode.so
+      8579:	  trying file=/lib/x86_64-linux-gnu/x86_64/libmycode.so
+      8579:	  trying file=/lib/x86_64-linux-gnu/libmycode.so
+      8579:	  trying file=/usr/lib/x86_64-linux-gnu/tls/haswell/x86_64/libmycode.so
+      8579:	  trying file=/usr/lib/x86_64-linux-gnu/tls/haswell/libmycode.so
+      8579:	  trying file=/usr/lib/x86_64-linux-gnu/tls/x86_64/libmycode.so
+      8579:	  trying file=/usr/lib/x86_64-linux-gnu/tls/libmycode.so
+      8579:	  trying file=/usr/lib/x86_64-linux-gnu/haswell/x86_64/libmycode.so
+      8579:	  trying file=/usr/lib/x86_64-linux-gnu/haswell/libmycode.so
+      8579:	  trying file=/usr/lib/x86_64-linux-gnu/x86_64/libmycode.so
+      8579:	  trying file=/usr/lib/x86_64-linux-gnu/libmycode.so
+      8579:	  trying file=/lib/tls/haswell/x86_64/libmycode.so
+      8579:	  trying file=/lib/tls/haswell/libmycode.so
+      8579:	  trying file=/lib/tls/x86_64/libmycode.so
+      8579:	  trying file=/lib/tls/libmycode.so
+      8579:	  trying file=/lib/haswell/x86_64/libmycode.so
+      8579:	  trying file=/lib/haswell/libmycode.so
+      8579:	  trying file=/lib/x86_64/libmycode.so
+      8579:	  trying file=/lib/libmycode.so
+      8579:	  trying file=/usr/lib/tls/haswell/x86_64/libmycode.so
+      8579:	  trying file=/usr/lib/tls/haswell/libmycode.so
+      8579:	  trying file=/usr/lib/tls/x86_64/libmycode.so
+      8579:	  trying file=/usr/lib/tls/libmycode.so
+      8579:	  trying file=/usr/lib/haswell/x86_64/libmycode.so
+      8579:	  trying file=/usr/lib/haswell/libmycode.so
+      8579:	  trying file=/usr/lib/x86_64/libmycode.so
+      8579:	  trying file=/usr/lib/libmycode.so
+      8579:
+INFO: Seed: 2499819812
+INFO: Loaded 1 modules   (7 inline 8-bit counters): 7 [0x7380d0, 0x7380d7),
+INFO: Loaded 1 PC tables (7 PCs): 7 [0x7380d8,0x738148),
+./fuzz.exe: Running 1 inputs 1 time(s) each.
+Running: seeds/good.txt
+fuzz.exe: main.c:37: int LLVMFuzzerTestOneInput(const uint8_t *, size_t): Assertion `fuzz_func != NULL' failed.
+==8579== ERROR: libFuzzer: deadly signal
+      8581:	find library=libLLVM-9.so.1 [0]; searching
+      8581:	 search path=./tls/haswell/x86_64:./tls/haswell:./tls/x86_64:./tls:./haswell/x86_64:./haswell:./x86_64:.		(LD_LIBRARY_PATH)
+      8581:	  trying file=./tls/haswell/x86_64/libLLVM-9.so.1
+      8581:	  trying file=./tls/haswell/libLLVM-9.so.1
+      8581:	  trying file=./tls/x86_64/libLLVM-9.so.1
+      8581:	  trying file=./tls/libLLVM-9.so.1
+      8581:	  trying file=./haswell/x86_64/libLLVM-9.so.1
+      8581:	  trying file=./haswell/libLLVM-9.so.1
+      8581:	  trying file=./x86_64/libLLVM-9.so.1
+      8581:	  trying file=./libLLVM-9.so.1
+      8581:	 search cache=/etc/ld.so.cache
+      8581:	  trying file=/usr/lib/x86_64-linux-gnu/libLLVM-9.so.1
+      8581:
+      8581:	find library=libpthread.so.0 [0]; searching
+      8581:	 search path=./tls/haswell/x86_64:./tls/haswell:./tls/x86_64:./tls:./haswell/x86_64:./haswell:./x86_64:.		(LD_LIBRARY_PATH)
+      8581:	  trying file=./tls/haswell/x86_64/libpthread.so.0
+      8581:	  trying file=./tls/haswell/libpthread.so.0
+      8581:	  trying file=./tls/x86_64/libpthread.so.0
+      8581:	  trying file=./tls/libpthread.so.0
+      8581:	  trying file=./haswell/x86_64/libpthread.so.0
+      8581:	  trying file=./haswell/libpthread.so.0
+      8581:	  trying file=./x86_64/libpthread.so.0
+      8581:	  trying file=./libpthread.so.0
+      8581:	 search cache=/etc/ld.so.cache
+      8581:	  trying file=/lib/x86_64-linux-gnu/libpthread.so.0
+      8581:
+      8581:	find library=libstdc++.so.6 [0]; searching
+      8581:	 search path=./tls/haswell/x86_64:./tls/haswell:./tls/x86_64:./tls:./haswell/x86_64:./haswell:./x86_64:.		(LD_LIBRARY_PATH)
+      8581:	  trying file=./tls/haswell/x86_64/libstdc++.so.6
+      8581:	  trying file=./tls/haswell/libstdc++.so.6
+      8581:	  trying file=./tls/x86_64/libstdc++.so.6
+      8581:	  trying file=./tls/libstdc++.so.6
+      8581:	  trying file=./haswell/x86_64/libstdc++.so.6
+      8581:	  trying file=./haswell/libstdc++.so.6
+      8581:	  trying file=./x86_64/libstdc++.so.6
+      8581:	  trying file=./libstdc++.so.6
+      8581:	 search cache=/etc/ld.so.cache
+      8581:	  trying file=/usr/lib/x86_64-linux-gnu/libstdc++.so.6
+      8581:
+      8581:	find library=libm.so.6 [0]; searching
+      8581:	 search path=./tls/haswell/x86_64:./tls/haswell:./tls/x86_64:./tls:./haswell/x86_64:./haswell:./x86_64:.		(LD_LIBRARY_PATH)
+      8581:	  trying file=./tls/haswell/x86_64/libm.so.6
+      8581:	  trying file=./tls/haswell/libm.so.6
+      8581:	  trying file=./tls/x86_64/libm.so.6
+      8581:	  trying file=./tls/libm.so.6
+      8581:	  trying file=./haswell/x86_64/libm.so.6
+      8581:	  trying file=./haswell/libm.so.6
+      8581:	  trying file=./x86_64/libm.so.6
+      8581:	  trying file=./libm.so.6
+      8581:	 search cache=/etc/ld.so.cache
+      8581:	  trying file=/lib/x86_64-linux-gnu/libm.so.6
+      8581:
+      8581:	find library=libgcc_s.so.1 [0]; searching
+      8581:	 search path=./tls/haswell/x86_64:./tls/haswell:./tls/x86_64:./tls:./haswell/x86_64:./haswell:./x86_64:.		(LD_LIBRARY_PATH)
+      8581:	  trying file=./tls/haswell/x86_64/libgcc_s.so.1
+      8581:	  trying file=./tls/haswell/libgcc_s.so.1
+      8581:	  trying file=./tls/x86_64/libgcc_s.so.1
+      8581:	  trying file=./tls/libgcc_s.so.1
+      8581:	  trying file=./haswell/x86_64/libgcc_s.so.1
+      8581:	  trying file=./haswell/libgcc_s.so.1
+      8581:	  trying file=./x86_64/libgcc_s.so.1
+      8581:	  trying file=./libgcc_s.so.1
+      8581:	 search cache=/etc/ld.so.cache
+      8581:	  trying file=/lib/x86_64-linux-gnu/libgcc_s.so.1
+      8581:
+      8581:	find library=libc.so.6 [0]; searching
+      8581:	 search path=./tls/haswell/x86_64:./tls/haswell:./tls/x86_64:./tls:./haswell/x86_64:./haswell:./x86_64:.		(LD_LIBRARY_PATH)
+      8581:	  trying file=./tls/haswell/x86_64/libc.so.6
+      8581:	  trying file=./tls/haswell/libc.so.6
+      8581:	  trying file=./tls/x86_64/libc.so.6
+      8581:	  trying file=./tls/libc.so.6
+      8581:	  trying file=./haswell/x86_64/libc.so.6
+      8581:	  trying file=./haswell/libc.so.6
+      8581:	  trying file=./x86_64/libc.so.6
+      8581:	  trying file=./libc.so.6
+      8581:	 search cache=/etc/ld.so.cache
+      8581:	  trying file=/lib/x86_64-linux-gnu/libc.so.6
+      8581:
+      8581:	find library=libffi.so.6 [0]; searching
+      8581:	 search path=./tls/haswell/x86_64:./tls/haswell:./tls/x86_64:./tls:./haswell/x86_64:./haswell:./x86_64:.		(LD_LIBRARY_PATH)
+      8581:	  trying file=./tls/haswell/x86_64/libffi.so.6
+      8581:	  trying file=./tls/haswell/libffi.so.6
+      8581:	  trying file=./tls/x86_64/libffi.so.6
+      8581:	  trying file=./tls/libffi.so.6
+      8581:	  trying file=./haswell/x86_64/libffi.so.6
+      8581:	  trying file=./haswell/libffi.so.6
+      8581:	  trying file=./x86_64/libffi.so.6
+      8581:	  trying file=./libffi.so.6
+      8581:	 search path=/usr/lib/x86_64-linux-gnu/../lib/tls/haswell/x86_64:/usr/lib/x86_64-linux-gnu/../lib/tls/haswell:/usr/lib/x86_64-linux-gnu/../lib/tls/x86_64:/usr/lib/x86_64-linux-gnu/../lib/tls:/usr/lib/x86_64-linux-gnu/../lib/haswell/x86_64:/usr/lib/x86_64-linux-gnu/../lib/haswell:/usr/lib/x86_64-linux-gnu/../lib/x86_64:/usr/lib/x86_64-linux-gnu/../lib		(RUNPATH from file /usr/lib/x86_64-linux-gnu/libLLVM-9.so.1)
+      8581:	  trying file=/usr/lib/x86_64-linux-gnu/../lib/tls/haswell/x86_64/libffi.so.6
+      8581:	  trying file=/usr/lib/x86_64-linux-gnu/../lib/tls/haswell/libffi.so.6
+      8581:	  trying file=/usr/lib/x86_64-linux-gnu/../lib/tls/x86_64/libffi.so.6
+      8581:	  trying file=/usr/lib/x86_64-linux-gnu/../lib/tls/libffi.so.6
+      8581:	  trying file=/usr/lib/x86_64-linux-gnu/../lib/haswell/x86_64/libffi.so.6
+      8581:	  trying file=/usr/lib/x86_64-linux-gnu/../lib/haswell/libffi.so.6
+      8581:	  trying file=/usr/lib/x86_64-linux-gnu/../lib/x86_64/libffi.so.6
+      8581:	  trying file=/usr/lib/x86_64-linux-gnu/../lib/libffi.so.6
+      8581:	 search cache=/etc/ld.so.cache
+      8581:	  trying file=/usr/lib/x86_64-linux-gnu/libffi.so.6
+      8581:
+      8581:	find library=libedit.so.2 [0]; searching
+      8581:	 search path=./tls/haswell/x86_64:./tls/haswell:./tls/x86_64:./tls:./haswell/x86_64:./haswell:./x86_64:.		(LD_LIBRARY_PATH)
+      8581:	  trying file=./tls/haswell/x86_64/libedit.so.2
+      8581:	  trying file=./tls/haswell/libedit.so.2
+      8581:	  trying file=./tls/x86_64/libedit.so.2
+      8581:	  trying file=./tls/libedit.so.2
+      8581:	  trying file=./haswell/x86_64/libedit.so.2
+      8581:	  trying file=./haswell/libedit.so.2
+      8581:	  trying file=./x86_64/libedit.so.2
+      8581:	  trying file=./libedit.so.2
+      8581:	 search cache=/etc/ld.so.cache
+      8581:	  trying file=/usr/lib/x86_64-linux-gnu/libedit.so.2
+      8581:
+      8581:	find library=libz.so.1 [0]; searching
+      8581:	 search path=./tls/haswell/x86_64:./tls/haswell:./tls/x86_64:./tls:./haswell/x86_64:./haswell:./x86_64:.		(LD_LIBRARY_PATH)
+      8581:	  trying file=./tls/haswell/x86_64/libz.so.1
+      8581:	  trying file=./tls/haswell/libz.so.1
+      8581:	  trying file=./tls/x86_64/libz.so.1
+      8581:	  trying file=./tls/libz.so.1
+      8581:	  trying file=./haswell/x86_64/libz.so.1
+      8581:	  trying file=./haswell/libz.so.1
+      8581:	  trying file=./x86_64/libz.so.1
+      8581:	  trying file=./libz.so.1
+      8581:	 search cache=/etc/ld.so.cache
+      8581:	  trying file=/lib/x86_64-linux-gnu/libz.so.1
+      8581:
+      8581:	find library=librt.so.1 [0]; searching
+      8581:	 search path=./tls/haswell/x86_64:./tls/haswell:./tls/x86_64:./tls:./haswell/x86_64:./haswell:./x86_64:.		(LD_LIBRARY_PATH)
+      8581:	  trying file=./tls/haswell/x86_64/librt.so.1
+      8581:	  trying file=./tls/haswell/librt.so.1
+      8581:	  trying file=./tls/x86_64/librt.so.1
+      8581:	  trying file=./tls/librt.so.1
+      8581:	  trying file=./haswell/x86_64/librt.so.1
+      8581:	  trying file=./haswell/librt.so.1
+      8581:	  trying file=./x86_64/librt.so.1
+      8581:	  trying file=./librt.so.1
+      8581:	 search cache=/etc/ld.so.cache
+      8581:	  trying file=/lib/x86_64-linux-gnu/librt.so.1
+      8581:
+      8581:	find library=libdl.so.2 [0]; searching
+      8581:	 search path=./tls/haswell/x86_64:./tls/haswell:./tls/x86_64:./tls:./haswell/x86_64:./haswell:./x86_64:.		(LD_LIBRARY_PATH)
+      8581:	  trying file=./tls/haswell/x86_64/libdl.so.2
+      8581:	  trying file=./tls/haswell/libdl.so.2
+      8581:	  trying file=./tls/x86_64/libdl.so.2
+      8581:	  trying file=./tls/libdl.so.2
+      8581:	  trying file=./haswell/x86_64/libdl.so.2
+      8581:	  trying file=./haswell/libdl.so.2
+      8581:	  trying file=./x86_64/libdl.so.2
+      8581:	  trying file=./libdl.so.2
+      8581:	 search cache=/etc/ld.so.cache
+      8581:	  trying file=/lib/x86_64-linux-gnu/libdl.so.2
+      8581:
+      8581:	find library=libtinfo.so.5 [0]; searching
+      8581:	 search path=./tls/haswell/x86_64:./tls/haswell:./tls/x86_64:./tls:./haswell/x86_64:./haswell:./x86_64:.		(LD_LIBRARY_PATH)
+      8581:	  trying file=./tls/haswell/x86_64/libtinfo.so.5
+      8581:	  trying file=./tls/haswell/libtinfo.so.5
+      8581:	  trying file=./tls/x86_64/libtinfo.so.5
+      8581:	  trying file=./tls/libtinfo.so.5
+      8581:	  trying file=./haswell/x86_64/libtinfo.so.5
+      8581:	  trying file=./haswell/libtinfo.so.5
+      8581:	  trying file=./x86_64/libtinfo.so.5
+      8581:	  trying file=./libtinfo.so.5
+      8581:	 search cache=/etc/ld.so.cache
+      8581:	  trying file=/lib/x86_64-linux-gnu/libtinfo.so.5
+      8581:
+      8581:
+      8581:	calling init: /lib/x86_64-linux-gnu/libpthread.so.0
+      8581:
+      8581:
+      8581:	calling init: /lib/x86_64-linux-gnu/libc.so.6
+      8581:
+      8581:
+      8581:	calling init: /lib/x86_64-linux-gnu/libtinfo.so.5
+      8581:
+      8581:
+      8581:	calling init: /lib/x86_64-linux-gnu/libdl.so.2
+      8581:
+      8581:
+      8581:	calling init: /lib/x86_64-linux-gnu/librt.so.1
+      8581:
+      8581:
+      8581:	calling init: /lib/x86_64-linux-gnu/libz.so.1
+      8581:
+      8581:
+      8581:	calling init: /usr/lib/x86_64-linux-gnu/libedit.so.2
+      8581:
+      8581:
+      8581:	calling init: /usr/lib/x86_64-linux-gnu/libffi.so.6
+      8581:
+      8581:
+      8581:	calling init: /lib/x86_64-linux-gnu/libgcc_s.so.1
+      8581:
+      8581:
+      8581:	calling init: /lib/x86_64-linux-gnu/libm.so.6
+      8581:
+      8581:
+      8581:	calling init: /usr/lib/x86_64-linux-gnu/libstdc++.so.6
+      8581:
+      8581:
+      8581:	calling init: /usr/lib/x86_64-linux-gnu/libLLVM-9.so.1
+      8581:
+      8581:
+      8581:	initialize program: /usr/bin/llvm-symbolizer-9
+      8581:
+      8581:
+      8581:	transferring control: /usr/bin/llvm-symbolizer-9
+      8581:
+    #0 0x4d5eb1 in __sanitizer_print_stack_trace (/home/user/fuzz.exe+0x4d5eb1)
+    #1 0x454f4b in fuzzer::PrintStackTrace() (/home/user/fuzz.exe+0x454f4b)
+    #2 0x439d53 in fuzzer::Fuzzer::CrashCallback() (/home/user/fuzz.exe+0x439d53)
+    #3 0x7fc0ead4f97f  (/lib/x86_64-linux-gnu/libpthread.so.0+0x1297f)
+    #4 0x7fc0e9fc8e86 in __libc_signal_restore_set /build/glibc-uZu3wS/glibc-2.27/signal/../sysdeps/unix/sysv/linux/nptl-signals.h:80
+    #5 0x7fc0e9fc8e86 in raise /build/glibc-uZu3wS/glibc-2.27/signal/../sysdeps/unix/sysv/linux/raise.c:48
+    #6 0x7fc0e9fca7f0 in abort /build/glibc-uZu3wS/glibc-2.27/stdlib/abort.c:79
+    #7 0x7fc0e9fba3f9 in __assert_fail_base /build/glibc-uZu3wS/glibc-2.27/assert/assert.c:92
+    #8 0x7fc0e9fba471 in __assert_fail /build/glibc-uZu3wS/glibc-2.27/assert/assert.c:101
+    #9 0x4fcf43 in LLVMFuzzerTestOneInput /home/runner/work/onefuzz/onefuzz/src/integration-tests/libfuzzer-dlopen/main.c:37:5
+    #10 0x43b281 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/home/user/fuzz.exe+0x43b281)
+    #11 0x423777 in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (/home/user/fuzz.exe+0x423777)
+    #12 0x429751 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/home/user/fuzz.exe+0x429751)
+    #13 0x4557b2 in main (/home/user/fuzz.exe+0x4557b2)
+    #14 0x7fc0e9fabc86 in __libc_start_main /build/glibc-uZu3wS/glibc-2.27/csu/../csu/libc-start.c:310
+    #15 0x41db69 in _start (/home/user/fuzz.exe+0x41db69)
+
+NOTE: libFuzzer has rudimentary signal handlers.
+      Combine libFuzzer with AddressSanitizer or similar for better crash reports.
+SUMMARY: libFuzzer: deadly signal
+      8581:
+      8581:	calling fini: /usr/bin/llvm-symbolizer-9 [0]
+      8581:
+      8581:
+      8581:	calling fini: /usr/lib/x86_64-linux-gnu/libLLVM-9.so.1 [0]
+      8581:
+      8581:
+      8581:	calling fini: /usr/lib/x86_64-linux-gnu/libstdc++.so.6 [0]
+      8581:
+      8581:
+      8581:	calling fini: /lib/x86_64-linux-gnu/libm.so.6 [0]
+      8581:
+      8581:
+      8581:	calling fini: /lib/x86_64-linux-gnu/libgcc_s.so.1 [0]
+      8581:
+      8581:
+      8581:	calling fini: /usr/lib/x86_64-linux-gnu/libffi.so.6 [0]
+      8581:
+      8581:
+      8581:	calling fini: /usr/lib/x86_64-linux-gnu/libedit.so.2 [0]
+      8581:
+      8581:
+      8581:	calling fini: /lib/x86_64-linux-gnu/libz.so.1 [0]
+      8581:
+      8581:
+      8581:	calling fini: /lib/x86_64-linux-gnu/librt.so.1 [0]
+      8581:
+      8581:
+      8581:	calling fini: /lib/x86_64-linux-gnu/libpthread.so.0 [0]
+      8581:
+      8581:
+      8581:	calling fini: /lib/x86_64-linux-gnu/libdl.so.2 [0]
+      8581:
+      8581:
+      8581:	calling fini: /lib/x86_64-linux-gnu/libtinfo.so.5 [0]
+      8581:

--- a/src/agent/dynamic-library/src/linux/ld_debug_output_none_missing.txt
+++ b/src/agent/dynamic-library/src/linux/ld_debug_output_none_missing.txt
@@ -1,0 +1,179 @@
+     10448:	find library=libstdc++.so.6 [0]; searching
+     10448:	 search path=./tls/haswell/x86_64:./tls/haswell:./tls/x86_64:./tls:./haswell/x86_64:./haswell:./x86_64:.		(LD_LIBRARY_PATH)
+     10448:	  trying file=./tls/haswell/x86_64/libstdc++.so.6
+     10448:	  trying file=./tls/haswell/libstdc++.so.6
+     10448:	  trying file=./tls/x86_64/libstdc++.so.6
+     10448:	  trying file=./tls/libstdc++.so.6
+     10448:	  trying file=./haswell/x86_64/libstdc++.so.6
+     10448:	  trying file=./haswell/libstdc++.so.6
+     10448:	  trying file=./x86_64/libstdc++.so.6
+     10448:	  trying file=./libstdc++.so.6
+     10448:	 search cache=/etc/ld.so.cache
+     10448:	  trying file=/usr/lib/x86_64-linux-gnu/libstdc++.so.6
+     10448:
+     10448:	find library=libpthread.so.0 [0]; searching
+     10448:	 search path=./tls/haswell/x86_64:./tls/haswell:./tls/x86_64:./tls:./haswell/x86_64:./haswell:./x86_64:.		(LD_LIBRARY_PATH)
+     10448:	  trying file=./tls/haswell/x86_64/libpthread.so.0
+     10448:	  trying file=./tls/haswell/libpthread.so.0
+     10448:	  trying file=./tls/x86_64/libpthread.so.0
+     10448:	  trying file=./tls/libpthread.so.0
+     10448:	  trying file=./haswell/x86_64/libpthread.so.0
+     10448:	  trying file=./haswell/libpthread.so.0
+     10448:	  trying file=./x86_64/libpthread.so.0
+     10448:	  trying file=./libpthread.so.0
+     10448:	 search cache=/etc/ld.so.cache
+     10448:	  trying file=/lib/x86_64-linux-gnu/libpthread.so.0
+     10448:
+     10448:	find library=librt.so.1 [0]; searching
+     10448:	 search path=./tls/haswell/x86_64:./tls/haswell:./tls/x86_64:./tls:./haswell/x86_64:./haswell:./x86_64:.		(LD_LIBRARY_PATH)
+     10448:	  trying file=./tls/haswell/x86_64/librt.so.1
+     10448:	  trying file=./tls/haswell/librt.so.1
+     10448:	  trying file=./tls/x86_64/librt.so.1
+     10448:	  trying file=./tls/librt.so.1
+     10448:	  trying file=./haswell/x86_64/librt.so.1
+     10448:	  trying file=./haswell/librt.so.1
+     10448:	  trying file=./x86_64/librt.so.1
+     10448:	  trying file=./librt.so.1
+     10448:	 search cache=/etc/ld.so.cache
+     10448:	  trying file=/lib/x86_64-linux-gnu/librt.so.1
+     10448:
+     10448:	find library=libm.so.6 [0]; searching
+     10448:	 search path=./tls/haswell/x86_64:./tls/haswell:./tls/x86_64:./tls:./haswell/x86_64:./haswell:./x86_64:.		(LD_LIBRARY_PATH)
+     10448:	  trying file=./tls/haswell/x86_64/libm.so.6
+     10448:	  trying file=./tls/haswell/libm.so.6
+     10448:	  trying file=./tls/x86_64/libm.so.6
+     10448:	  trying file=./tls/libm.so.6
+     10448:	  trying file=./haswell/x86_64/libm.so.6
+     10448:	  trying file=./haswell/libm.so.6
+     10448:	  trying file=./x86_64/libm.so.6
+     10448:	  trying file=./libm.so.6
+     10448:	 search cache=/etc/ld.so.cache
+     10448:	  trying file=/lib/x86_64-linux-gnu/libm.so.6
+     10448:
+     10448:	find library=libdl.so.2 [0]; searching
+     10448:	 search path=./tls/haswell/x86_64:./tls/haswell:./tls/x86_64:./tls:./haswell/x86_64:./haswell:./x86_64:.		(LD_LIBRARY_PATH)
+     10448:	  trying file=./tls/haswell/x86_64/libdl.so.2
+     10448:	  trying file=./tls/haswell/libdl.so.2
+     10448:	  trying file=./tls/x86_64/libdl.so.2
+     10448:	  trying file=./tls/libdl.so.2
+     10448:	  trying file=./haswell/x86_64/libdl.so.2
+     10448:	  trying file=./haswell/libdl.so.2
+     10448:	  trying file=./x86_64/libdl.so.2
+     10448:	  trying file=./libdl.so.2
+     10448:	 search cache=/etc/ld.so.cache
+     10448:	  trying file=/lib/x86_64-linux-gnu/libdl.so.2
+     10448:
+     10448:	find library=libgcc_s.so.1 [0]; searching
+     10448:	 search path=./tls/haswell/x86_64:./tls/haswell:./tls/x86_64:./tls:./haswell/x86_64:./haswell:./x86_64:.		(LD_LIBRARY_PATH)
+     10448:	  trying file=./tls/haswell/x86_64/libgcc_s.so.1
+     10448:	  trying file=./tls/haswell/libgcc_s.so.1
+     10448:	  trying file=./tls/x86_64/libgcc_s.so.1
+     10448:	  trying file=./tls/libgcc_s.so.1
+     10448:	  trying file=./haswell/x86_64/libgcc_s.so.1
+     10448:	  trying file=./haswell/libgcc_s.so.1
+     10448:	  trying file=./x86_64/libgcc_s.so.1
+     10448:	  trying file=./libgcc_s.so.1
+     10448:	 search cache=/etc/ld.so.cache
+     10448:	  trying file=/lib/x86_64-linux-gnu/libgcc_s.so.1
+     10448:
+     10448:	find library=libc.so.6 [0]; searching
+     10448:	 search path=./tls/haswell/x86_64:./tls/haswell:./tls/x86_64:./tls:./haswell/x86_64:./haswell:./x86_64:.		(LD_LIBRARY_PATH)
+     10448:	  trying file=./tls/haswell/x86_64/libc.so.6
+     10448:	  trying file=./tls/haswell/libc.so.6
+     10448:	  trying file=./tls/x86_64/libc.so.6
+     10448:	  trying file=./tls/libc.so.6
+     10448:	  trying file=./haswell/x86_64/libc.so.6
+     10448:	  trying file=./haswell/libc.so.6
+     10448:	  trying file=./x86_64/libc.so.6
+     10448:	  trying file=./libc.so.6
+     10448:	 search cache=/etc/ld.so.cache
+     10448:	  trying file=/lib/x86_64-linux-gnu/libc.so.6
+     10448:
+     10448:
+     10448:	calling init: /lib/x86_64-linux-gnu/libpthread.so.0
+     10448:
+     10448:
+     10448:	calling preinit: ./fuzz.exe
+     10448:
+     10448:	./fuzz.exe: error: symbol lookup error: undefined symbol: __isoc99_printf (fatal)
+     10448:	./fuzz.exe: error: symbol lookup error: undefined symbol: __isoc99_sprintf (fatal)
+     10448:	./fuzz.exe: error: symbol lookup error: undefined symbol: __isoc99_snprintf (fatal)
+     10448:	./fuzz.exe: error: symbol lookup error: undefined symbol: __isoc99_fprintf (fatal)
+     10448:	./fuzz.exe: error: symbol lookup error: undefined symbol: __isoc99_vprintf (fatal)
+     10448:	./fuzz.exe: error: symbol lookup error: undefined symbol: __isoc99_vsprintf (fatal)
+     10448:	./fuzz.exe: error: symbol lookup error: undefined symbol: __isoc99_vsnprintf (fatal)
+     10448:	./fuzz.exe: error: symbol lookup error: undefined symbol: __isoc99_vfprintf (fatal)
+     10448:	./fuzz.exe: error: symbol lookup error: undefined symbol: __cxa_rethrow_primary_exception (fatal)
+     10448:	./fuzz.exe: error: symbol lookup error: undefined symbol: swift_demangle (fatal)
+     10448:
+     10448:	calling init: /lib/x86_64-linux-gnu/libc.so.6
+     10448:
+     10448:
+     10448:	calling init: /lib/x86_64-linux-gnu/libgcc_s.so.1
+     10448:
+     10448:
+     10448:	calling init: /lib/x86_64-linux-gnu/libdl.so.2
+     10448:
+     10448:
+     10448:	calling init: /lib/x86_64-linux-gnu/libm.so.6
+     10448:
+     10448:
+     10448:	calling init: /lib/x86_64-linux-gnu/librt.so.1
+     10448:
+     10448:
+     10448:	calling init: /usr/lib/x86_64-linux-gnu/libstdc++.so.6
+     10448:
+     10448:
+     10448:	initialize program: ./fuzz.exe
+     10448:
+     10448:
+     10448:	transferring control: ./fuzz.exe
+     10448:
+     10448:	find library=libmycode.so [0]; searching
+     10448:	 search path=./tls/haswell/x86_64:./tls/haswell:./tls/x86_64:./tls:./haswell/x86_64:./haswell:./x86_64:.		(LD_LIBRARY_PATH)
+     10448:	  trying file=./tls/haswell/x86_64/libmycode.so
+     10448:	  trying file=./tls/haswell/libmycode.so
+     10448:	  trying file=./tls/x86_64/libmycode.so
+     10448:	  trying file=./tls/libmycode.so
+     10448:	  trying file=./haswell/x86_64/libmycode.so
+     10448:	  trying file=./haswell/libmycode.so
+     10448:	  trying file=./x86_64/libmycode.so
+     10448:	  trying file=./libmycode.so
+     10448:
+     10448:
+     10448:	calling init: ./libmycode.so
+     10448:
+INFO: Seed: 1508909392
+INFO: Loaded 2 modules   (28 inline 8-bit counters): 7 [0x7380d0, 0x7380d7), 21 [0x7fa8a17ff0e0, 0x7fa8a17ff0f5),
+INFO: Loaded 2 PC tables (28 PCs): 7 [0x7380d8,0x738148), 21 [0x7fa8a17ff0f8,0x7fa8a17ff248),
+./fuzz.exe: Running 1 inputs 1 time(s) each.
+Running: seeds/good.txt
+Executed seeds/good.txt in 0 ms
+***
+*** NOTE: fuzzing was not performed, you have only
+***       executed the target code on a fixed set of inputs.
+***
+     10448:
+     10448:	calling fini: ./fuzz.exe [0]
+     10448:
+     10448:
+     10448:	calling fini: /usr/lib/x86_64-linux-gnu/libstdc++.so.6 [0]
+     10448:
+     10448:
+     10448:	calling fini: /lib/x86_64-linux-gnu/librt.so.1 [0]
+     10448:
+     10448:
+     10448:	calling fini: /lib/x86_64-linux-gnu/libpthread.so.0 [0]
+     10448:
+     10448:
+     10448:	calling fini: /lib/x86_64-linux-gnu/libm.so.6 [0]
+     10448:
+     10448:
+     10448:	calling fini: /lib/x86_64-linux-gnu/libdl.so.2 [0]
+     10448:
+     10448:
+     10448:	calling fini: /lib/x86_64-linux-gnu/libgcc_s.so.1 [0]
+     10448:
+     10448:
+     10448:	calling fini: ./libmycode.so [0]
+     10448:

--- a/src/agent/dynamic-library/src/linux/ldd_output_missing_0.txt
+++ b/src/agent/dynamic-library/src/linux/ldd_output_missing_0.txt
@@ -1,0 +1,5 @@
+	linux-vdso.so.1 (0x00007ffd717b5000)
+	libmycode.so => /my/project/libmycode.so.1 (0x00007ffd717b5000)
+	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f1c2ac27000)
+	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f1c29e74000)
+	/lib64/ld-linux-x86-64.so.2 (0x00007f1c2b1cf000)

--- a/src/agent/dynamic-library/src/linux/ldd_output_missing_1.txt
+++ b/src/agent/dynamic-library/src/linux/ldd_output_missing_1.txt
@@ -1,0 +1,5 @@
+	linux-vdso.so.1 (0x00007ffd717b5000)
+	libmycode.so => not found
+	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f1c2ac27000)
+	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f1c29e74000)
+	/lib64/ld-linux-x86-64.so.2 (0x00007f1c2b1cf000)

--- a/src/agent/dynamic-library/src/linux/ldd_output_missing_2.txt
+++ b/src/agent/dynamic-library/src/linux/ldd_output_missing_2.txt
@@ -1,0 +1,6 @@
+	linux-vdso.so.1 (0x00007ffd717b5000)
+	libmycode.so => not found
+	libmyothercode.so => not found
+	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f1c2ac27000)
+	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f1c29e74000)
+	/lib64/ld-linux-x86-64.so.2 (0x00007f1c2b1cf000)

--- a/src/agent/dynamic-library/src/linux/tests.rs
+++ b/src/agent/dynamic-library/src/linux/tests.rs
@@ -1,0 +1,83 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+use super::*;
+
+const LDD_OUTPUT_MISSING_0: &[u8] = include_bytes!("./ldd_output_missing_0.txt");
+const LDD_OUTPUT_MISSING_1: &[u8] = include_bytes!("./ldd_output_missing_1.txt");
+const LDD_OUTPUT_MISSING_2: &[u8] = include_bytes!("./ldd_output_missing_2.txt");
+
+const LD_DEBUG_OUTPUT_MISSING: &[u8] = include_bytes!("./ld_debug_output_missing.txt");
+const LD_DEBUG_OUTPUT_NONE_MISSING: &[u8] = include_bytes!("./ld_debug_output_none_missing.txt");
+
+#[test]
+fn test_linked_dynamic_libraries_missing_0() {
+    let linked = LinkedDynamicLibraries::parse(LDD_OUTPUT_MISSING_0);
+
+    assert_eq!(linked.libraries.len(), 3);
+    assert_eq!(
+        linked.libraries["libmycode.so"],
+        Some("/my/project/libmycode.so.1".to_owned())
+    );
+    assert_eq!(
+        linked.libraries["libpthread.so.0"],
+        Some("/lib/x86_64-linux-gnu/libpthread.so.0".to_owned())
+    );
+    assert_eq!(
+        linked.libraries["libc.so.6"],
+        Some("/lib/x86_64-linux-gnu/libc.so.6".to_owned())
+    );
+}
+
+#[test]
+fn test_linked_dynamic_libraries_missing_1() {
+    let linked = LinkedDynamicLibraries::parse(LDD_OUTPUT_MISSING_1);
+
+    assert_eq!(linked.libraries.len(), 3);
+    assert_eq!(linked.libraries["libmycode.so"], None);
+    assert_eq!(
+        linked.libraries["libpthread.so.0"],
+        Some("/lib/x86_64-linux-gnu/libpthread.so.0".to_owned())
+    );
+    assert_eq!(
+        linked.libraries["libc.so.6"],
+        Some("/lib/x86_64-linux-gnu/libc.so.6".to_owned())
+    );
+}
+
+#[test]
+fn test_linked_dynamic_libraries_missing_none() {
+    let linked = LinkedDynamicLibraries::parse(LDD_OUTPUT_MISSING_2);
+
+    assert_eq!(linked.libraries.len(), 4);
+    assert_eq!(linked.libraries["libmycode.so"], None);
+    assert_eq!(linked.libraries["libmyothercode.so"], None);
+    assert_eq!(
+        linked.libraries["libpthread.so.0"],
+        Some("/lib/x86_64-linux-gnu/libpthread.so.0".to_owned())
+    );
+    assert_eq!(
+        linked.libraries["libc.so.6"],
+        Some("/lib/x86_64-linux-gnu/libc.so.6".to_owned())
+    );
+}
+
+#[test]
+fn test_ld_debug_logs_parse_missing() {
+    let logs = LdDebugLogs::parse(LD_DEBUG_OUTPUT_MISSING);
+    let missing = logs.missing();
+
+    assert_eq!(missing.len(), 1);
+
+    let expected = MissingDynamicLibrary {
+        name: "libmycode.so".to_owned(),
+    };
+    assert!(missing.contains(&expected));
+}
+
+#[test]
+fn test_ld_debug_logs_parse_none_missing() {
+    let logs = LdDebugLogs::parse(LD_DEBUG_OUTPUT_NONE_MISSING);
+    let missing = logs.missing();
+
+    assert!(missing.is_empty())
+}

--- a/src/agent/dynamic-library/src/windows.rs
+++ b/src/agent/dynamic-library/src/windows.rs
@@ -217,9 +217,9 @@ impl Drop for ImageLoaderSnapsGuard {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct MissingDynamicLibrary {
-    name: String,
-    parent: String,
-    status: u32,
+    pub name: String,
+    pub parent: String,
+    pub status: u32,
 }
 
 impl MissingDynamicLibrary {


### PR DESCRIPTION
Add support for detecting for missing dynamic libraries on Linux, and extend the existing CLI tool.

This uses the `ldd` tool and the `LD_DEBUG` environment variable to enable `ld.so` debug logging. We could replace the use of `ldd` with `LD_TRACE_LOADED_OBJECTS` and target invocation, but I think the presence of `ldd` is a safe assumption.

Integration tested with the `linux-libfuzzer-dlopen` and `linux-libfuzzer-linked-library` example binaries. Verified that the CLI tool works as expected with 0, 1, or many missing shared libraries, both when linking at process startup or loading at runtime.