### PR TITLE
Switch to misuse-resistant smart constructor

### DIFF
--- a/src/agent/onefuzz-agent/src/local/common.rs
+++ b/src/agent/onefuzz-agent/src/local/common.rs
@@ -1,5 +1,10 @@
-use crate::tasks::config::CommonConfig;
-use crate::tasks::utils::parse_key_value;
+use std::{
+    collections::HashMap,
+    env::current_dir,
+    path::{Path, PathBuf},
+    time::Duration,
+};
+
 use anyhow::Result;
 use backoff::{future::retry, Error as BackoffError, ExponentialBackoff};
 use clap::{App, Arg, ArgMatches};
@@ -7,13 +12,11 @@ use flume::Sender;
 use onefuzz::{blob::url::BlobContainerUrl, monitor::DirectoryMonitor, syncdir::SyncedDir};
 use path_absolutize::Absolutize;
 use reqwest::Url;
-use std::{
-    collections::HashMap,
-    env::current_dir,
-    path::{Path, PathBuf},
-    time::Duration,
-};
+use storage_queue::{local_queue::ChannelQueueClient, QueueClient};
 use uuid::Uuid;
+
+use crate::tasks::config::CommonConfig;
+use crate::tasks::utils::parse_key_value;
 
 pub const SETUP_DIR: &str = "setup_dir";
 pub const INPUTS_DIR: &str = "inputs_dir";
@@ -267,24 +270,10 @@ pub struct DirectoryMonitorQueue {
 
 impl DirectoryMonitorQueue {
     pub async fn start_monitoring(directory_path: impl AsRef<Path>) -> Result<Self> {
-        let directory_path = PathBuf::from(directory_path.as_ref());
-        let directory_path_clone = directory_path.clone();
-        let queue_client = storage_queue::QueueClient::Channel(
-            storage_queue::local_queue::ChannelQueueClient::new()?,
-        );
-        let queue = queue_client.clone();
-        let handle: tokio::task::JoinHandle<Result<()>> = tokio::spawn(async move {
-            let mut monitor = DirectoryMonitor::new(directory_path_clone.clone())?;
-            monitor.start().await?;
-
-            while let Some(file_path) = monitor.next_file().await? {
-                let file_url =
-                    Url::from_file_path(file_path).map_err(|_| anyhow!("invalid file path"))?;
-                queue.enqueue(file_url).await?;
-            }
-
-            Ok(())
-        });
+        let directory_path = directory_path.as_ref().to_owned();
+        let queue_client = QueueClient::Channel(ChannelQueueClient::new()?);
+        let monitor_task = monitor_directory(queue_client.clone(), directory_path.clone());
+        let handle = tokio::spawn(monitor_task);
 
         Ok(DirectoryMonitorQueue {
             directory_path,
@@ -292,6 +281,18 @@ impl DirectoryMonitorQueue {
             handle,
         })
     }
+}
+
+async fn monitor_directory(queue_client: QueueClient, directory: PathBuf) -> Result<()> {
+    let mut monitor = DirectoryMonitor::new(&directory).await?;
+
+    while let Some(file_path) = monitor.next_file().await? {
+        let file_url = Url::from_file_path(file_path).map_err(|_| anyhow!("invalid file path"))?;
+
+        queue_client.enqueue(file_url).await?;
+    }
+
+    Ok(())
 }
 
 pub async fn wait_for_dir(path: impl AsRef<Path>) -> Result<()> {

--- a/src/agent/onefuzz-agent/src/tasks/report/crash_report.rs
+++ b/src/agent/onefuzz-agent/src/tasks/report/crash_report.rs
@@ -311,12 +311,13 @@ pub async fn monitor_reports(
         return Ok(());
     }
 
-    let mut monitor = DirectoryMonitor::new(base_dir)?;
-    monitor.start().await?;
+    let mut monitor = DirectoryMonitor::new(base_dir).await?;
+
     while let Some(file) = monitor.next_file().await? {
         let result = parse_report_file(file).await?;
         result.save(unique_reports, reports, no_crash).await?;
     }
+
     Ok(())
 }
 

--- a/src/agent/onefuzz/examples/dir-monitor.rs
+++ b/src/agent/onefuzz/examples/dir-monitor.rs
@@ -15,8 +15,7 @@ struct Opt {
 async fn main() -> Result<()> {
     let opt = Opt::from_args();
 
-    let mut monitor = DirectoryMonitor::new(opt.path)?;
-    monitor.start().await?;
+    let mut monitor = DirectoryMonitor::new(opt.path).await?;
 
     while let Some(created) = monitor.next_file().await? {
         println!("[create] {}", created.display());

--- a/src/agent/onefuzz/src/syncdir.rs
+++ b/src/agent/onefuzz/src/syncdir.rs
@@ -225,8 +225,7 @@ impl SyncedDir {
     ) -> Result<()> {
         debug!("monitoring {}", path.display());
 
-        let mut monitor = DirectoryMonitor::new(path.clone())?;
-        monitor.start().await?;
+        let mut monitor = DirectoryMonitor::new(path.clone()).await?;
 
         if let Some(path) = url.as_file_path() {
             fs::create_dir_all(&path).await?;


### PR DESCRIPTION
Use a simpler and less error-prone API for `DirectoryMonitor`.

- Make `new()` ctor async, set watch on construction
- Remove `start()`, validate that target path is a directory in `new()`

Closes #1864.