### PR TITLE
Attempt to improve sccacheability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,9 @@ jobs:
           sccache
           src/agent/target
         key: agent-${{ runner.os }}-${{ hashFiles('src/agent/Cargo.lock') }}-${{ env.ACTIONS_CACHE_KEY_DATE }}
+        restore-keys: |
+          agent-${{ runner.os }}-${{ hashFiles('src/agent/Cargo.lock') }}-
+          agent-${{ runner.os }}-
     - name: Linux Prereqs
       run: |
         sudo apt-get -y update
@@ -203,6 +206,9 @@ jobs:
           sccache
           src/proxy-manager/target
         key: proxy-${{ runner.os }}-${{ hashFiles('src/proxy-manager/Cargo.lock') }}-${{ env.ACTIONS_CACHE_KEY_DATE }}
+        restore-keys: |
+          proxy-${{ runner.os }}-${{ hashFiles('src/proxy-manager/Cargo.lock') }}-
+          proxy-${{ runner.os }}-
     - run: src/ci/proxy.sh
     - uses: actions/upload-artifact@v2.2.2
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ env:
   CARGO_TERM_COLOR: always
   SCCACHE_DIR: ${{github.workspace}}/sccache/
   SCCACHE_CACHE_SIZE: 1G
-  ACTIONS_CACHE_KEY_DATE: 2021-08-26-01
+  ACTIONS_CACHE_KEY_DATE: 2022-06-02-01
   CI: true
 
 jobs:

--- a/src/ci/agent.sh
+++ b/src/ci/agent.sh
@@ -12,7 +12,7 @@ exists() {
 # only set RUSTC_WRAPPER if sccache exists
 SCCACHE=$(which sccache)
 if [ ! -z "$SCCACHE" ]; then
-    export RUSTC_WRAPPER=$(which sccache)
+    export RUSTC_WRAPPER=$SCCACHE
 fi
 
 # only set CARGO_INCREMENTAL on non-release builds

--- a/src/ci/agent.sh
+++ b/src/ci/agent.sh
@@ -10,7 +10,8 @@ exists() {
 }
 
 # only set RUSTC_WRAPPER if sccache exists
-if sccache --help; then
+SCCACHE=$(which sccache)
+if [ ! -z "$SCCACHE" ]; then
     export RUSTC_WRAPPER=$(which sccache)
 fi
 
@@ -61,6 +62,10 @@ cargo test --release --workspace
 
 # TODO: once Salvo is integrated, this can get deleted
 cargo build --release --manifest-path ./onefuzz-telemetry/Cargo.toml --all-features
+
+if [ ! -z "$SCCACHE" ]; then
+    sccache --show-stats
+fi
 
 cp target/release/onefuzz-task* ../../artifacts/agent-$(uname)
 cp target/release/onefuzz-agent* ../../artifacts/agent-$(uname)

--- a/src/ci/agent.sh
+++ b/src/ci/agent.sh
@@ -58,13 +58,13 @@ cargo build --release --locked
 cargo clippy --release --locked --all-targets -- -D warnings
 # export RUST_LOG=trace
 export RUST_BACKTRACE=full
-cargo test --release --workspace
+cargo test --release --locked --workspace
 
 # TODO: re-enable integration tests.
 # cargo test --release --manifest-path ./onefuzz-task/Cargo.toml --features integration_test -- --nocapture
 
 # TODO: once Salvo is integrated, this can get deleted
-cargo build --release --manifest-path ./onefuzz-telemetry/Cargo.toml --all-features
+cargo build --release --locked --manifest-path ./onefuzz-telemetry/Cargo.toml --all-features
 
 if [ ! -z "$SCCACHE" ]; then
     sccache --show-stats

--- a/src/ci/agent.sh
+++ b/src/ci/agent.sh
@@ -39,7 +39,10 @@ cargo audit --version
 cargo clippy --version
 cargo fmt --version
 
-cargo clean
+# unless we're doing incremental builds, start clean during CI
+if [ X${CARGO_INCREMENTAL} == X ]; then
+    cargo clean
+fi
 
 cargo fmt -- --check
 # RUSTSEC-2020-0016: a dependency `net2` (pulled in from tokio) is deprecated

--- a/src/ci/agent.sh
+++ b/src/ci/agent.sh
@@ -9,7 +9,7 @@ exists() {
     [ -e "$1" ]
 }
 
-SCCACHE=$(which sccache)
+SCCACHE=$(which sccache || echo '')
 if [ ! -z "$SCCACHE" ]; then
     # only set RUSTC_WRAPPER if sccache exists
     export RUSTC_WRAPPER=$SCCACHE
@@ -55,7 +55,7 @@ cargo fmt -- --check
 cargo audit --deny warnings --deny unmaintained --deny unsound --deny yanked --ignore RUSTSEC-2020-0016 --ignore RUSTSEC-2020-0036 --ignore RUSTSEC-2019-0036 --ignore RUSTSEC-2021-0065 --ignore RUSTSEC-2020-0159 --ignore RUSTSEC-2020-0071 --ignore RUSTSEC-2020-0077
 cargo-license -j > data/licenses.json
 cargo build --release --locked
-cargo clippy --release --all-targets -- -D warnings
+cargo clippy --release --locked --all-targets -- -D warnings
 # export RUST_LOG=trace
 export RUST_BACKTRACE=full
 cargo test --release --workspace


### PR DESCRIPTION
## Summary of the Pull Request

Attempt to speed up CI builds:
1. Disable incremental builds when using `sccache` (incremental can't be cached)
2. Set `--locked` on all invocations of cargo

<table>
<thead>
<tr>
<th>Before</th>
<th>After (old cache)</th>
<th>After (new cache)</th>
<th>Latest on branch</th>
</tr>
</thead>
<tbody>
<tr>
<td>

```
+ sccache --show-stats
Compile requests                    767
Compile requests executed           588
Cache hits                           31
Cache hits (C/C++)                   31
Cache misses                        557
Cache misses (Rust)                 557
Cache timeouts                        0
Cache read errors                     0
Forced recaches                       0
Cache write errors                    0
Compilation failures                  0
Cache errors                          0
Non-cacheable compilations            0
Non-cacheable calls                 178
Non-compilation calls                 1
Unsupported compiler calls            0
Average cache write               0.822 s
Average cache read miss           0.822 s
Average cache read hit            0.000 s
Failed distributed compilations       0

Non-cacheable reasons:
crate-type                          104
incremental                          34
multiple input files                 20
unknown source language              11
-                                     9

Cache size                          547 MiB
Max cache size                        1 GiB

```

</td>

<td>

```
+ sccache --show-stats
Compile requests                    770
Compile requests executed           602
Cache hits                           31
Cache hits (C/C++)                   31
Cache misses                        571
Cache misses (Rust)                 571
Cache timeouts                        0
Cache read errors                     0
Forced recaches                       0
Cache write errors                    0
Compilation failures                  0
Cache errors                          0
Non-cacheable compilations            0
Non-cacheable calls                 167
Non-compilation calls                 1
Unsupported compiler calls            0
Average cache write               0.835 s
Average cache read miss           0.835 s
Average cache read hit            0.000 s
Failed distributed compilations       0

Non-cacheable reasons:
crate-type                          124
multiple input files                 20
-                                    12
unknown source language              11

Cache size                          554 MiB
Max cache size                        1 GiB
```

</td>
<td>

```
+ sccache --show-stats
Compile requests                    767
Compile requests executed           602
Cache hits                           31
Cache hits (C/C++)                   31
Cache misses                        571
Cache misses (Rust)                 571
Cache timeouts                        0
Cache read errors                     0
++ uname
Forced recaches                       0
Cache write errors                    0
Compilation failures                  0
Cache errors                          0
Non-cacheable compilations            0
Non-cacheable calls                 164
Non-compilation calls                 1
Unsupported compiler calls            0
Average cache write               0.803 s
Average cache read miss           0.803 s
Average cache read hit            0.000 s
Failed distributed compilations       0
Non-cacheable reasons:
crate-type                          124
multiple input files                 20
unknown source language              11
-                                     9
Cache size                          561 MiB
Max cache size                        1 GiB

```

</td>
<td>

```
Compile requests                    134
Compile requests executed            39
Cache hits                            5
Cache hits (Rust)                     5
Cache misses                         34
Cache misses (Rust)                  34
Cache timeouts                        0
Cache read errors                     0
Forced recaches                       0
Cache write errors                    0
Compilation failures                  0
Cache errors                          0
Non-cacheable compilations            0
Non-cacheable calls                  95
Non-compilation calls                 0
Unsupported compiler calls            0
Average cache write               0.852 s
Average cache read miss           0.852 s
Average cache read hit            0.000 s
Failed distributed compilations       0
Non-cacheable reasons:
multiple input files                 51
crate-type                           38
-                                     6
Cache size                          296 MiB
Max cache size                        1 GiB
```

</td>
</tr>
</tbody>
</table>

