### PR TITLE
Ensure `GlobalFlag` reg value is initialized for target

### DIFF
--- a/src/agent/dynamic-library/src/windows.rs
+++ b/src/agent/dynamic-library/src/windows.rs
@@ -110,8 +110,11 @@ pub enum ImageGlobalFlagsError {
     #[error("could not create registry key for `{image}`")]
     CreateKey { image: ImageFile, source: io::Error },
 
-    #[error("could not access `GlobalFlag` value of registry key for `{image}`")]
-    AccessValue { image: ImageFile, source: io::Error },
+    #[error("could not get `GlobalFlag` value of registry key for `{image}`")]
+    GetValue { image: ImageFile, source: io::Error },
+
+    #[error("could not set `GlobalFlag` value of registry key for `{image}`")]
+    SetValue { image: ImageFile, source: io::Error },
 }
 
 const GFLAGS_KEY_NAME: &str = "GlobalFlag"; // Singular
@@ -133,7 +136,7 @@ impl ImageGlobalFlags {
         let value = self
             .create_key()?
             .get_value(GFLAGS_KEY_NAME)
-            .map_err(|source| ImageGlobalFlagsError::AccessValue {
+            .map_err(|source| ImageGlobalFlagsError::GetValue {
                 source,
                 image: self.image.clone(),
             })?;
@@ -144,7 +147,7 @@ impl ImageGlobalFlags {
     pub fn set_value(&self, value: u32) -> Result<(), ImageGlobalFlagsError> {
         self.create_key()?
             .set_value(GFLAGS_KEY_NAME, &value)
-            .map_err(|source| ImageGlobalFlagsError::AccessValue {
+            .map_err(|source| ImageGlobalFlagsError::SetValue {
                 source,
                 image: self.image.clone(),
             })?;

--- a/src/agent/dynamic-library/src/windows.rs
+++ b/src/agent/dynamic-library/src/windows.rs
@@ -196,7 +196,9 @@ impl ImageLoaderSnapsGuard {
     }
 
     fn enable(&self) -> Result<(), ImageGlobalFlagsError> {
-        let mut value = self.gflags.get_value()?;
+        // Value may not yet exist.
+        let mut value = self.gflags.get_value().unwrap_or(0x0);
+
         value |= GFLAGS_SHOW_LOADER_SNAPS;
         self.gflags.set_value(value)?;
 
@@ -204,7 +206,9 @@ impl ImageLoaderSnapsGuard {
     }
 
     fn disable(&self) -> Result<(), ImageGlobalFlagsError> {
-        let mut value = self.gflags.get_value()?;
+        // Value may not yet exist.
+        let mut value = self.gflags.get_value().unwrap_or(0x0);
+
         value &= !GFLAGS_SHOW_LOADER_SNAPS;
         self.gflags.set_value(value)?;
 

--- a/src/agent/dynamic-library/src/windows.rs
+++ b/src/agent/dynamic-library/src/windows.rs
@@ -117,7 +117,7 @@ pub enum ImageGlobalFlagsError {
     SetValue { image: ImageFile, source: io::Error },
 }
 
-const GFLAGS_KEY_NAME: &str = "GlobalFlag"; // Singular
+const GFLAGS_VALUE_NAME: &str = "GlobalFlag"; // Singular
 const GFLAGS_SHOW_LOADER_SNAPS: u32 = 0x2;
 
 /// The global flags for an image file.
@@ -135,7 +135,7 @@ impl ImageGlobalFlags {
     pub fn get_value(&self) -> Result<u32, ImageGlobalFlagsError> {
         let value = self
             .create_key()?
-            .get_value(GFLAGS_KEY_NAME)
+            .get_value(GFLAGS_VALUE_NAME)
             .map_err(|source| ImageGlobalFlagsError::GetValue {
                 source,
                 image: self.image.clone(),
@@ -146,7 +146,7 @@ impl ImageGlobalFlags {
 
     pub fn set_value(&self, value: u32) -> Result<(), ImageGlobalFlagsError> {
         self.create_key()?
-            .set_value(GFLAGS_KEY_NAME, &value)
+            .set_value(GFLAGS_VALUE_NAME, &value)
             .map_err(|source| ImageGlobalFlagsError::SetValue {
                 source,
                 image: self.image.clone(),


### PR DESCRIPTION
### Context

We ensured that the key exists for the target, but not the leaf `GlobalFlag` _value_. We tried to retrieve an existing value and update just [`FLG_SHOW_LDR_SNAPS`](https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/show-loader-snaps), but somehow missed the base case in manual testing.

Fixes #1826.

### Changes

- Zero-initialize `GlobalFlag` registry values as needed
- Update an internal error type for easier debugging

### Testing

Manually tested by creating jobs using `windows-libfuzzer-linked-library` and `windows-libfuzzer-load-library` tasks, but with one DLL dependency removed from the setup dir. Both failed as expected with the descriptive error:
> `Error: fuzzer does not respond to '-help=1'. missing shared libraries: bad.dll.`