### PR TITLE
When a tag is created, trigger a build.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - '*'
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
When we tag a commit, it's useful to be able to get the build artifacts for our release process. 
#1929 
