### PR TITLE
Removing stray print statement in the task_logger

### DIFF
--- a/src/agent/onefuzz-agent/src/tasks/task_logger.rs
+++ b/src/agent/onefuzz-agent/src/tasks/task_logger.rs
@@ -121,7 +121,6 @@ impl BlobLogWriter {
 impl LogWriter<BlobLogWriter> for BlobLogWriter {
     async fn write_logs(&self, logs: &[LogEvent]) -> Result<WriteLogResponse> {
         let blob_name = self.get_blob_name();
-        print!("{}", blob_name);
         let blob_client = self.container_client.as_blob_client(blob_name);
         let data_stream = logs
             .iter()


### PR DESCRIPTION
## Summary of the Pull Request
The print statement is causing confusion when a task fails and the content of stdout is collected. 
It gives the impression that something wrong happened when uploading the logs.
