### PR TITLE
Hotpatch to 5.4.0 to fix the report deserialization issue

### DIFF
--- a/docs/webhook_events.md
+++ b/docs/webhook_events.md
@@ -267,10 +267,7 @@ If webhook is set to have Event Grid message format then the payload will look a
                 "call_stack_sha256",
                 "input_sha256",
                 "task_id",
-                "job_id",
-                "tool_name",
-                "tool_version",
-                "onefuzz_version"
+                "job_id"
             ],
             "title": "Report",
             "type": "object"
@@ -2129,10 +2126,7 @@ If webhook is set to have Event Grid message format then the payload will look a
                 "call_stack_sha256",
                 "input_sha256",
                 "task_id",
-                "job_id",
-                "tool_name",
-                "tool_version",
-                "onefuzz_version"
+                "job_id"
             ],
             "title": "Report",
             "type": "object"
@@ -6383,10 +6377,7 @@ If webhook is set to have Event Grid message format then the payload will look a
                 "call_stack_sha256",
                 "input_sha256",
                 "task_id",
-                "job_id",
-                "tool_name",
-                "tool_version",
-                "onefuzz_version"
+                "job_id"
             ],
             "title": "Report",
             "type": "object"

--- a/src/pytypes/onefuzztypes/models.py
+++ b/src/pytypes/onefuzztypes/models.py
@@ -214,9 +214,9 @@ class Report(BaseModel):
     asan_log: Optional[str]
     task_id: UUID
     job_id: UUID
-    tool_name: str
-    tool_version: str
-    onefuzz_version: str
+    tool_name: Optional[str]
+    tool_version: Optional[str]
+    onefuzz_version: Optional[str]
     scariness_score: Optional[int]
     scariness_description: Optional[str]
     minimized_stack: Optional[List[str]]


### PR DESCRIPTION
This PR makes the following fields of the report optional
- tool_name
- tool_version
- onefuzz_version