### PR TITLE
Allow old reports to be parsed

### DIFF
--- a/src/agent/onefuzz-agent/data/fake-crash-report-old.json
+++ b/src/agent/onefuzz-agent/data/fake-crash-report-old.json
@@ -1,0 +1,29 @@
+{
+  "input_url": null,
+  "input_blob": {
+    "account": "fakestorageaccount",
+    "container": "fake-storage-container",
+    "name": "fake-crash-sample"
+  },
+  "executable": "dds.exe",
+  "crash_type": "fake crash report",
+  "crash_site": "fake crash site",
+  "call_stack": [
+    "#0 fake",
+    "#1 call",
+    "#2 stack"
+  ],
+  "call_stack_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+  "input_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "asan_log": "fake asan log",
+  "task_id": "2061fc8d-9f02-4d06-838a-87f59880e4e8",
+  "job_id": "510f8e4e-3c4d-4b54-968c-4da459d09f04",
+  "scariness_score": null,
+  "scariness_description": null,
+  "minimized_stack": [],
+  "minimized_stack_sha256": null,
+  "minimized_stack_function_names": [],
+  "minimized_stack_function_names_sha256": null,
+  "minimized_stack_function_lines": null,
+  "minimized_stack_function_lines_sha256": null
+}

--- a/src/agent/onefuzz-agent/src/tasks/report/crash_report.rs
+++ b/src/agent/onefuzz-agent/src/tasks/report/crash_report.rs
@@ -58,11 +58,14 @@ pub struct CrashReport {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub scariness_description: Option<String>,
 
-    pub onefuzz_version: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub onefuzz_version: Option<String>,
 
-    pub tool_name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_name: Option<String>,
 
-    pub tool_version: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_version: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -250,9 +253,9 @@ impl CrashReport {
             scariness_description: crash_log.scariness_description,
             task_id,
             job_id,
-            onefuzz_version,
-            tool_name,
-            tool_version,
+            onefuzz_version: Some(onefuzz_version),
+            tool_name: Some(tool_name),
+            tool_version: Some(tool_version),
         }
     }
 
@@ -330,6 +333,20 @@ mod tests {
     async fn test_parse_fake_crash_report() -> Result<()> {
         let path = std::path::PathBuf::from("data/fake-crash-report.json");
         parse_report_file(path).await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_parse_fake_crash_report_old() -> Result<()> {
+        let path = std::path::PathBuf::from("data/fake-crash-report-old.json");
+        if let CrashTestResult::CrashReport(report) = parse_report_file(path).await? {
+            assert!(report.onefuzz_version == None);
+            assert!(report.tool_name == None);
+            assert!(report.tool_version == None);
+        } else {
+            assert!(false, "expected CrashReport");
+        }
+
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary of the Pull Request

Make onefuzz_version, tool_name, and tool_version optional