### PR TITLE
Continue inline access search on local error

### DIFF
--- a/src/agent/coverage/src/block/pe_provider.rs
+++ b/src/agent/coverage/src/block/pe_provider.rs
@@ -254,7 +254,17 @@ impl<'d, 'p> SancovInlineAccessVisitor<'d, 'p> {
 
         let offset: u64 = rva.try_into()?;
         let va: u64 = self.scanner.base + offset;
-        self.scanner.scan(data, va)?;
+
+        if let Err(err) = self.scanner.scan(data, va) {
+            // Errors here are aren't fatal to the larger reversing of inline accesses.
+            //
+            // Typically, it means we attempted to disassemble local data (like jump tables).
+            log::warn!(
+                "error scanning procedure code for inline accesses; procedure = {}, error = {}",
+                proc.name,
+                err
+            );
+        }
 
         Ok(())
     }


### PR DESCRIPTION
When scanning for inline accesses to a SanCov table, if we hit a procedure-local disassembly error, only stop inline access search within that procedure. Log a warning, but continue scanning generally.

Closes #1795.