### PR TITLE
Don't trigger build on every push, enable manual trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: Build
-on: [push, pull_request]
+on: [pull_request, workflow_dispatch]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Update build action triggers to only build on either PR creation/reopen/push, or manual build triggering.

- Remove the `push` trigger for the "Build" action
- Add the `workflow_dispatch` trigger to the "Build" action, to [enable pre-PR manual workflow triggers](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow#configuring-a-workflow-to-run-manually)

Closes #1871.