### PR TITLE
Use consistent logger names

### DIFF
--- a/src/cli/onefuzz/backend.py
+++ b/src/cli/onefuzz/backend.py
@@ -46,7 +46,7 @@ DEFAULT_TOKEN_PATH = os.path.join(ONEFUZZ_BASE_PATH, "access_token.json")
 REQUEST_CONNECT_TIMEOUT = 30.0
 REQUEST_READ_TIMEOUT = 120.0
 
-LOGGER = logging.getLogger("nsv-backend")
+LOGGER = logging.getLogger("backend")
 
 
 @contextlib.contextmanager

--- a/src/cli/onefuzz/cli.py
+++ b/src/cli/onefuzz/cli.py
@@ -558,11 +558,11 @@ def execute_api(api: Any, api_types: List[Any], version: str) -> int:
     elif args.verbose == 1:
         logging.basicConfig(level=logging.WARNING)
         api.logger.setLevel(logging.INFO)
-        logging.getLogger("nsv-backend").setLevel(logging.DEBUG)
+        logging.getLogger("backend").setLevel(logging.DEBUG)
     elif args.verbose == 2:
         logging.basicConfig(level=logging.INFO)
         api.logger.setLevel(logging.DEBUG)
-        logging.getLogger("nsv-backend").setLevel(logging.DEBUG)
+        logging.getLogger("backend").setLevel(logging.DEBUG)
     elif args.verbose >= 3:
         logging.basicConfig(level=logging.DEBUG)
         api.logger.setLevel(logging.DEBUG)

--- a/src/cli/onefuzz/ssh.py
+++ b/src/cli/onefuzz/ssh.py
@@ -78,7 +78,7 @@ def build_ssh_command(
         if port:
             cmd += ["-p", str(port)]
 
-        log_level = logging.getLogger("nsv-backend").getEffectiveLevel()
+        log_level = logging.getLogger("backend").getEffectiveLevel()
         if log_level <= logging.DEBUG:
             cmd += ["-v"]
 


### PR DESCRIPTION
Remove the vestigial and confusing `nsv` prefix from the backend logger.