### PR TITLE
Include `LD_LIBRARY_PATH` iff set by command

### DIFF
--- a/src/agent/dynamic-library/src/bin/dynamic-library.rs
+++ b/src/agent/dynamic-library/src/bin/dynamic-library.rs
@@ -14,6 +14,9 @@ struct Opt {
 
     #[structopt(short, long)]
     quiet: bool,
+
+    #[structopt(short, long)]
+    ld_library_path: Option<String>,
 }
 
 fn main() -> Result<()> {
@@ -29,6 +32,11 @@ fn main() -> Result<()> {
     if opt.quiet {
         cmd.stdout(Stdio::null());
         cmd.stderr(Stdio::null());
+    }
+
+    if let Some(path) = &opt.ld_library_path {
+        println!("setting LD_LIBRARY_PATH = \"{}\"", path);
+        cmd.env("LD_LIBRARY_PATH", path);
     }
 
     let missing = find_missing(cmd)?;


### PR DESCRIPTION
On Linux, when calling `find_missing()`, include `LD_LIBRARY_PATH` if and only if the invoked `Command` explicitly sets some value for that variable. This ensures consistent search results, no matter the process environment of the calling context.

Closes #1827.

- [x] Tested locally by invoking `dynamic-library` with and without `LD_LIBRARY_PATH` set in env, set via flag
- [x] Tested remotely by submitting job to OneFuzz deployment
  - Shared lib in `{setup_dir}` (passes no matter what, because we default to `LD_LIBRARY_PATH={setup_dir}`)
  - Shared lib in `{setup_dir}/lib`, no `target_env` (fails)
  - Shared lib in `{setup-dir}/lib`, with `--target_env LD_LIBRARY_PATH={setup_dir}/lib` (passes)