### PR TITLE
copy api-service-net.zip to deployment folder #1752

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -363,6 +363,7 @@ jobs:
           cp artifacts/agent-Linux/onefuzz-agent src/deployment/tools/linux/
           cp artifacts/proxy/onefuzz-proxy-manager src/deployment/tools/linux/
           cp artifacts/service/api-service.zip src/deployment
+          cp artifacts/service-net/api-service-net.zip src/deployment          
           cp -r artifacts/third-party src/deployment
           cp -r src/agent/script/linux/libfuzzer-coverage src/deployment/tools/linux/libfuzzer-coverage
           cp -r src/agent/script/win64/libfuzzer-coverage src/deployment/tools/win64/libfuzzer-coverage


### PR DESCRIPTION
## Summary of the Pull Request

Missing a needed copy statement in CI config for moving api-service-net.zip into the deployment folder.

## PR Checklist
* [x] Applies to work item: #1752

## Info on Pull Request

Updated:
.github/workflows/ci.yml

