### PR TITLE
Use sas for agent log download

### DIFF
--- a/.devcontainer/post-create-script.sh
+++ b/.devcontainer/post-create-script.sh
@@ -27,7 +27,8 @@ echo "Restore dotnet dependencies"
 cd /workspaces/onefuzz/src/ApiService
 dotnet restore
 
-sudo apt-get install direnv
+sudo apt-get install direnv uuid-runtime
+pip install wheel
 
 echo "Setting up venv"
 cd /workspaces/onefuzz/src
@@ -53,3 +54,7 @@ direnv allow
 pip install -r requirements-dev.txt
 cd __app__
 pip install -r requirements.txt
+
+cd /workspaces/onefuzz/src/utils
+chmod u+x lint.sh
+pip install types-six


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_
This allows the client to use a SAS URL generated by the service as the authentication mechanism to download a container from a storage account.

It follows this pattern: https://docs.microsoft.com/en-us/azure/storage/common/storage-sas-overview#when-to-use-a-shared-access-signature

## PR Checklist
* [ ] Applies to work item: #xxx
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/onefuzz) and sign the CLI.
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_

1. Download containers via SAS URL
2. Some small dev container quality of life improvements

## Validation Steps Performed

_How does someone test & validate?_

1. Run `onefuzz debug logs get --job_id {job_id}`
2. Check the files were still downloaded
