### PR TITLE
Allow some safe functions with `HANDLE` arguments

### DIFF
--- a/src/agent/debugger/src/lib.rs
+++ b/src/agent/debugger/src/lib.rs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 #![cfg(windows)]
-
 // Allow safe functions that take `HANDLE` arguments.
 //
 // Though they type alias raw pointers, they are opaque. In the future, we will

--- a/src/agent/debugger/src/lib.rs
+++ b/src/agent/debugger/src/lib.rs
@@ -3,6 +3,13 @@
 
 #![cfg(windows)]
 
+// Allow safe functions that take `HANDLE` arguments.
+//
+// Though they type alias raw pointers, they are opaque. In the future, we will
+// wrap them in a newtype. This will witness that they were obtained via win32
+// API calls or documented pseudohandle construction.
+#![allow(clippy::not_unsafe_ptr_arg_deref)]
+
 mod breakpoint;
 pub mod dbghelp;
 mod debug_event;

--- a/src/agent/win-util/src/lib.rs
+++ b/src/agent/win-util/src/lib.rs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 #![cfg(windows)]
-
 // Allow safe functions that take `HANDLE` arguments.
 //
 // Though they type alias raw pointers, they are opaque. In the future, we will

--- a/src/agent/win-util/src/lib.rs
+++ b/src/agent/win-util/src/lib.rs
@@ -3,6 +3,13 @@
 
 #![cfg(windows)]
 
+// Allow safe functions that take `HANDLE` arguments.
+//
+// Though they type alias raw pointers, they are opaque. In the future, we will
+// wrap them in a newtype. This will witness that they were obtained via win32
+// API calls or documented pseudohandle construction.
+#![allow(clippy::not_unsafe_ptr_arg_deref)]
+
 #[macro_use]
 pub mod macros;
 


### PR DESCRIPTION
Fixes the build in the face of a new clippy lint.

Proper follow-up captured in #1793.