### PR TITLE
Collect .NET coverage info

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,6 +267,7 @@ jobs:
       run: |
         cd src/ApiService/
         dotnet restore --locked-mode
+        dotnet tool restore
     - name: Check Formatting
       run: |
         cd src/ApiService/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,10 +275,12 @@ jobs:
       run: |
         cd src/ApiService/
         dotnet build -warnaserror --configuration Release
-    - name: Test
+    - name: Test & Collect coverage info
       run: |
         cd src/ApiService/
-        dotnet test --no-restore
+        dotnet test --no-restore --collect:"XPlat Code Coverage"
+        dotnet tool run reportgenerator -reports:Tests/TestResults/*/coverage.cobertura.xml -targetdir:coverage -reporttypes:MarkdownSummary
+        cat coverage/*.md > $GITHUB_STEP_SUMMARY
     - name: copy artifacts
       run: |
         ./src/ci/get-version.sh > src/deployment/VERSION

--- a/src/ApiService/.config/dotnet-tools.json
+++ b/src/ApiService/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-reportgenerator-globaltool": {
+      "version": "5.1.9",
+      "commands": [
+        "reportgenerator"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary of the Pull Request

Collect .NET coverage during build and display it in GitHub Summary.

## Info on Pull Request

Add the `reportgenerator` tool, run it after tests.

## Validation Steps Performed

Run workflow and make sure it works.

See example coverage output here: https://github.com/microsoft/onefuzz/actions/runs/2458088617