### PR TITLE
adding function app settings bicep template and updating deploy.py 

### DIFF
--- a/src/deployment/azuredeploy.bicep
+++ b/src/deployment/azuredeploy.bicep
@@ -24,6 +24,9 @@ param diagnosticsLogLevel string = 'Verbose'
 var log_retention = 30
 var tenantId = subscription().tenantId
 
+var python_functions_disabled = '0'
+var dotnet_functions_disabled = '1'
+
 var scaleset_identity = '${name}-scalesetid'
 
 var StorageBlobDataReader = '2a2b9908-6ea1-4ae2-8e65-a410df84e7d1'
@@ -261,6 +264,7 @@ module pythonFunctionSettings 'bicep-templates/function-settings.bicep' = {
     keyvault_name: keyVaultName
     monitor_account_name: operationalInsights.outputs.monitorAccountName
     multi_tenant_domain: multi_tenant_domain
+    functions_disabled: python_functions_disabled
   }
   dependsOn: [
     pythonFunction
@@ -286,6 +290,7 @@ module netFunctionSettings 'bicep-templates/function-settings.bicep' = {
     keyvault_name: keyVaultName
     monitor_account_name: operationalInsights.outputs.monitorAccountName
     multi_tenant_domain: multi_tenant_domain
+    functions_disabled: dotnet_functions_disabled
   }
   dependsOn: [
     netFunction

--- a/src/deployment/azuredeploy.bicep
+++ b/src/deployment/azuredeploy.bicep
@@ -265,6 +265,44 @@ module pythonFunctionSettings 'bicep-templates/function-settings.bicep' = {
     monitor_account_name: operationalInsights.outputs.monitorAccountName
     multi_tenant_domain: multi_tenant_domain
     functions_disabled: python_functions_disabled
+    all_function_names: [
+      'agent_can_schedule'    //0
+      'agent_commands'        //1
+      'agent_events'          //2
+      'agent_registration'    //3
+      'containers'            //4
+      'download'              //5
+      'info'                  //6
+      'instance_config'       //7
+      'jobs'                  //8
+      'job_templates'         //9
+      'job_templates_manage'  //10
+      'negotiate'             //11
+      'node'                  //12
+      'node_add_ssh_key'      //13
+      'notifications'         //14
+      'pool'                  //15
+      'proxy'                 //16
+      'queue_file_changes'    //17
+      'queue_node_heartbeat'  //18
+      'queue_proxy_update'    //19
+      'queue_signalr_events'  //20
+      'queue_task_heartbeat'  //21
+      'queue_updates'         //22
+      'queue_webhooks'        //23
+      'repro_vms'             //24
+      'scaleset'              //25
+      'tasks'                 //26
+      'timer_daily'           //27
+      'timer_proxy'           //28
+      'timer_repro'           //29
+      'timer_retention'       //30
+      'timer_tasks'           //31
+      'timer_workers'         //32
+      'webhooks'              //33
+      'webhooks_logs'         //34
+      'webhooks_ping'         //35
+    ]
   }
   dependsOn: [
     pythonFunction
@@ -291,6 +329,44 @@ module netFunctionSettings 'bicep-templates/function-settings.bicep' = {
     monitor_account_name: operationalInsights.outputs.monitorAccountName
     multi_tenant_domain: multi_tenant_domain
     functions_disabled: dotnet_functions_disabled
+    all_function_names: [
+      'AgentCanSchedule'      //0
+      'AgentCommands'         //1
+      'AgentEvents'           //2
+      'AgentRegistration'     //3
+      'Containers'            //4
+      'Download'              //5
+      'Info'                  //6
+      'InstanceConfig'        //7
+      'Jobs'                  //8
+      'JobTemplates'          //9
+      'JobTemplatesManage'    //10
+      'Negotiate'             //11
+      'Node'                  //12
+      'NodeAddSshKey'         //13
+      'Notifications'         //14
+      'Pool'                  //15
+      'Proxy'                 //16
+      'QueueFileChanges'      //17
+      'QueueNodeHeartbeat'    //18
+      'QueueProxyUpdate'      //19
+      'QueueSignalrEvents'    //20
+      'QueueTaskHeartbeat'    //21
+      'QueueUpdates'          //22
+      'QueueWebhooks'         //23
+      'ReproVms'              //24
+      'Scaleset'              //25
+      'Tasks'                 //26
+      'TimerDaily'            //27
+      'TimerProxy'            //28
+      'TimerRepro'            //29
+      'TimerRetention'        //30
+      'TimerTasks'            //31
+      'TimerWorkers'          //32
+      'Webhooks'              //33
+      'WebhooksLogs'          //34
+      'WebhooksPing'          //35    
+    ]
   }
   dependsOn: [
     netFunction

--- a/src/deployment/bicep-templates/function-settings-disabled-apps.bicep
+++ b/src/deployment/bicep-templates/function-settings-disabled-apps.bicep
@@ -1,46 +1,8 @@
 param functions_disabled_setting string
 
-var allFunctions = [
-  'agent_can_schedule'    //0
-  'agent_commands'        //1
-  'agent_events'          //2
-  'agent_registration'    //3
-  'containers'            //4
-  'download'              //5
-  'info'                  //6
-  'instance_config'       //7
-  'jobs'                  //8
-  'job_templates'         //9
-  'job_templates_manage'  //10
-  'negotiate'             //11
-  'node'                  //12
-  'node_add_ssh_key'      //13
-  'notifications'         //14
-  'pool'                  //15
-  'proxy'                 //16
-  'queue_file_changes'    //17
-  'queue_node_heartbeat'  //18
-  'queue_proxy_update'    //19
-  'queue_signalr_events'  //20
-  'queue_task_heartbeat'  //21
-  'queue_updates'         //22
-  'queue_webhooks'        //23
-  'repro_vms'             //24
-  'scaleset'              //25
-  'tasks'                 //26
-  'timer_daily'           //27
-  'timer_proxy'           //28
-  'timer_repro'           //29
-  'timer_retention'       //30
-  'timer_tasks'           //31
-  'timer_workers'         //32
-  'webhooks'              //33
-  'webhooks_logs'         //34
-  'webhooks_ping'         //35
-]
+param allFunctions array
 
 var disabledFunctions = [for f in allFunctions: 'AzureWebJobs.${f}.Disabled' ]
-
 
 var disabledFunctionsAppSettings = {
   '${disabledFunctions[0]}' : functions_disabled_setting
@@ -90,3 +52,4 @@ var disabledFunctionsAppSettings = {
 
 output functions array = disabledFunctions
 output appSettings object = disabledFunctionsAppSettings
+

--- a/src/deployment/bicep-templates/function-settings-disabled-apps.bicep
+++ b/src/deployment/bicep-templates/function-settings-disabled-apps.bicep
@@ -1,0 +1,92 @@
+param functions_disabled_setting string
+
+var allFunctions = [
+  'agent_can_schedule'    //0
+  'agent_commands'        //1
+  'agent_events'          //2
+  'agent_registration'    //3
+  'containers'            //4
+  'download'              //5
+  'info'                  //6
+  'instance_config'       //7
+  'jobs'                  //8
+  'job_templates'         //9
+  'job_templates_manage'  //10
+  'negotiate'             //11
+  'node'                  //12
+  'node_add_ssh_key'      //13
+  'notifications'         //14
+  'pool'                  //15
+  'proxy'                 //16
+  'queue_file_changes'    //17
+  'queue_node_heartbeat'  //18
+  'queue_proxy_update'    //19
+  'queue_signalr_events'  //20
+  'queue_task_heartbeat'  //21
+  'queue_updates'         //22
+  'queue_webhooks'        //23
+  'repro_vms'             //24
+  'scaleset'              //25
+  'tasks'                 //26
+  'timer_daily'           //27
+  'timer_proxy'           //28
+  'timer_repro'           //29
+  'timer_retention'       //30
+  'timer_tasks'           //31
+  'timer_workers'         //32
+  'webhooks'              //33
+  'webhooks_logs'         //34
+  'webhooks_ping'         //35
+]
+
+var disabledFunctions = [for f in allFunctions: 'AzureWebJobs.${f}.Disabled' ]
+
+
+var disabledFunctionsAppSettings = {
+  '${disabledFunctions[0]}' : functions_disabled_setting
+  '${disabledFunctions[1]}' : functions_disabled_setting
+  '${disabledFunctions[2]}' : functions_disabled_setting
+  '${disabledFunctions[3]}' : functions_disabled_setting
+  '${disabledFunctions[4]}' : functions_disabled_setting
+
+  '${disabledFunctions[5]}' : functions_disabled_setting
+  '${disabledFunctions[6]}' : functions_disabled_setting
+  '${disabledFunctions[7]}' : functions_disabled_setting
+  '${disabledFunctions[8]}' : functions_disabled_setting
+  '${disabledFunctions[9]}' : functions_disabled_setting
+
+  '${disabledFunctions[10]}' : functions_disabled_setting
+  '${disabledFunctions[11]}' : functions_disabled_setting
+  '${disabledFunctions[12]}' : functions_disabled_setting
+  '${disabledFunctions[13]}' : functions_disabled_setting
+  '${disabledFunctions[14]}' : functions_disabled_setting
+
+  '${disabledFunctions[15]}' : functions_disabled_setting
+  '${disabledFunctions[16]}' : functions_disabled_setting
+  '${disabledFunctions[17]}' : functions_disabled_setting
+  '${disabledFunctions[18]}' : functions_disabled_setting
+  '${disabledFunctions[19]}' : functions_disabled_setting
+
+  '${disabledFunctions[20]}' : functions_disabled_setting
+  '${disabledFunctions[21]}' : functions_disabled_setting
+  '${disabledFunctions[22]}' : functions_disabled_setting
+  '${disabledFunctions[23]}' : functions_disabled_setting
+  '${disabledFunctions[24]}' : functions_disabled_setting
+
+  '${disabledFunctions[25]}' : functions_disabled_setting
+  '${disabledFunctions[26]}' : functions_disabled_setting
+  '${disabledFunctions[27]}' : functions_disabled_setting
+  '${disabledFunctions[28]}' : functions_disabled_setting
+  '${disabledFunctions[29]}' : functions_disabled_setting
+
+  '${disabledFunctions[30]}' : functions_disabled_setting
+  '${disabledFunctions[31]}' : functions_disabled_setting
+  '${disabledFunctions[32]}' : functions_disabled_setting
+  '${disabledFunctions[33]}' : functions_disabled_setting
+  '${disabledFunctions[34]}' : functions_disabled_setting
+
+  '${disabledFunctions[35]}' : functions_disabled_setting  
+}
+
+output functions array = disabledFunctions
+output appSettings object = disabledFunctionsAppSettings

--- a/src/deployment/bicep-templates/function-settings.bicep
+++ b/src/deployment/bicep-templates/function-settings.bicep
@@ -26,16 +26,27 @@ param monitor_account_name string
 param functions_worker_runtime string
 param functions_extension_version string
 
+param functions_disabled string
+
+var disabledFunctionName = 'disabledFunctions-${functions_worker_runtime}'
+
 var telemetry = 'd7a73cf4-5a1a-4030-85e1-e5b25867e45a'
 
 resource function 'Microsoft.Web/sites@2021-02-01' existing = {
   name: name
 }
 
+module disabledFunctions 'function-settings-disabled-apps.bicep' = {
+  name: disabledFunctionName
+  params:{
+    functions_disabled_setting: functions_disabled
+  }
+}
+
 resource functionSettings 'Microsoft.Web/sites/config@2021-03-01' = {
   parent: function
   name: 'appsettings'
-  properties: {
+  properties: union({
       'FUNCTIONS_EXTENSION_VERSION': functions_extension_version
       'FUNCTIONS_WORKER_RUNTIME': functions_worker_runtime
       'FUNCTIONS_WORKER_PROCESS_COUNT': '1'
@@ -56,6 +67,6 @@ resource functionSettings 'Microsoft.Web/sites/config@2021-03-01' = {
       'ONEFUZZ_KEYVAULT': keyvault_name
       'ONEFUZZ_OWNER': owner
       'ONEFUZZ_CLIENT_SECRET': client_secret
-  }
+  }, disabledFunctions.outputs.appSettings)
 }
 

--- a/src/deployment/bicep-templates/function-settings.bicep
+++ b/src/deployment/bicep-templates/function-settings.bicep
@@ -28,6 +28,8 @@ param functions_extension_version string
 
 param functions_disabled string
 
+param all_function_names array
+
 var disabledFunctionName = 'disabledFunctions-${functions_worker_runtime}'
 
 var telemetry = 'd7a73cf4-5a1a-4030-85e1-e5b25867e45a'
@@ -40,6 +42,7 @@ module disabledFunctions 'function-settings-disabled-apps.bicep' = {
   name: disabledFunctionName
   params:{
     functions_disabled_setting: functions_disabled
+    allFunctions: all_function_names
   }
 }
 

--- a/src/deployment/deploy.py
+++ b/src/deployment/deploy.py
@@ -152,7 +152,7 @@ class Client:
         subscription_id: Optional[str],
         admins: List[UUID],
         allowed_aad_tenants: List[UUID],
-        enable_dotnet: str,
+        enable_dotnet: List[str],
     ):
         self.subscription_id = subscription_id
         self.resource_group = resource_group
@@ -1070,10 +1070,9 @@ class Client:
 
     def enable_dotnet_func(self) -> None:
         if self.enable_dotnet:
-            dotnet_functions = self.enable_dotnet.split(",")
             func = shutil.which("az")
             assert func is not None
-            for function_name in dotnet_functions:
+            for function_name in self.enable_dotnet:
                 format_name = function_name.split("_")
                 dotnet_name = "".join(x.title() for x in format_name)
                 error: Optional[subprocess.CalledProcessError] = None
@@ -1307,9 +1306,10 @@ def main() -> None:
     parser.add_argument(
         "--enable_dotnet",
         type=str,
-        default=None,
-        help="Provide a csv list of python function names to disable their "
-        "functions and enable corresponding dotnet functions in the Azure "
+        nargs="+",
+        default=[],
+        help="Provide a space-seperated list of python function names to disable "
+        "their functions and enable corresponding dotnet functions in the Azure "
         "Function App deployment",
     )
     args = parser.parse_args()

--- a/src/deployment/deploy.py
+++ b/src/deployment/deploy.py
@@ -8,7 +8,6 @@ import json
 import logging
 import os
 import platform
-import resource
 import shutil
 import subprocess
 import sys

--- a/src/deployment/deploy.py
+++ b/src/deployment/deploy.py
@@ -152,7 +152,7 @@ class Client:
         subscription_id: Optional[str],
         admins: List[UUID],
         allowed_aad_tenants: List[UUID],
-        enable_dotnet: str
+        enable_dotnet: str,
     ):
         self.subscription_id = subscription_id
         self.resource_group = resource_group
@@ -1070,18 +1070,18 @@ class Client:
 
     def enable_dotnet_func(self) -> None:
         if self.enable_dotnet:
-            dotnet_functions = self.enable_dotnet.split(',')
+            dotnet_functions = self.enable_dotnet.split(",")
             func = shutil.which("az")
             assert func is not None
             for function_name in dotnet_functions:
-                format_name = function_name.split('_')
-                dotnet_name = ''.join(x.title() for x in format_name)
+                format_name = function_name.split("_")
+                dotnet_name = "".join(x.title() for x in format_name)
                 error: Optional[subprocess.CalledProcessError] = None
                 max_tries = 5
                 for i in range(max_tries):
                     try:
                         # disable python function
-                        logger.info(f'disabling PYTHON function: {function_name}')
+                        logger.info(f"disabling PYTHON function: {function_name}")
                         subprocess.check_output(
                             [
                                 func,
@@ -1099,7 +1099,7 @@ class Client:
                             env=dict(os.environ, CLI_DEBUG="1"),
                         )
                         # enable dotnet function
-                        logger.info(f'enabling DOTNET function: {dotnet_name}')
+                        logger.info(f"enabling DOTNET function: {dotnet_name}")
                         subprocess.check_output(
                             [
                                 func,
@@ -1129,7 +1129,6 @@ class Client:
                             time.sleep(60)
             if error is not None:
                 raise error
-    
 
     def update_registration(self) -> None:
         if not self.create_registration:
@@ -1194,7 +1193,7 @@ def main() -> None:
         ("dotnet-api", Client.deploy_dotnet_app),
         ("export_appinsights", Client.add_log_export),
         ("update_registration", Client.update_registration),
-        ("enable_dotnet", Client.enable_dotnet_func)
+        ("enable_dotnet", Client.enable_dotnet_func),
     ]
 
     formatter = argparse.ArgumentDefaultsHelpFormatter

--- a/src/deployment/deploy.py
+++ b/src/deployment/deploy.py
@@ -1129,8 +1129,6 @@ class Client:
                             time.sleep(60)
             if error is not None:
                 raise error
-        else:
-            print(f'*** NO DOTNET FUNCTIONS ENABLED: {self.enable_dotnet} ***')
     
 
     def update_registration(self) -> None:
@@ -1311,8 +1309,9 @@ def main() -> None:
         "--enable_dotnet",
         type=str,
         default=None,
-        help="Provide a csv list of python function names to disables the python "
-        "function and enables dotnet functions in Azure Function App deployment",
+        help="Provide a csv list of python function names to disable their "
+        "functions and enable corresponding dotnet functions in the Azure "
+        "Function App deployment",
     )
     args = parser.parse_args()
 

--- a/src/deployment/deploy.py
+++ b/src/deployment/deploy.py
@@ -1075,6 +1075,8 @@ class Client:
             func = shutil.which("az")
             assert func is not None
             for function_name in dotnet_functions:
+                format_name = function_name.split('_')
+                dotnet_name = ''.join(x.title() for x in format_name)
                 error: Optional[subprocess.CalledProcessError] = None
                 max_tries = 5
                 for i in range(max_tries):
@@ -1098,7 +1100,7 @@ class Client:
                             env=dict(os.environ, CLI_DEBUG="1"),
                         )
                         # enable dotnet function
-                        logger.info(f'enabling DOTNET function: {function_name}')
+                        logger.info(f'enabling DOTNET function: {dotnet_name}')
                         subprocess.check_output(
                             [
                                 func,
@@ -1111,7 +1113,7 @@ class Client:
                                 "--resource-group",
                                 self.application_name,
                                 "--settings",
-                                f"AzureWebJobs.{function_name}.Disabled=0",
+                                f"AzureWebJobs.{dotnet_name}.Disabled=0",
                             ],
                             env=dict(os.environ, CLI_DEBUG="1"),
                         )
@@ -1310,9 +1312,8 @@ def main() -> None:
         "--enable_dotnet",
         type=str,
         default=None,
-        help="Enables dotnet functions from a provided csv list and disables the python"
-        " functions in Azure Function App deployment",
-
+        help="Provide a csv list of python function names to disables the python "
+        "function and enables dotnet functions in Azure Function App deployment",
     )
     args = parser.parse_args()
 

--- a/src/deployment/deploy.py
+++ b/src/deployment/deploy.py
@@ -153,7 +153,7 @@ class Client:
         subscription_id: Optional[str],
         admins: List[UUID],
         allowed_aad_tenants: List[UUID],
-        enable_dotnet: List[str]
+        enable_dotnet: str
     ):
         self.subscription_id = subscription_id
         self.resource_group = resource_group


### PR DESCRIPTION
## Summary of the Pull Request

This adds app settings for all dotnet and python functions to automatically disable (AzureWebJobs.$FUNCTION.Disabled=1) all dotnet functions and enable all python functions in their corresponding function apps

To enable dotnet functions at deployment time, deploy.py was updated with an argument '--enable_dotnet' that accepts a space separated list of <del>dotnet</del> python functions to disable while enabling the dotnet function of the same name (except pascal cased names for dotnet vs python snake cased names)

example: 
```bash
./deploy.py --enable_dotnet tasks webhooks pool
```
This would enable the Tasks, Webhooks, and Pool functions in dotnet and turn these off in python

## PR Checklist
* [x] Applies to work item: #1948
* [x] Tests passed

## Info on Pull Request
#### added:
src/deployment/bicep-templates/function-settings-disabled-apps.bicep
#### updated:
src/deployment/azuredeploy.bicep
src/deployment/bicep-templates/function-settings.bicep
src/deployment/deploy.py

