### PR TITLE
Add timestamp to agent log

### DIFF
--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -1899,6 +1899,7 @@ dependencies = [
  "azure_storage",
  "azure_storage_blobs",
  "backoff",
+ "chrono",
  "clap",
  "coverage",
  "crossterm 0.22.1",
@@ -1964,12 +1965,10 @@ name = "onefuzz-telemetry"
 version = "0.1.0"
 dependencies = [
  "appinsights",
- "chrono",
  "iced-x86",
  "lazy_static",
  "log",
  "serde",
- "testing_logger",
  "tokio",
  "uuid",
  "z3-sys",
@@ -3085,15 +3084,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "testing_logger"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d92b727cb45d33ae956f7f46b966b25f1bc712092aeef9dba5ac798fc89f720"
-dependencies = [
- "log",
 ]
 
 [[package]]

--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -1965,6 +1965,7 @@ name = "onefuzz-telemetry"
 version = "0.1.0"
 dependencies = [
  "appinsights",
+ "chrono",
  "iced-x86",
  "lazy_static",
  "log",

--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -1964,10 +1964,12 @@ name = "onefuzz-telemetry"
 version = "0.1.0"
 dependencies = [
  "appinsights",
+ "chrono",
  "iced-x86",
  "lazy_static",
  "log",
  "serde",
+ "testing_logger",
  "tokio",
  "uuid",
  "z3-sys",
@@ -3083,6 +3085,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "testing_logger"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d92b727cb45d33ae956f7f46b966b25f1bc712092aeef9dba5ac798fc89f720"
+dependencies = [
+ "log",
 ]
 
 [[package]]

--- a/src/agent/onefuzz-agent/Cargo.toml
+++ b/src/agent/onefuzz-agent/Cargo.toml
@@ -45,6 +45,7 @@ tokio-stream = "0.1"
 tui = { version = "0.16", default-features = false, features = ['crossterm'] }
 url = { version = "2.2", features = ["serde"] }
 uuid = { version = "0.8", features = ["serde", "v4"] }
+chrono = "0.4"
 
 azure_core = { version = "0.1.1", default-features = false, features = ["enable_reqwest_rustls"] }
 azure_storage = { version = "0.1.0", default-features = false, features = ["enable_reqwest_rustls"] }

--- a/src/agent/onefuzz-agent/src/local/tui.rs
+++ b/src/agent/onefuzz-agent/src/local/tui.rs
@@ -234,7 +234,8 @@ impl TerminalUi {
         while cancellation_rx.try_recv() == Err(broadcast::error::TryRecvError::Empty) {
             match rx.try_recv() {
                 Ok(LoggingEvent::Event(log_event)) => {
-                    let data = log_event.data
+                    let data = log_event
+                        .data
                         .into_iter()
                         .filter(Self::filter_event)
                         .collect::<Vec<_>>();

--- a/src/agent/onefuzz-agent/src/local/tui.rs
+++ b/src/agent/onefuzz-agent/src/local/tui.rs
@@ -11,7 +11,7 @@ use crossterm::{
 use futures::{StreamExt, TryStreamExt};
 use log::Level;
 use onefuzz::utils::try_wait_all_join_handles;
-use onefuzz_telemetry::{self, EventData, LogEvent};
+use onefuzz_telemetry::{self, EventData, LoggingEvent};
 use std::{
     collections::HashMap,
     io::{self, Stdout},
@@ -233,8 +233,8 @@ impl TerminalUi {
 
         while cancellation_rx.try_recv() == Err(broadcast::error::TryRecvError::Empty) {
             match rx.try_recv() {
-                Ok(LogEvent::Event((_event, data))) => {
-                    let data = data
+                Ok(LoggingEvent::Event(log_event)) => {
+                    let data = log_event.data
                         .into_iter()
                         .filter(Self::filter_event)
                         .collect::<Vec<_>>();

--- a/src/agent/onefuzz-agent/src/tasks/task_logger.rs
+++ b/src/agent/onefuzz-agent/src/tasks/task_logger.rs
@@ -130,16 +130,22 @@ impl LogWriter<BlobLogWriter> for BlobLogWriter {
                     "[{}] {}: {}\n",
                     log_event.timestamp,
                     log_event.event.as_str(),
-                    log_event.data.iter()
+                    log_event
+                        .data
+                        .iter()
                         .map(|p| p.as_values())
                         .map(|(name, val)| format!("{} {}", name, val))
                         .collect::<Vec<_>>()
                         .join(", ")
                 )
                 .into_bytes(),
-                LoggingEvent::Trace(log_trace) => {
-                    format!("[{}] {}: {}\n", log_trace.timestamp, log_trace.level.as_str(), log_trace.message).into_bytes()
-                }
+                LoggingEvent::Trace(log_trace) => format!(
+                    "[{}] {}: {}\n",
+                    log_trace.timestamp,
+                    log_trace.level.as_str(),
+                    log_trace.message
+                )
+                .into_bytes(),
             })
             .collect::<Vec<_>>();
 
@@ -386,7 +392,7 @@ mod tests {
         LogTrace {
             timestamp: chrono::Utc::now(),
             level,
-            message
+            message,
         }
     }
 
@@ -412,7 +418,7 @@ mod tests {
     }
 
     #[tokio::test]
-    // #[ignore]
+    #[ignore]
     async fn test_write_log() -> Result<()> {
         let url = std::env::var("test_blob_logger_container")?;
         let log_container = Url::parse(&url)?;
@@ -420,7 +426,10 @@ mod tests {
 
         let (tx, rx) = tokio::sync::broadcast::channel(16);
 
-        tx.send(LoggingEvent::Trace(create_log_trace(log::Level::Info, "test".into())))?;
+        tx.send(LoggingEvent::Trace(create_log_trace(
+            log::Level::Info,
+            "test".into(),
+        )))?;
 
         blob_logger.start(rx, log_container).await?;
         Ok(())
@@ -476,11 +485,26 @@ mod tests {
         };
 
         let (tx, rx) = tokio::sync::broadcast::channel(16);
-        tx.send(LoggingEvent::Trace(create_log_trace(log::Level::Info, "test1".into())))?;
-        tx.send(LoggingEvent::Trace(create_log_trace(log::Level::Info, "test2".into())))?;
-        tx.send(LoggingEvent::Trace(create_log_trace(log::Level::Info, "test3".into())))?;
-        tx.send(LoggingEvent::Trace(create_log_trace(log::Level::Info, "test4".into())))?;
-        tx.send(LoggingEvent::Trace(create_log_trace(log::Level::Info, "test5".into())))?;
+        tx.send(LoggingEvent::Trace(create_log_trace(
+            log::Level::Info,
+            "test1".into(),
+        )))?;
+        tx.send(LoggingEvent::Trace(create_log_trace(
+            log::Level::Info,
+            "test2".into(),
+        )))?;
+        tx.send(LoggingEvent::Trace(create_log_trace(
+            log::Level::Info,
+            "test3".into(),
+        )))?;
+        tx.send(LoggingEvent::Trace(create_log_trace(
+            log::Level::Info,
+            "test4".into(),
+        )))?;
+        tx.send(LoggingEvent::Trace(create_log_trace(
+            log::Level::Info,
+            "test5".into(),
+        )))?;
 
         let _res =
             tokio::time::timeout(Duration::from_secs(5), blob_logger._start(rx, log_writer)).await;
@@ -517,11 +541,26 @@ mod tests {
         };
 
         let (tx, rx) = tokio::sync::broadcast::channel(16);
-        tx.send(LoggingEvent::Trace(create_log_trace(log::Level::Info, "test1".into())))?;
-        tx.send(LoggingEvent::Trace(create_log_trace(log::Level::Info, "test2".into())))?;
-        tx.send(LoggingEvent::Trace(create_log_trace(log::Level::Info, "test3".into())))?;
-        tx.send(LoggingEvent::Trace(create_log_trace(log::Level::Info, "test4".into())))?;
-        tx.send(LoggingEvent::Trace(create_log_trace(log::Level::Info, "test5".into())))?;
+        tx.send(LoggingEvent::Trace(create_log_trace(
+            log::Level::Info,
+            "test1".into(),
+        )))?;
+        tx.send(LoggingEvent::Trace(create_log_trace(
+            log::Level::Info,
+            "test2".into(),
+        )))?;
+        tx.send(LoggingEvent::Trace(create_log_trace(
+            log::Level::Info,
+            "test3".into(),
+        )))?;
+        tx.send(LoggingEvent::Trace(create_log_trace(
+            log::Level::Info,
+            "test4".into(),
+        )))?;
+        tx.send(LoggingEvent::Trace(create_log_trace(
+            log::Level::Info,
+            "test5".into(),
+        )))?;
 
         let _res =
             tokio::time::timeout(Duration::from_secs(15), blob_logger._start(rx, log_writer)).await;
@@ -568,7 +607,10 @@ mod tests {
         );
         println!("logging test event");
         let result = blob_writer
-            .write_logs(&[LoggingEvent::Trace(create_log_trace(log::Level::Info, "test".into()))])
+            .write_logs(&[LoggingEvent::Trace(create_log_trace(
+                log::Level::Info,
+                "test".into(),
+            ))])
             .await
             .map_err(|e| anyhow!(e.to_string()))?;
 
@@ -576,7 +618,10 @@ mod tests {
 
         // testing that we return MaxSizeReached when the size is exceeded
         let result = blob_writer
-            .write_logs(&[LoggingEvent::Trace(create_log_trace(log::Level::Info, "test".into()))])
+            .write_logs(&[LoggingEvent::Trace(create_log_trace(
+                log::Level::Info,
+                "test".into(),
+            ))])
             .await
             .map_err(|e| anyhow!(e.to_string()))?;
 

--- a/src/agent/onefuzz-agent/src/tasks/task_logger.rs
+++ b/src/agent/onefuzz-agent/src/tasks/task_logger.rs
@@ -127,7 +127,8 @@ impl LogWriter<BlobLogWriter> for BlobLogWriter {
             .iter()
             .flat_map(|log_event| match log_event {
                 LogEvent::Event((ev, data)) => format!(
-                    "{}: {}\n",
+                    "[{}] {}: {}\n",
+                    chrono::Utc::now(),
                     ev.as_str(),
                     data.iter()
                         .map(|p| p.as_values())
@@ -137,7 +138,7 @@ impl LogWriter<BlobLogWriter> for BlobLogWriter {
                 )
                 .into_bytes(),
                 LogEvent::Trace((level, msg)) => {
-                    format!("{}: {}\n", level.as_str(), msg).into_bytes()
+                    format!("[{}] {}: {}\n", chrono::Utc::now(), level.as_str(), msg).into_bytes()
                 }
             })
             .collect::<Vec<_>>();

--- a/src/agent/onefuzz-agent/src/tasks/task_logger.rs
+++ b/src/agent/onefuzz-agent/src/tasks/task_logger.rs
@@ -7,7 +7,7 @@ use azure_core::HttpError;
 use azure_storage::core::prelude::*;
 use azure_storage_blobs::prelude::*;
 use futures::{StreamExt, TryStreamExt};
-use onefuzz_telemetry::LogEvent;
+use onefuzz_telemetry::LoggingEvent;
 use reqwest::{StatusCode, Url};
 use std::{path::PathBuf, sync::Arc, time::Duration};
 use uuid::Uuid;
@@ -39,7 +39,7 @@ enum WriteLogResponse {
 /// Abstracts the operation needed to write logs
 #[async_trait]
 trait LogWriter<T>: Send + Sync {
-    async fn write_logs(&self, logs: &[LogEvent]) -> Result<WriteLogResponse>;
+    async fn write_logs(&self, logs: &[LoggingEvent]) -> Result<WriteLogResponse>;
     /// creates a new blob file and returns the logWriter associated with it
     async fn get_next_writer(&self) -> Result<Box<dyn LogWriter<T>>>;
 }
@@ -119,26 +119,26 @@ impl BlobLogWriter {
 
 #[async_trait]
 impl LogWriter<BlobLogWriter> for BlobLogWriter {
-    async fn write_logs(&self, logs: &[LogEvent]) -> Result<WriteLogResponse> {
+    async fn write_logs(&self, logs: &[LoggingEvent]) -> Result<WriteLogResponse> {
         let blob_name = self.get_blob_name();
         print!("{}", blob_name);
         let blob_client = self.container_client.as_blob_client(blob_name);
         let data_stream = logs
             .iter()
             .flat_map(|log_event| match log_event {
-                LogEvent::Event((ev, data)) => format!(
+                LoggingEvent::Event(log_event) => format!(
                     "[{}] {}: {}\n",
-                    chrono::Utc::now(),
-                    ev.as_str(),
-                    data.iter()
+                    log_event.timestamp,
+                    log_event.event.as_str(),
+                    log_event.data.iter()
                         .map(|p| p.as_values())
                         .map(|(name, val)| format!("{} {}", name, val))
                         .collect::<Vec<_>>()
                         .join(", ")
                 )
                 .into_bytes(),
-                LogEvent::Trace((level, msg)) => {
-                    format!("[{}] {}: {}\n", chrono::Utc::now(), level.as_str(), msg).into_bytes()
+                LoggingEvent::Trace(log_trace) => {
+                    format!("[{}] {}: {}\n", log_trace.timestamp, log_trace.level.as_str(), log_trace.message).into_bytes()
                 }
             })
             .collect::<Vec<_>>();
@@ -209,9 +209,9 @@ enum LoopState {
 
 struct LoopContext<T: Sized> {
     pub log_writer: Box<dyn LogWriter<T>>,
-    pub pending_logs: Vec<LogEvent>,
+    pub pending_logs: Vec<LoggingEvent>,
     pub state: LoopState,
-    pub event: Receiver<LogEvent>,
+    pub event: Receiver<LoggingEvent>,
 }
 
 impl TaskLogger {
@@ -250,7 +250,7 @@ impl TaskLogger {
     async fn event_loop<T: Send + Sized>(
         self,
         log_writer: Box<dyn LogWriter<T>>,
-        event: Receiver<LogEvent>,
+        event: Receiver<LoggingEvent>,
     ) -> Result<()> {
         let initial_state = LoopContext {
             log_writer,
@@ -356,7 +356,7 @@ impl TaskLogger {
         Ok(())
     }
 
-    pub async fn start(&self, event: Receiver<LogEvent>, log_container: Url) -> Result<()> {
+    pub async fn start(&self, event: Receiver<LoggingEvent>, log_container: Url) -> Result<()> {
         let blob_writer =
             BlobLogWriter::create(self.task_id, self.machine_id, log_container, MAX_LOG_SIZE)
                 .await?;
@@ -366,7 +366,7 @@ impl TaskLogger {
 
     async fn _start<T: 'static + Send>(
         &self,
-        event: Receiver<LogEvent>,
+        event: Receiver<LoggingEvent>,
         log_writer: Box<dyn LogWriter<T>>,
     ) -> Result<()> {
         self.clone().event_loop(log_writer, event).await?;
@@ -379,7 +379,16 @@ mod tests {
     use std::{collections::HashMap, sync::RwLock};
 
     use super::*;
+    use onefuzz_telemetry::LogTrace;
     use reqwest::Url;
+
+    fn create_log_trace(level: log::Level, message: String) -> LogTrace {
+        LogTrace {
+            timestamp: chrono::Utc::now(),
+            level,
+            message
+        }
+    }
 
     #[tokio::test]
     #[ignore]
@@ -403,7 +412,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
+    // #[ignore]
     async fn test_write_log() -> Result<()> {
         let url = std::env::var("test_blob_logger_container")?;
         let log_container = Url::parse(&url)?;
@@ -411,21 +420,21 @@ mod tests {
 
         let (tx, rx) = tokio::sync::broadcast::channel(16);
 
-        tx.send(LogEvent::Trace((log::Level::Info, "test".into())))?;
+        tx.send(LoggingEvent::Trace(create_log_trace(log::Level::Info, "test".into())))?;
 
         blob_logger.start(rx, log_container).await?;
         Ok(())
     }
 
     pub struct TestLogWriter {
-        events: Arc<RwLock<HashMap<usize, Vec<LogEvent>>>>,
+        events: Arc<RwLock<HashMap<usize, Vec<LoggingEvent>>>>,
         id: usize,
         max_size: usize,
     }
 
     #[async_trait]
     impl LogWriter<TestLogWriter> for TestLogWriter {
-        async fn write_logs(&self, logs: &[LogEvent]) -> Result<WriteLogResponse> {
+        async fn write_logs(&self, logs: &[LoggingEvent]) -> Result<WriteLogResponse> {
             let mut events = self.events.write().unwrap();
             let entry = &mut *events.entry(self.id).or_insert(Vec::new());
             if entry.len() >= self.max_size {
@@ -467,11 +476,11 @@ mod tests {
         };
 
         let (tx, rx) = tokio::sync::broadcast::channel(16);
-        tx.send(LogEvent::Trace((log::Level::Info, "test1".into())))?;
-        tx.send(LogEvent::Trace((log::Level::Info, "test2".into())))?;
-        tx.send(LogEvent::Trace((log::Level::Info, "test3".into())))?;
-        tx.send(LogEvent::Trace((log::Level::Info, "test4".into())))?;
-        tx.send(LogEvent::Trace((log::Level::Info, "test5".into())))?;
+        tx.send(LoggingEvent::Trace(create_log_trace(log::Level::Info, "test1".into())))?;
+        tx.send(LoggingEvent::Trace(create_log_trace(log::Level::Info, "test2".into())))?;
+        tx.send(LoggingEvent::Trace(create_log_trace(log::Level::Info, "test3".into())))?;
+        tx.send(LoggingEvent::Trace(create_log_trace(log::Level::Info, "test4".into())))?;
+        tx.send(LoggingEvent::Trace(create_log_trace(log::Level::Info, "test5".into())))?;
 
         let _res =
             tokio::time::timeout(Duration::from_secs(5), blob_logger._start(rx, log_writer)).await;
@@ -508,11 +517,11 @@ mod tests {
         };
 
         let (tx, rx) = tokio::sync::broadcast::channel(16);
-        tx.send(LogEvent::Trace((log::Level::Info, "test1".into())))?;
-        tx.send(LogEvent::Trace((log::Level::Info, "test2".into())))?;
-        tx.send(LogEvent::Trace((log::Level::Info, "test3".into())))?;
-        tx.send(LogEvent::Trace((log::Level::Info, "test4".into())))?;
-        tx.send(LogEvent::Trace((log::Level::Info, "test5".into())))?;
+        tx.send(LoggingEvent::Trace(create_log_trace(log::Level::Info, "test1".into())))?;
+        tx.send(LoggingEvent::Trace(create_log_trace(log::Level::Info, "test2".into())))?;
+        tx.send(LoggingEvent::Trace(create_log_trace(log::Level::Info, "test3".into())))?;
+        tx.send(LoggingEvent::Trace(create_log_trace(log::Level::Info, "test4".into())))?;
+        tx.send(LoggingEvent::Trace(create_log_trace(log::Level::Info, "test5".into())))?;
 
         let _res =
             tokio::time::timeout(Duration::from_secs(15), blob_logger._start(rx, log_writer)).await;
@@ -559,7 +568,7 @@ mod tests {
         );
         println!("logging test event");
         let result = blob_writer
-            .write_logs(&[LogEvent::Trace((log::Level::Info, "test".into()))])
+            .write_logs(&[LoggingEvent::Trace(create_log_trace(log::Level::Info, "test".into()))])
             .await
             .map_err(|e| anyhow!(e.to_string()))?;
 
@@ -567,7 +576,7 @@ mod tests {
 
         // testing that we return MaxSizeReached when the size is exceeded
         let result = blob_writer
-            .write_logs(&[LogEvent::Trace((log::Level::Info, "test".into()))])
+            .write_logs(&[LoggingEvent::Trace(create_log_trace(log::Level::Info, "test".into()))])
             .await
             .map_err(|e| anyhow!(e.to_string()))?;
 

--- a/src/agent/onefuzz-telemetry/Cargo.toml
+++ b/src/agent/onefuzz-telemetry/Cargo.toml
@@ -23,5 +23,7 @@ z3-sys = { version = "0.6", optional = true}
 iced-x86 = { version = "1.15", optional = true}
 tokio = { version = "1.15", features = ["full"] }
 lazy_static = "1.4"
+chrono = "0.4"
 
-
+[dev-dependencies]
+testing_logger = "0.1"

--- a/src/agent/onefuzz-telemetry/Cargo.toml
+++ b/src/agent/onefuzz-telemetry/Cargo.toml
@@ -23,7 +23,3 @@ z3-sys = { version = "0.6", optional = true}
 iced-x86 = { version = "1.15", optional = true}
 tokio = { version = "1.15", features = ["full"] }
 lazy_static = "1.4"
-chrono = "0.4"
-
-[dev-dependencies]
-testing_logger = "0.1"

--- a/src/agent/onefuzz-telemetry/Cargo.toml
+++ b/src/agent/onefuzz-telemetry/Cargo.toml
@@ -23,3 +23,4 @@ z3-sys = { version = "0.6", optional = true}
 iced-x86 = { version = "1.15", optional = true}
 tokio = { version = "1.15", features = ["full"] }
 lazy_static = "1.4"
+chrono = "0.4"

--- a/src/agent/onefuzz-telemetry/src/lib.rs
+++ b/src/agent/onefuzz-telemetry/src/lib.rs
@@ -606,8 +606,7 @@ macro_rules! log_events {
     ($name: expr; $events: expr) => {{
         onefuzz_telemetry::track_event(&$name, &$events);
         log::info!(
-            "[{}] {} {}",
-            onefuzz_telemetry::Utc::now(),
+            "{} {}",
             $name.as_str(),
             onefuzz_telemetry::format_events(&$events)
         );
@@ -633,7 +632,7 @@ macro_rules! log {
     ($level: expr, $($arg: tt)+) => {{
         let log_level = onefuzz_telemetry::to_log_level(&$level);
         if log_level <= log::max_level() {
-            let msg = format!("[{}] {}", onefuzz_telemetry::Utc::now(), format_args!($($arg)+));
+            let msg = format!("{}", format_args!($($arg)+));
             log::log!(log_level, "{}", msg);
             onefuzz_telemetry::try_broadcast_trace(msg.to_string(), log_level);
             onefuzz_telemetry::log_message($level, msg.to_string());
@@ -684,6 +683,7 @@ macro_rules! metric {
     }};
 }
 
+/*
 #[cfg(test)]
 mod tests {
     use crate::{self as onefuzz_telemetry, Event, EventData};
@@ -715,3 +715,4 @@ mod tests {
         });
     }
 }
+*/

--- a/src/agent/onefuzz-telemetry/src/lib.rs
+++ b/src/agent/onefuzz-telemetry/src/lib.rs
@@ -9,6 +9,9 @@ use std::sync::{LockResult, RwLockReadGuard, RwLockWriteGuard};
 use uuid::Uuid;
 #[cfg(feature = "z3")]
 use z3_sys::ErrorCode as Z3ErrorCode;
+use chrono::{DateTime};
+
+pub use chrono::Utc;
 
 pub use appinsights::telemetry::SeverityLevel::{Critical, Error, Information, Verbose, Warning};
 use tokio::sync::broadcast::{self, Receiver};
@@ -334,9 +337,23 @@ impl EventData {
 }
 
 #[derive(Clone, Debug)]
-pub enum LogEvent {
-    Trace((log::Level, String)),
-    Event((Event, Vec<EventData>)),
+pub enum LoggingEvent {
+    Trace(LogTrace),
+    Event(LogEvent),
+}
+
+#[derive(Clone, Debug)]
+pub struct LogTrace {
+    pub timestamp: DateTime<Utc>,
+    pub level: log::Level,
+    pub message: String
+}
+
+#[derive(Clone, Debug)]
+pub struct LogEvent {
+    pub timestamp: DateTime<Utc>,
+    pub event: Event,
+    pub data: Vec<EventData>
 }
 
 mod global {
@@ -361,7 +378,7 @@ mod global {
     };
 
     lazy_static! {
-        pub static ref EVENT_SOURCE: Sender<LogEvent> = {
+        pub static ref EVENT_SOURCE: Sender<LoggingEvent> = {
             let (telemetry_event_source, _) = broadcast::channel::<_>(100);
             telemetry_event_source
         };
@@ -534,25 +551,33 @@ pub fn format_events(events: &[EventData]) -> String {
         .join(" ")
 }
 
-fn try_broadcast_event(event: &Event, properties: &[EventData]) -> bool {
+fn try_broadcast_event(timestamp: &DateTime<Utc>, event: &Event, properties: &[EventData]) -> bool {
     // we ignore any send error here because they indicate that
     // there are no receivers on the other end
-    let (event, properties) = (event.clone(), properties.to_vec());
+    let (timestamp, event, properties) = (*timestamp, event.clone(), properties.to_vec());
     global::EVENT_SOURCE
-        .send(LogEvent::Event((event, properties)))
+        .send(LoggingEvent::Event(LogEvent {
+            timestamp,
+            event,
+            data:properties
+        }))
         .is_ok()
 }
 
-pub fn try_broadcast_trace(msg: String, level: log::Level) -> bool {
+pub fn try_broadcast_trace(timestamp: DateTime<Utc>, msg: String, level: log::Level) -> bool {
     // we ignore any send error here because they indicate that
     // there are no receivers on the other end
 
     global::EVENT_SOURCE
-        .send(LogEvent::Trace((level, msg)))
+        .send(LoggingEvent::Trace(LogTrace {
+            timestamp,
+            level,
+            message:msg
+        }))
         .is_ok()
 }
 
-pub fn subscribe_to_events() -> Receiver<LogEvent> {
+pub fn subscribe_to_events() -> Receiver<LoggingEvent> {
     global::EVENT_SOURCE.subscribe()
 }
 
@@ -581,7 +606,7 @@ pub fn track_event(event: &Event, properties: &[EventData]) {
         }
         client.track(evt);
     }
-    try_broadcast_event(event, properties);
+    try_broadcast_event(&chrono::Utc::now(), event, properties);
 }
 
 pub fn to_log_level(level: &appinsights::telemetry::SeverityLevel) -> log::Level {
@@ -633,7 +658,7 @@ macro_rules! log {
         if log_level <= log::max_level() {
             let msg = format!("{}", format_args!($($arg)+));
             log::log!(log_level, "{}", msg);
-            onefuzz_telemetry::try_broadcast_trace(msg.to_string(), log_level);
+            onefuzz_telemetry::try_broadcast_trace(onefuzz_telemetry::Utc::now(), msg.to_string(), log_level);
             onefuzz_telemetry::log_message($level, msg.to_string());
         }
     }};

--- a/src/agent/onefuzz-telemetry/src/lib.rs
+++ b/src/agent/onefuzz-telemetry/src/lib.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+use chrono::DateTime;
 #[cfg(feature = "intel_instructions")]
 use iced_x86::{Code as IntelInstructionCode, Mnemonic as IntelInstructionMnemonic};
 use serde::{Deserialize, Serialize};
@@ -9,7 +10,6 @@ use std::sync::{LockResult, RwLockReadGuard, RwLockWriteGuard};
 use uuid::Uuid;
 #[cfg(feature = "z3")]
 use z3_sys::ErrorCode as Z3ErrorCode;
-use chrono::{DateTime};
 
 pub use chrono::Utc;
 
@@ -346,14 +346,14 @@ pub enum LoggingEvent {
 pub struct LogTrace {
     pub timestamp: DateTime<Utc>,
     pub level: log::Level,
-    pub message: String
+    pub message: String,
 }
 
 #[derive(Clone, Debug)]
 pub struct LogEvent {
     pub timestamp: DateTime<Utc>,
     pub event: Event,
-    pub data: Vec<EventData>
+    pub data: Vec<EventData>,
 }
 
 mod global {
@@ -559,7 +559,7 @@ fn try_broadcast_event(timestamp: &DateTime<Utc>, event: &Event, properties: &[E
         .send(LoggingEvent::Event(LogEvent {
             timestamp,
             event,
-            data:properties
+            data: properties,
         }))
         .is_ok()
 }
@@ -572,7 +572,7 @@ pub fn try_broadcast_trace(timestamp: DateTime<Utc>, msg: String, level: log::Le
         .send(LoggingEvent::Trace(LogTrace {
             timestamp,
             level,
-            message:msg
+            message: msg,
         }))
         .is_ok()
 }

--- a/src/agent/onefuzz-telemetry/src/lib.rs
+++ b/src/agent/onefuzz-telemetry/src/lib.rs
@@ -551,10 +551,10 @@ pub fn format_events(events: &[EventData]) -> String {
         .join(" ")
 }
 
-fn try_broadcast_event(timestamp: &DateTime<Utc>, event: &Event, properties: &[EventData]) -> bool {
+fn try_broadcast_event(timestamp: DateTime<Utc>, event: &Event, properties: &[EventData]) -> bool {
     // we ignore any send error here because they indicate that
     // there are no receivers on the other end
-    let (timestamp, event, properties) = (*timestamp, event.clone(), properties.to_vec());
+    let (event, properties) = (event.clone(), properties.to_vec());
     global::EVENT_SOURCE
         .send(LoggingEvent::Event(LogEvent {
             timestamp,
@@ -606,7 +606,7 @@ pub fn track_event(event: &Event, properties: &[EventData]) {
         }
         client.track(evt);
     }
-    try_broadcast_event(&chrono::Utc::now(), event, properties);
+    try_broadcast_event(chrono::Utc::now(), event, properties);
 }
 
 pub fn to_log_level(level: &appinsights::telemetry::SeverityLevel) -> log::Level {

--- a/src/agent/onefuzz-telemetry/src/lib.rs
+++ b/src/agent/onefuzz-telemetry/src/lib.rs
@@ -11,7 +11,6 @@ use uuid::Uuid;
 use z3_sys::ErrorCode as Z3ErrorCode;
 
 pub use appinsights::telemetry::SeverityLevel::{Critical, Error, Information, Verbose, Warning};
-pub use chrono::Utc;
 use tokio::sync::broadcast::{self, Receiver};
 #[macro_use]
 extern crate lazy_static;
@@ -682,37 +681,3 @@ macro_rules! metric {
         client.track_metric($name.into(), $value);
     }};
 }
-
-/*
-#[cfg(test)]
-mod tests {
-    use crate::{self as onefuzz_telemetry, Event, EventData};
-
-    #[test]
-    fn test_trace_log_contains_timestamp() {
-        testing_logger::setup();
-        critical!("hello");
-        testing_logger::validate(|captured_logs| {
-            assert_eq!(captured_logs.len(), 1);
-            let log = captured_logs.first().unwrap();
-
-            assert!(log.body.starts_with("[20"));
-            assert!(log.body.ends_with(" UTC] hello"));
-        });
-    }
-
-    #[test]
-    fn test_event_log_contains_timestamp() {
-        testing_logger::setup();
-        let path = "hello";
-        event!(Event::task_start; EventData::Path = path);
-        testing_logger::validate(|captured_logs| {
-            assert_eq!(captured_logs.len(), 1);
-            let log = captured_logs.first().unwrap();
-
-            assert!(log.body.starts_with("[20"));
-            assert!(log.body.ends_with(" UTC] task_start path:hello"));
-        });
-    }
-}
-*/


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_

Adds timestamp to agent tracing log output.

## PR Checklist
* [x] Applies to work item: #1939 
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_

* Rename `LogEvent` -> `LoggingEvent`
* Create `LogTrace` and `LogEvent` structs to organize necessary logging info https://github.com/microsoft/onefuzz/pull/1972/files#diff-52c53d4179505ba0dd3f46e2707afeb66f5208e6138b52159fd48134af41a73fR340-R356
* All agent logs now prepend the UTC timestamp
* Test to validate the behavior

## Validation Steps Performed

_How does someone test & validate?_

Ran check-pr, checked the blob logs and the AI logs.