### PR TITLE
pinning the version of dotnet to 6.0.202

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,7 +260,7 @@ jobs:
     - name: Setup .NET Core SDK
       uses: actions/setup-dotnet@v2
       with:
-        dotnet-version: '6.0.x'
+        dotnet-version: '6.0.202'
     - name: Install dependencies
       run: |
         cd src/ApiService/
@@ -383,7 +383,7 @@ jobs:
           cp artifacts/agent-Linux/onefuzz-agent src/deployment/tools/linux/
           cp artifacts/proxy/onefuzz-proxy-manager src/deployment/tools/linux/
           cp artifacts/service/api-service.zip src/deployment
-          cp artifacts/service-net/api-service-net.zip src/deployment          
+          cp artifacts/service-net/api-service-net.zip src/deployment
           cp -r artifacts/third-party src/deployment
           cp -r src/agent/script/linux/libfuzzer-coverage src/deployment/tools/linux/libfuzzer-coverage
           cp -r src/agent/script/win64/libfuzzer-coverage src/deployment/tools/win64/libfuzzer-coverage


### PR DESCRIPTION
A new version came out today and is causing the formatting break in the build release.
We decided to pin the release the version number.