### PR TITLE
Fix typo in C# query

### DIFF
--- a/src/ApiService/ApiService/onefuzzlib/NodeOperations.cs
+++ b/src/ApiService/ApiService/onefuzzlib/NodeOperations.cs
@@ -424,7 +424,7 @@ public class NodeTasksOperations : StatefulOrm<NodeTasks, NodeTaskState>, INodeT
     }
 
     public IAsyncEnumerable<NodeTasks> GetByMachineId(Guid machineId) {
-        return QueryAsync($"macine_id eq '{machineId}'");
+        return QueryAsync($"machine_id eq '{machineId}'");
     }
 
     public IAsyncEnumerable<NodeTasks> GetByTaskId(Guid taskId) {


### PR DESCRIPTION
Small fix `machie_id` → `machine_id`.