### PR TITLE
Introducing OnefuzzContext to prevent circular references

### DIFF
--- a/src/ApiService/ApiService/OneFuzzTypes/Model.cs
+++ b/src/ApiService/ApiService/OneFuzzTypes/Model.cs
@@ -86,17 +86,19 @@ public record Node
     [RowKey] Guid MachineId,
     Guid? PoolId,
     string Version,
-
     DateTimeOffset? Heartbeat = null,
     DateTimeOffset? InitializedAt = null,
     NodeState State = NodeState.Init,
-    List<NodeTasks>? Tasks = null,
-    List<NodeCommand>? Messages = null,
+
     Guid? ScalesetId = null,
     bool ReimageRequested = false,
     bool DeleteRequested = false,
     bool DebugKeepNode = false
-) : StatefulEntityBase<NodeState>(State);
+) : StatefulEntityBase<NodeState>(State) {
+
+    public List<NodeTasks>? Tasks {get; set;}
+    public List<NodeCommand>? Messages {get; set;}
+}
 
 
 public record Forward

--- a/src/ApiService/ApiService/OneFuzzTypes/Model.cs
+++ b/src/ApiService/ApiService/OneFuzzTypes/Model.cs
@@ -96,8 +96,8 @@ public record Node
     bool DebugKeepNode = false
 ) : StatefulEntityBase<NodeState>(State) {
 
-    public List<NodeTasks>? Tasks {get; set;}
-    public List<NodeCommand>? Messages {get; set;}
+    public List<NodeTasks>? Tasks { get; set; }
+    public List<NodeCommand>? Messages { get; set; }
 }
 
 

--- a/src/ApiService/ApiService/Program.cs
+++ b/src/ApiService/ApiService/Program.cs
@@ -103,6 +103,7 @@ public class Program {
             .AddScoped<IVmssOperations, VmssOperations>()
             .AddScoped<INodeTasksOperations, NodeTasksOperations>()
             .AddScoped<INodeMessageOperations, NodeMessageOperations>()
+            .AddScoped<IOnefuzzContext, OnefuzzContext>()
 
             .AddSingleton<ICreds, Creds>()
             .AddSingleton<IServiceConfig, ServiceConfiguration>()

--- a/src/ApiService/ApiService/QueueNodeHearbeat.cs
+++ b/src/ApiService/ApiService/QueueNodeHearbeat.cs
@@ -8,22 +8,22 @@ namespace Microsoft.OneFuzz.Service;
 public class QueueNodeHearbeat {
     private readonly ILogTracer _log;
 
-    private readonly IEvents _events;
-    private readonly INodeOperations _nodes;
+    private readonly IOnefuzzContext _context;
 
-    public QueueNodeHearbeat(ILogTracer log, INodeOperations nodes, IEvents events) {
+    public QueueNodeHearbeat(ILogTracer log, IOnefuzzContext context) {
         _log = log;
-        _nodes = nodes;
-        _events = events;
+        _context = context;
     }
 
     [Function("QueueNodeHearbeat")]
     public async Async.Task Run([QueueTrigger("myqueue-items", Connection = "AzureWebJobsStorage")] string msg) {
         _log.Info($"heartbeat: {msg}");
+        var nodes = _context.NodeOperations;
+        var events = _context.Events;
 
         var hb = JsonSerializer.Deserialize<NodeHeartbeatEntry>(msg, EntityConverter.GetJsonSerializerOptions()).EnsureNotNull($"wrong data {msg}");
 
-        var node = await _nodes.GetByMachineId(hb.NodeId);
+        var node = await nodes.GetByMachineId(hb.NodeId);
 
         var log = _log.WithTag("NodeId", hb.NodeId.ToString());
 
@@ -34,7 +34,7 @@ public class QueueNodeHearbeat {
 
         var newNode = node with { Heartbeat = DateTimeOffset.UtcNow };
 
-        var r = await _nodes.Replace(newNode);
+        var r = await nodes.Replace(newNode);
 
         if (!r.IsOk) {
             var (status, reason) = r.ErrorV;
@@ -42,6 +42,6 @@ public class QueueNodeHearbeat {
         }
 
         // TODO: do we still send event if we fail do update the table ?
-        await _events.SendEvent(new EventNodeHeartbeat(node.MachineId, node.ScalesetId, node.PoolName));
+        await events.SendEvent(new EventNodeHeartbeat(node.MachineId, node.ScalesetId, node.PoolName));
     }
 }

--- a/src/ApiService/ApiService/onefuzzlib/InstanceConfig.cs
+++ b/src/ApiService/ApiService/onefuzzlib/InstanceConfig.cs
@@ -11,16 +11,14 @@ public interface IConfigOperations : IOrm<InstanceConfig> {
 }
 
 public class ConfigOperations : Orm<InstanceConfig>, IConfigOperations {
-    private readonly IEvents _events;
     private readonly ILogTracer _log;
 
-    public ConfigOperations(IStorage storage, IEvents events, ILogTracer log, IServiceConfig config) : base(storage, log, config) {
-        _events = events;
+    public ConfigOperations(ILogTracer log, IOnefuzzContext context) : base(log, context) {
         _log = log;
     }
 
     public async Task<InstanceConfig> Fetch() {
-        var key = _config.OneFuzzInstanceName ?? throw new Exception("Environment variable ONEFUZZ_INSTANCE_NAME is not set");
+        var key = _context.ServiceConfiguration.OneFuzzInstanceName ?? throw new Exception("Environment variable ONEFUZZ_INSTANCE_NAME is not set");
         var config = await GetEntityAsync(key, key);
         return config;
     }
@@ -44,6 +42,6 @@ public class ConfigOperations : Orm<InstanceConfig>, IConfigOperations {
             }
         }
 
-        await _events.SendEvent(new EventInstanceConfigUpdated(config));
+        await _context.Events.SendEvent(new EventInstanceConfigUpdated(config));
     }
 }

--- a/src/ApiService/ApiService/onefuzzlib/JobOperations.cs
+++ b/src/ApiService/ApiService/onefuzzlib/JobOperations.cs
@@ -12,10 +12,8 @@ public interface IJobOperations : IStatefulOrm<Job, JobState> {
 }
 
 public class JobOperations : StatefulOrm<Job, JobState>, IJobOperations {
-    private readonly IEvents _events;
 
-    public JobOperations(IStorage storage, ILogTracer logTracer, IServiceConfig config, IEvents events) : base(storage, logTracer, config) {
-        _events = events;
+    public JobOperations(ILogTracer logTracer, IOnefuzzContext context) : base(logTracer, context) {
     }
 
     public async Async.Task<Job?> Get(Guid jobId) {
@@ -59,7 +57,7 @@ public class JobOperations : StatefulOrm<Job, JobState>, IJobOperations {
         } else {
             job = job with { State = JobState.Stopped };
             var taskInfo = stopped.Select(t => new JobTaskStopped(t.TaskId, t.Config.Task.Type, t.Error)).ToList();
-            await _events.SendEvent(new EventJobStopped(job.JobId, job.Config, job.UserInfo, taskInfo));
+            await _context.Events.SendEvent(new EventJobStopped(job.JobId, job.Config, job.UserInfo, taskInfo));
         }
 
         await Replace(job);

--- a/src/ApiService/ApiService/onefuzzlib/NotificationOperations.cs
+++ b/src/ApiService/ApiService/onefuzzlib/NotificationOperations.cs
@@ -9,28 +9,15 @@ public interface INotificationOperations : IOrm<Notification> {
 }
 
 public class NotificationOperations : Orm<Notification>, INotificationOperations {
-    private IReports _reports;
-    private ITaskOperations _taskOperations;
 
-    private IContainers _containers;
+    public NotificationOperations(ILogTracer log, IOnefuzzContext context)
+        : base(log, context) {
 
-    private IQueue _queue;
-
-    private IEvents _events;
-
-    public NotificationOperations(ILogTracer log, IStorage storage, IReports reports, ITaskOperations taskOperations, IContainers containers, IQueue queue, IEvents events, IServiceConfig config)
-        : base(storage, log, config) {
-
-        _reports = reports;
-        _taskOperations = taskOperations;
-        _containers = containers;
-        _queue = queue;
-        _events = events;
     }
     public async Async.Task NewFiles(Container container, string filename, bool failTaskOnTransientError) {
         var notifications = GetNotifications(container);
         var hasNotifications = await notifications.AnyAsync();
-        var report = await _reports.GetReportOrRegression(container, filename, expectReports: hasNotifications);
+        var report = await _context.Reports.GetReportOrRegression(container, filename, expectReports: hasNotifications);
 
         if (!hasNotifications) {
             return;
@@ -64,18 +51,18 @@ public class NotificationOperations : Orm<Notification>, INotificationOperations
         await foreach (var (task, containers) in GetQueueTasks()) {
             if (containers.Contains(container.ContainerName)) {
                 _logTracer.Info($"queuing input {container.ContainerName} {filename} {task.TaskId}");
-                var url = _containers.GetFileSasUrl(container, filename, StorageType.Corpus, BlobSasPermissions.Read | BlobSasPermissions.Delete);
-                await _queue.SendMessage(task.TaskId.ToString(), url?.ToString() ?? "", StorageType.Corpus);
+                var url = _context.Containers.GetFileSasUrl(container, filename, StorageType.Corpus, BlobSasPermissions.Read | BlobSasPermissions.Delete);
+                await _context.Queue.SendMessage(task.TaskId.ToString(), url?.ToString() ?? "", StorageType.Corpus);
             }
         }
 
         if (report == null) {
-            await _events.SendEvent(new EventFileAdded(container, filename));
+            await _context.Events.SendEvent(new EventFileAdded(container, filename));
         } else if (report.Report != null) {
-            var reportTask = await _taskOperations.GetByJobIdAndTaskId(report.Report.JobId, report.Report.TaskId);
+            var reportTask = await _context.TaskOperations.GetByJobIdAndTaskId(report.Report.JobId, report.Report.TaskId);
 
             var crashReportedEvent = new EventCrashReported(report.Report, container, filename, reportTask?.Config);
-            await _events.SendEvent(crashReportedEvent);
+            await _context.Events.SendEvent(crashReportedEvent);
         } else if (report.RegressionReport != null) {
             var reportTask = await GetRegressionReportTask(report.RegressionReport);
 
@@ -89,17 +76,17 @@ public class NotificationOperations : Orm<Notification>, INotificationOperations
 
     public IAsyncEnumerable<(Task, IEnumerable<string>)> GetQueueTasks() {
         // Nullability mismatch: We filter tuples where the containers are null
-        return _taskOperations.SearchStates(states: TaskStateHelper.Available())
-            .Select(task => (task, _taskOperations.GetInputContainerQueues(task.Config)))
+        return _context.TaskOperations.SearchStates(states: TaskStateHelper.Available())
+            .Select(task => (task, _context.TaskOperations.GetInputContainerQueues(task.Config)))
             .Where(taskTuple => taskTuple.Item2 != null)!;
     }
 
     private async Async.Task<Task?> GetRegressionReportTask(RegressionReport report) {
         if (report.CrashTestResult.CrashReport != null) {
-            return await _taskOperations.GetByJobIdAndTaskId(report.CrashTestResult.CrashReport.JobId, report.CrashTestResult.CrashReport.TaskId);
+            return await _context.TaskOperations.GetByJobIdAndTaskId(report.CrashTestResult.CrashReport.JobId, report.CrashTestResult.CrashReport.TaskId);
         }
         if (report.CrashTestResult.NoReproReport != null) {
-            return await _taskOperations.GetByJobIdAndTaskId(report.CrashTestResult.NoReproReport.JobId, report.CrashTestResult.NoReproReport.TaskId);
+            return await _context.TaskOperations.GetByJobIdAndTaskId(report.CrashTestResult.NoReproReport.JobId, report.CrashTestResult.NoReproReport.TaskId);
         }
 
         _logTracer.Error($"unable to find crash_report or no repro entry for report: {JsonSerializer.Serialize(report)}");

--- a/src/ApiService/ApiService/onefuzzlib/OnefuzzContext.cs
+++ b/src/ApiService/ApiService/onefuzzlib/OnefuzzContext.cs
@@ -1,0 +1,78 @@
+﻿namespace Microsoft.OneFuzz.Service;
+
+using Microsoft.Extensions.DependencyInjection;
+
+public interface IOnefuzzContext {
+    IConfig Config { get; }
+    IConfigOperations ConfigOperations { get; }
+    IContainers Containers { get; }
+    ICreds Creds { get; }
+    IDiskOperations DiskOperations { get; }
+    IEvents Events { get; }
+    IExtensions Extensions { get; }
+    IIpOperations IpOperations { get; }
+    IJobOperations JobOperations { get; }
+    ILogAnalytics LogAnalytics { get; }
+    INodeMessageOperations NodeMessageOperations { get; }
+    INodeOperations NodeOperations { get; }
+    INodeTasksOperations NodeTasksOperations { get; }
+    INotificationOperations NotificationOperations { get; }
+    IPoolOperations PoolOperations { get; }
+    IProxyForwardOperations ProxyForwardOperations { get; }
+    IProxyOperations ProxyOperations { get; }
+    IQueue Queue { get; }
+    IReports Reports { get; }
+    IReproOperations ReproOperations { get; }
+    IScalesetOperations ScalesetOperations { get; }
+    IScheduler Scheduler { get; }
+    ISecretsOperations SecretsOperations { get; }
+    IServiceConfig ServiceConfiguration { get; }
+    IStorage Storage { get; }
+    ITaskOperations TaskOperations { get; }
+    IUserCredentials UserCredentials { get; }
+    IVmOperations VmOperations { get; }
+    IVmssOperations VmssOperations { get; }
+    IWebhookMessageLogOperations WebhookMessageLogOperations { get; }
+    IWebhookOperations WebhookOperations { get; }
+}
+
+public class OnefuzzContext : IOnefuzzContext {
+
+    private readonly IServiceProvider _serviceProvider;
+    public INodeOperations NodeOperations { get => _serviceProvider.GetService<INodeOperations>() ?? throw new Exception("No INodeOperations service"); }
+    public IEvents Events { get => _serviceProvider.GetService<IEvents>() ?? throw new Exception("No IEvents service"); }
+    public IWebhookOperations WebhookOperations { get => _serviceProvider.GetService<IWebhookOperations>() ?? throw new Exception("No IWebhookOperations service"); }
+    public IWebhookMessageLogOperations WebhookMessageLogOperations { get => _serviceProvider.GetService<IWebhookMessageLogOperations>() ?? throw new Exception("No IWebhookMessageLogOperations service"); }
+    public ITaskOperations TaskOperations { get => _serviceProvider.GetService<ITaskOperations>() ?? throw new Exception("No ITaskOperations service"); }
+    public IQueue Queue { get => _serviceProvider.GetService<IQueue>() ?? throw new Exception("No IQueue service"); }
+    public IStorage Storage { get => _serviceProvider.GetService<IStorage>() ?? throw new Exception("No IStorage service"); }
+    public IProxyOperations ProxyOperations { get => _serviceProvider.GetService<IProxyOperations>() ?? throw new Exception("No IProxyOperations service"); }
+    public IProxyForwardOperations ProxyForwardOperations { get => _serviceProvider.GetService<IProxyForwardOperations>() ?? throw new Exception("No IProxyForwardOperations service"); }
+    public IConfigOperations ConfigOperations { get => _serviceProvider.GetService<IConfigOperations>() ?? throw new Exception("No IConfigOperations service"); }
+    public IScalesetOperations ScalesetOperations { get => _serviceProvider.GetService<IScalesetOperations>() ?? throw new Exception("No IScalesetOperations service"); }
+    public IContainers Containers { get => _serviceProvider.GetService<IContainers>() ?? throw new Exception("No IContainers service"); }
+    public IReports Reports { get => _serviceProvider.GetService<IReports>() ?? throw new Exception("No IReports service"); }
+    public INotificationOperations NotificationOperations { get => _serviceProvider.GetService<INotificationOperations>() ?? throw new Exception("No INotificationOperations service"); }
+    public IUserCredentials UserCredentials { get => _serviceProvider.GetService<IUserCredentials>() ?? throw new Exception("No IUserCredentials service"); }
+    public IReproOperations ReproOperations { get => _serviceProvider.GetService<IReproOperations>() ?? throw new Exception("No IReproOperations service"); }
+    public IPoolOperations PoolOperations { get => _serviceProvider.GetService<IPoolOperations>() ?? throw new Exception("No IPoolOperations service"); }
+    public IIpOperations IpOperations { get => _serviceProvider.GetService<IIpOperations>() ?? throw new Exception("No IIpOperations service"); }
+    public IDiskOperations DiskOperations { get => _serviceProvider.GetService<IDiskOperations>() ?? throw new Exception("No IDiskOperations service"); }
+    public IVmOperations VmOperations { get => _serviceProvider.GetService<IVmOperations>() ?? throw new Exception("No IVmOperations service"); }
+    public ISecretsOperations SecretsOperations { get => _serviceProvider.GetService<ISecretsOperations>() ?? throw new Exception("No ISecretsOperations service"); }
+    public IJobOperations JobOperations { get => _serviceProvider.GetService<IJobOperations>() ?? throw new Exception("No IJobOperations service"); }
+    public IScheduler Scheduler { get => _serviceProvider.GetService<IScheduler>() ?? throw new Exception("No IScheduler service"); }
+    public IConfig Config { get => _serviceProvider.GetService<IConfig>() ?? throw new Exception("No IConfig service"); }
+    public ILogAnalytics LogAnalytics { get => _serviceProvider.GetService<ILogAnalytics>() ?? throw new Exception("No ILogAnalytics service"); }
+    public IExtensions Extensions { get => _serviceProvider.GetService<IExtensions>() ?? throw new Exception("No IExtensions service"); }
+    public IVmssOperations VmssOperations { get => _serviceProvider.GetService<IVmssOperations>() ?? throw new Exception("No IVmssOperations service"); }
+    public INodeTasksOperations NodeTasksOperations { get => _serviceProvider.GetService<INodeTasksOperations>() ?? throw new Exception("No INodeTasksOperations service"); }
+    public INodeMessageOperations NodeMessageOperations { get => _serviceProvider.GetService<INodeMessageOperations>() ?? throw new Exception("No INodeMessageOperations service"); }
+    public ICreds Creds { get => _serviceProvider.GetService<ICreds>() ?? throw new Exception("No ICreds service"); }
+    public IServiceConfig ServiceConfiguration { get => _serviceProvider.GetService<IServiceConfig>() ?? throw new Exception("No IServiceConfiguration service"); }
+
+    public OnefuzzContext(IServiceProvider serviceProvider) {
+        _serviceProvider = serviceProvider;
+    }
+}
+

--- a/src/ApiService/ApiService/onefuzzlib/PoolOperations.cs
+++ b/src/ApiService/ApiService/onefuzzlib/PoolOperations.cs
@@ -9,13 +9,10 @@ public interface IPoolOperations {
 }
 
 public class PoolOperations : StatefulOrm<Pool, PoolState>, IPoolOperations {
-    private IConfigOperations _configOperations;
-    private readonly IQueue _queue;
 
-    public PoolOperations(IStorage storage, ILogTracer log, IServiceConfig config, IConfigOperations configOperations, IQueue queue)
-        : base(storage, log, config) {
-        _configOperations = configOperations;
-        _queue = queue;
+    public PoolOperations(ILogTracer log, IOnefuzzContext context)
+        : base(log, context) {
+
     }
 
     public async Async.Task<Result<Pool, Error>> GetByName(string poolName) {
@@ -37,7 +34,7 @@ public class PoolOperations : StatefulOrm<Pool, PoolState>, IPoolOperations {
             return false;
         }
 
-        return await _queue.QueueObject(GetPoolQueue(pool), workSet, StorageType.Corpus);
+        return await _context.Queue.QueueObject(GetPoolQueue(pool), workSet, StorageType.Corpus);
     }
 
     private string GetPoolQueue(Pool pool) {

--- a/src/ApiService/ApiService/onefuzzlib/ProxyForwardOperations.cs
+++ b/src/ApiService/ApiService/onefuzzlib/ProxyForwardOperations.cs
@@ -12,7 +12,7 @@ public class ProxyForwardOperations : Orm<ProxyForward>, IProxyForwardOperations
     public ProxyForwardOperations(ILogTracer log, IOnefuzzContext context)
         : base(log, context) {
 
-        }
+    }
 
     public IAsyncEnumerable<ProxyForward> SearchForward(Guid? scalesetId = null, string? region = null, Guid? machineId = null, Guid? proxyId = null, int? dstPort = null) {
 

--- a/src/ApiService/ApiService/onefuzzlib/ProxyForwardOperations.cs
+++ b/src/ApiService/ApiService/onefuzzlib/ProxyForwardOperations.cs
@@ -9,8 +9,10 @@ public interface IProxyForwardOperations : IOrm<ProxyForward> {
 
 
 public class ProxyForwardOperations : Orm<ProxyForward>, IProxyForwardOperations {
-    public ProxyForwardOperations(IStorage storage, ILogTracer logTracer, IServiceConfig config) : base(storage, logTracer, config) {
-    }
+    public ProxyForwardOperations(ILogTracer log, IOnefuzzContext context)
+        : base(log, context) {
+
+        }
 
     public IAsyncEnumerable<ProxyForward> SearchForward(Guid? scalesetId = null, string? region = null, Guid? machineId = null, Guid? proxyId = null, int? dstPort = null) {
 

--- a/src/ApiService/ApiService/onefuzzlib/ProxyOperations.cs
+++ b/src/ApiService/ApiService/onefuzzlib/ProxyOperations.cs
@@ -15,22 +15,14 @@ public interface IProxyOperations : IStatefulOrm<Proxy, VmState> {
 }
 public class ProxyOperations : StatefulOrm<Proxy, VmState>, IProxyOperations {
 
-    private readonly IEvents _events;
-    private readonly IProxyForwardOperations _proxyForwardOperations;
-    private readonly IContainers _containers;
-    private readonly IQueue _queue;
-    private readonly ICreds _creds;
 
     static TimeSpan PROXY_LIFESPAN = TimeSpan.FromDays(7);
 
-    public ProxyOperations(ILogTracer log, IStorage storage, IEvents events, IProxyForwardOperations proxyForwardOperations, IContainers containers, IQueue queue, ICreds creds, IServiceConfig config)
-            : base(storage, log.WithTag("Component", "scaleset-proxy"), config) {
-        _events = events;
-        _proxyForwardOperations = proxyForwardOperations;
-        _containers = containers;
-        _queue = queue;
-        _creds = creds;
+    public ProxyOperations(ILogTracer log, IOnefuzzContext context)
+        : base(log.WithTag("Component", "scaleset-proxy"), context) {
+
     }
+
 
     public async Task<Proxy?> GetByProxyId(Guid proxyId) {
 
@@ -55,10 +47,10 @@ public class ProxyOperations : StatefulOrm<Proxy, VmState>, IProxyOperations {
         }
 
         _logTracer.Info($"creating proxy: region:{region}");
-        var newProxy = new Proxy(region, Guid.NewGuid(), DateTimeOffset.UtcNow, VmState.Init, Auth.BuildAuth(), null, null, _config.OneFuzzVersion.ToString(), null, false);
+        var newProxy = new Proxy(region, Guid.NewGuid(), DateTimeOffset.UtcNow, VmState.Init, Auth.BuildAuth(), null, null, _context.ServiceConfiguration.OneFuzzVersion, null, false);
 
         await Replace(newProxy);
-        await _events.SendEvent(new EventProxyCreated(region, newProxy.ProxyId));
+        await _context.Events.SendEvent(new EventProxyCreated(region, newProxy.ProxyId));
         return newProxy;
     }
 
@@ -83,8 +75,8 @@ public class ProxyOperations : StatefulOrm<Proxy, VmState>, IProxyOperations {
             return false;
         }
 
-        if (proxy.Version != _config.OneFuzzVersion) {
-            _logTracer.Info($"mismatch version: proxy:{proxy.Version} service:{_config.OneFuzzVersion} state:{proxy.State}");
+        if (proxy.Version != _context.ServiceConfiguration.OneFuzzVersion) {
+            _logTracer.Info($"mismatch version: proxy:{proxy.Version} service:{_context.ServiceConfiguration.OneFuzzVersion} state:{proxy.State}");
             return true;
         }
 
@@ -99,8 +91,8 @@ public class ProxyOperations : StatefulOrm<Proxy, VmState>, IProxyOperations {
 
     public async Async.Task SaveProxyConfig(Proxy proxy) {
         var forwards = await GetForwards(proxy);
-        var url = (await _containers.GetFileSasUrl(new Container("proxy-configs"), $"{proxy.Region}/{proxy.ProxyId}/config.json", StorageType.Config, BlobSasPermissions.Read)).EnsureNotNull("Can't generate file sas");
-        var queueSas = await _queue.GetQueueSas("proxy", StorageType.Config, QueueSasPermissions.Add).EnsureNotNull("can't generate queue sas") ?? throw new Exception("Queue sas is null");
+        var url = (await _context.Containers.GetFileSasUrl(new Container("proxy-configs"), $"{proxy.Region}/{proxy.ProxyId}/config.json", StorageType.Config, BlobSasPermissions.Read)).EnsureNotNull("Can't generate file sas");
+        var queueSas = await _context.Queue.GetQueueSas("proxy", StorageType.Config, QueueSasPermissions.Add).EnsureNotNull("can't generate queue sas") ?? throw new Exception("Queue sas is null");
 
         var proxyConfig = new ProxyConfig(
             Url: url,
@@ -108,11 +100,11 @@ public class ProxyOperations : StatefulOrm<Proxy, VmState>, IProxyOperations {
             Region: proxy.Region,
             ProxyId: proxy.ProxyId,
             Forwards: forwards,
-            InstanceTelemetryKey: _config.ApplicationInsightsInstrumentationKey.EnsureNotNull("missing InstrumentationKey"),
-            MicrosoftTelemetryKey: _config.OneFuzzTelemetry.EnsureNotNull("missing Telemetry"),
-            InstanceId: await _containers.GetInstanceId());
+            InstanceTelemetryKey: _context.ServiceConfiguration.ApplicationInsightsInstrumentationKey.EnsureNotNull("missing InstrumentationKey"),
+            MicrosoftTelemetryKey: _context.ServiceConfiguration.OneFuzzTelemetry.EnsureNotNull("missing Telemetry"),
+            InstanceId: await _context.Containers.GetInstanceId());
 
-        await _containers.SaveBlob(new Container("proxy-configs"), $"{proxy.Region}/{proxy.ProxyId}/config.json", _entityConverter.ToJsonString(proxyConfig), StorageType.Config);
+        await _context.Containers.SaveBlob(new Container("proxy-configs"), $"{proxy.Region}/{proxy.ProxyId}/config.json", _entityConverter.ToJsonString(proxyConfig), StorageType.Config);
     }
 
 
@@ -124,16 +116,16 @@ public class ProxyOperations : StatefulOrm<Proxy, VmState>, IProxyOperations {
 
         await Replace(proxy with { State = state });
 
-        await _events.SendEvent(new EventProxyStateUpdated(proxy.Region, proxy.ProxyId, proxy.State));
+        await _context.Events.SendEvent(new EventProxyStateUpdated(proxy.Region, proxy.ProxyId, proxy.State));
     }
 
 
     public async Async.Task<List<Forward>> GetForwards(Proxy proxy) {
         var forwards = new List<Forward>();
 
-        await foreach (var entry in _proxyForwardOperations.SearchForward(region: proxy.Region, proxyId: proxy.ProxyId)) {
+        await foreach (var entry in _context.ProxyForwardOperations.SearchForward(region: proxy.Region, proxyId: proxy.ProxyId)) {
             if (entry.EndTime < DateTimeOffset.UtcNow) {
-                await _proxyForwardOperations.Delete(entry);
+                await _context.ProxyForwardOperations.Delete(entry);
             } else {
                 forwards.Add(new Forward(entry.Port, entry.DstPort, entry.DstIp));
             }

--- a/src/ApiService/ApiService/onefuzzlib/ReproOperations.cs
+++ b/src/ApiService/ApiService/onefuzzlib/ReproOperations.cs
@@ -19,19 +19,11 @@ public class ReproOperations : StatefulOrm<Repro, VmState>, IReproOperations {
 
     const string DEFAULT_SKU = "Standard_DS1_v2";
 
-    private IConfigOperations _configOperations;
-    private ITaskOperations _taskOperations;
 
-    private IVmOperations _vmOperations;
 
-    private ICreds _creds;
+    public ReproOperations(ILogTracer log, IOnefuzzContext context)
+        : base(log, context) {
 
-    public ReproOperations(IStorage storage, ILogTracer log, IServiceConfig config, IConfigOperations configOperations, ITaskOperations taskOperations, ICreds creds, IVmOperations vmOperations)
-        : base(storage, log, config) {
-        _configOperations = configOperations;
-        _taskOperations = taskOperations;
-        _creds = creds;
-        _vmOperations = vmOperations;
     }
 
     public IAsyncEnumerable<Repro> SearchExpired() {
@@ -39,20 +31,21 @@ public class ReproOperations : StatefulOrm<Repro, VmState>, IReproOperations {
     }
 
     public async Async.Task<Vm> GetVm(Repro repro, InstanceConfig config) {
+        var taskOperations = _context.TaskOperations;
         var tags = config.VmTags;
-        var task = await _taskOperations.GetByTaskId(repro.TaskId);
+        var task = await taskOperations.GetByTaskId(repro.TaskId);
         if (task == null) {
             throw new Exception($"previous existing task missing: {repro.TaskId}");
         }
 
-        var vmConfig = await _taskOperations.GetReproVmConfig(task);
+        var vmConfig = await taskOperations.GetReproVmConfig(task);
         if (vmConfig == null) {
             if (!DEFAULT_OS.ContainsKey(task.Os)) {
                 throw new NotImplementedException($"unsupport OS for repro {task.Os}");
             }
 
             vmConfig = new TaskVm(
-                await _creds.GetBaseRegion(),
+                await _context.Creds.GetBaseRegion(),
                 DEFAULT_SKU,
                 DEFAULT_OS[task.Os],
                 null
@@ -75,11 +68,12 @@ public class ReproOperations : StatefulOrm<Repro, VmState>, IReproOperations {
     }
 
     public async Async.Task Stopping(Repro repro) {
-        var config = await _configOperations.Fetch();
+        var config = await _context.ConfigOperations.Fetch();
         var vm = await GetVm(repro, config);
-        if (!await _vmOperations.IsDeleted(vm)) {
+        var vmOperations = _context.VmOperations;
+        if (!await vmOperations.IsDeleted(vm)) {
             _logTracer.Info($"vm stopping: {repro.VmId}");
-            await _vmOperations.Delete(vm);
+            await vmOperations.Delete(vm);
             await Replace(repro);
         } else {
             await Stopped(repro);

--- a/src/ApiService/ApiService/onefuzzlib/orm/EntityConverter.cs
+++ b/src/ApiService/ApiService/onefuzzlib/orm/EntityConverter.cs
@@ -276,7 +276,7 @@ public class EntityConverter {
             entityRecord.TimeStamp = entity.Timestamp;
             return entityRecord;
 
-        } catch (Exception ex ) {
+        } catch (Exception ex) {
             var stringParam = string.Join(", ", parameters);
             throw new Exception($"Could not initialize object of type {typeof(T)} with the following parameters: {stringParam} constructor {entityInfo.constructor} : {ex}");
         }

--- a/src/ApiService/ApiService/onefuzzlib/orm/EntityConverter.cs
+++ b/src/ApiService/ApiService/onefuzzlib/orm/EntityConverter.cs
@@ -276,9 +276,9 @@ public class EntityConverter {
             entityRecord.TimeStamp = entity.Timestamp;
             return entityRecord;
 
-        } catch (Exception) {
+        } catch (Exception ex ) {
             var stringParam = string.Join(", ", parameters);
-            throw new Exception($"Could not initialize object of type {typeof(T)} with the following parameters: {stringParam} constructor {entityInfo.constructor}");
+            throw new Exception($"Could not initialize object of type {typeof(T)} with the following parameters: {stringParam} constructor {entityInfo.constructor} : {ex}");
         }
 
     }

--- a/src/ApiService/ApiService/onefuzzlib/orm/Orm.cs
+++ b/src/ApiService/ApiService/onefuzzlib/orm/Orm.cs
@@ -19,18 +19,15 @@ namespace ApiService.OneFuzzLib.Orm {
 
 
     public class Orm<T> : IOrm<T> where T : EntityBase {
-        protected readonly IStorage _storage;
         protected readonly EntityConverter _entityConverter;
+        protected readonly IOnefuzzContext _context;
         protected readonly ILogTracer _logTracer;
 
-        protected readonly IServiceConfig _config;
 
-
-        public Orm(IStorage storage, ILogTracer logTracer, IServiceConfig config) {
-            _storage = storage;
-            _entityConverter = new EntityConverter();
+        public Orm(ILogTracer logTracer, IOnefuzzContext context) {
+            _context = context;
             _logTracer = logTracer;
-            _config = config;
+            _entityConverter = new EntityConverter();
         }
 
         public async IAsyncEnumerable<T> QueryAsync(string? filter = null) {
@@ -87,8 +84,8 @@ namespace ApiService.OneFuzzLib.Orm {
         }
 
         public async Task<TableClient> GetTableClient(string table, string? accountId = null) {
-            var account = accountId ?? _config.OneFuzzFuncStorage ?? throw new ArgumentNullException(nameof(accountId));
-            var (name, key) = await _storage.GetStorageAccountNameAndKey(account);
+            var account = accountId ?? _context.ServiceConfiguration.OneFuzzFuncStorage ?? throw new ArgumentNullException(nameof(accountId));
+            var (name, key) = await _context.Storage.GetStorageAccountNameAndKey(account);
             var tableClient = new TableServiceClient(new Uri($"https://{name}.table.core.windows.net"), new TableSharedKeyCredential(name, key));
             await tableClient.CreateTableIfNotExistsAsync(table);
             return tableClient.GetTableClient(table);
@@ -134,7 +131,7 @@ namespace ApiService.OneFuzzLib.Orm {
                 };
         }
 
-        public StatefulOrm(IStorage storage, ILogTracer logTracer, IServiceConfig config) : base(storage, logTracer, config) {
+        public StatefulOrm(ILogTracer logTracer, IOnefuzzContext context) : base(logTracer, context) {
         }
 
         /// <summary>


### PR DESCRIPTION
- Creating a OnefuzzContext object that contains most of our dependencies
- update some classes to use this object instead of direct dependencies