### PR TITLE
updating deploy.py to push dotnet by default

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,7 +150,7 @@ OneFuzz is built with multiple components and runs on Linux and Windows:
 * [Python](https://www.python.org) (at least 3.7 or later)
 * [Azure Functions Core
   Tools](https://docs.microsoft.com/en-us/azure/azure-functions/functions-run-local)
-(latest version of the 3.x)
+(latest version of the 4.x)
 
 While local builds are possible for every component of the system, new
 contributors may find [automatic builds for

--- a/contrib/deploy-onefuzz-via-azure-devops/deploy-onefuzz.yml
+++ b/contrib/deploy-onefuzz-via-azure-devops/deploy-onefuzz.yml
@@ -74,7 +74,7 @@ stages:
               wget -q https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb
               sudo dpkg -i packages-microsoft-prod.deb
               sudo apt-get update
-              sudo apt-get install azure-functions-core-tools-3
+              sudo apt-get install azure-functions-core-tools-4
 
         - task: CmdLine@2
           displayName: "Deploying update to OneFuzz"

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -19,7 +19,7 @@ registered:
 ## Deploying an instance of OneFuzz
 
 Ensure you have Python with `python --version` >= 3.7, [Azure Functions Core Tools
-v3](https://docs.microsoft.com/en-us/azure/azure-functions/functions-run-local),
+v4](https://docs.microsoft.com/en-us/azure/azure-functions/functions-run-local),
 and OpenSSL installed.
 
 From the [Latest Release of

--- a/src/ApiService/ApiService/az-local.settings.json
+++ b/src/ApiService/ApiService/az-local.settings.json
@@ -1,6 +1,7 @@
 {
     "IsEncrypted": false,
     "Values": {
-      "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated"
+      "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
+      "linux_fx_version": "DOTNET-ISOLATED|6.0"
     }
 }

--- a/src/deployment/deploy.py
+++ b/src/deployment/deploy.py
@@ -1125,6 +1125,7 @@ def main() -> None:
         ("instance-specific-setup", Client.upload_instance_setup),
         ("third-party", Client.upload_third_party),
         ("api", Client.deploy_app),
+        ("dotnet-api", Client.deploy_dotnet_app),
         ("export_appinsights", Client.add_log_export),
         ("update_registration", Client.update_registration),
     ]
@@ -1237,11 +1238,6 @@ def main() -> None:
         nargs="*",
         help="Set additional AAD tenants beyond the tenant the app is deployed in",
     )
-    parser.add_argument(
-        "--dotnet_deploy",
-        action="store_true",
-        help="deploys the dotnet version of the app along with the python version",
-    )
 
     args = parser.parse_args()
 
@@ -1289,12 +1285,6 @@ def main() -> None:
         )
         states = rbac_only_states
     else:
-        if args.dotnet_deploy:
-            logger.info("deploying dotnet and python services for Azure functions")
-            after_python = full_deployment_states.index(("api", Client.deploy_app)) + 1
-            full_deployment_states.insert(
-                after_python, ("dotnet-api", Client.deploy_dotnet_app)
-            )
         states = full_deployment_states
 
     if args.start_at != states[0][0]:

--- a/src/deployment/deploy.py
+++ b/src/deployment/deploy.py
@@ -90,7 +90,7 @@ AZCOPY_MISSING_ERROR = (
 )
 FUNC_TOOLS_ERROR = (
     "azure-functions-core-tools is not installed, "
-    "install v3 using instructions: "
+    "install v4 using instructions: "
     "https://github.com/Azure/azure-functions-core-tools#installing"
 )
 

--- a/src/utils/check-pr/README.md
+++ b/src/utils/check-pr/README.md
@@ -5,7 +5,7 @@
 * Python >= 3.7, and dependencies (see `requirements.txt`)
 * [az-cli](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli).
 * [azcopy](https://docs.microsoft.com/en-us/azure/storage/common/storage-use-azcopy-v10)
-* [azure-functions-core-tools](https://docs.microsoft.com/en-us/azure/azure-functions/functions-run-local?tabs=v3%2Clinux%2Ccsharp%2Cportal%2Cbash%2Ckeda#install-the-azure-functions-core-tools) (ver. 4.x required)
+* [azure-functions-core-tools](https://docs.microsoft.com/en-us/azure/azure-functions/functions-run-local?tabs=v4%2Clinux%2Ccsharp%2Cportal%2Cbash#install-the-azure-functions-core-tools) (ver. 4.x required)
 
 ## Setup
 

--- a/src/utils/check-pr/README.md
+++ b/src/utils/check-pr/README.md
@@ -5,7 +5,7 @@
 * Python >= 3.7, and dependencies (see `requirements.txt`)
 * [az-cli](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli).
 * [azcopy](https://docs.microsoft.com/en-us/azure/storage/common/storage-use-azcopy-v10)
-* [azure-functions-core-tools](https://docs.microsoft.com/en-us/azure/azure-functions/functions-run-local?tabs=v3%2Clinux%2Ccsharp%2Cportal%2Cbash%2Ckeda#install-the-azure-functions-core-tools)
+* [azure-functions-core-tools](https://docs.microsoft.com/en-us/azure/azure-functions/functions-run-local?tabs=v3%2Clinux%2Ccsharp%2Cportal%2Cbash%2Ckeda#install-the-azure-functions-core-tools) (ver. 4.x required)
 
 ## Setup
 


### PR DESCRIPTION
## Summary of the Pull Request

- Making dotnet deployment the default, so python and dotnet functions will both be uploaded during an Azure deployment.
- Updating all 'function-core-tools' (Azure Functions CLI) references to V4 to match what's now required for deployment.


## Info on Pull Request
Updated:
CONTRIBUTING.md
src/deployment/deploy.py
src/deployment/ApiService/ApiService/az-local.settings.json
contrib/deploy-onefuzz-via-azure-devops/deploy-onefuzz.yml
src/ApiService/ApiService/az-local.settings.json
src/utils/check-pr/README.md
docs/getting-started.md
