### PR TITLE
Allow ignoring directories

### DIFF
--- a/src/agent/onefuzz/examples/dir-monitor.rs
+++ b/src/agent/onefuzz/examples/dir-monitor.rs
@@ -15,7 +15,9 @@ struct Opt {
 async fn main() -> Result<()> {
     let opt = Opt::from_args();
 
-    let mut monitor = DirectoryMonitor::new(opt.path).await?;
+    let mut monitor = DirectoryMonitor::new(opt.path)
+        .await?
+        .set_report_directories(true);
 
     while let Some(created) = monitor.next_file().await? {
         println!("[create] {}", created.display());

--- a/src/agent/onefuzz/examples/dir-monitor.rs
+++ b/src/agent/onefuzz/examples/dir-monitor.rs
@@ -15,9 +15,8 @@ struct Opt {
 async fn main() -> Result<()> {
     let opt = Opt::from_args();
 
-    let mut monitor = DirectoryMonitor::new(opt.path)
-        .await?
-        .set_report_directories(true);
+    let mut monitor = DirectoryMonitor::new(opt.path).await?;
+    monitor.set_report_directories(true);
 
     while let Some(created) = monitor.next_file().await? {
         println!("[create] {}", created.display());

--- a/src/agent/onefuzz/src/monitor.rs
+++ b/src/agent/onefuzz/src/monitor.rs
@@ -10,6 +10,8 @@ use tokio::{
     sync::mpsc::{unbounded_channel, UnboundedReceiver},
 };
 
+const DEFAULT_REPORT_DIRECTORIES: bool = false;
+
 /// Watches a directory, and on file creation, emits the path to the file.
 pub struct DirectoryMonitor {
     dir: PathBuf,
@@ -44,19 +46,16 @@ impl DirectoryMonitor {
         let mut watcher = notify::recommended_watcher(event_handler)?;
         watcher.watch(&dir, RecursiveMode::NonRecursive)?;
 
-        let report_directories = true;
-
         Ok(Self {
             dir,
             notify_events,
             watcher,
-            report_directories,
+            report_directories: DEFAULT_REPORT_DIRECTORIES,
         })
     }
 
-    pub fn set_report_directories(mut self, report_directories: bool) -> Self {
+    pub fn set_report_directories(&mut self, report_directories: bool) {
         self.report_directories = report_directories;
-        self
     }
 
     pub fn stop(&mut self) -> Result<()> {


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_

Allow the DirectoryMonitor to skip reporting directories. The default behavior is to continue reporting them so we don't change the behavior unexpectedly.

## PR Checklist
* [ ] Closes #1856 
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/onefuzz) and sign the CLI.
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_

## Validation Steps Performed

_How does someone test & validate?_

Tested with the `dir-monitor` example.
