### PR TITLE
Add scripts to install dotnet on windows and ubuntu

### DIFF
--- a/src/runtime-tools/linux/install-dotnet.sh
+++ b/src/runtime-tools/linux/install-dotnet.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+apt update
+apt install curl libicu-dev -y
+
+mkdir /onefuzz/tools/dotnet
+
+curl -sSL https://dot.net/v1/dotnet-install.sh -o dotnet-install.sh
+chmod u+x dotnet-install.sh
+. ./dotnet-install.sh --version 6.0.300 --install-dir /onefuzz/tools/dotnet
+
+mkdir /etc/dotnet
+touch /etc/dotnet/install_location
+echo "/onefuzz/tools/dotnet" >> /etc/dotnet/install_location
+
+dotnet tool install dotnet-dump --tool-path /onefuzz/tools
+dotnet tool install dotnet-coverage --tool-path /onefuzz/tools
+dotnet tool install dotnet-sos --tool-path /onefuzz/tools

--- a/src/runtime-tools/win64/install-dotnet.ps1
+++ b/src/runtime-tools/win64/install-dotnet.ps1
@@ -1,0 +1,19 @@
+# Install dotnet
+&powershell -NoProfile -ExecutionPolicy unrestricted -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://dot.net/v1/dotnet-install.ps1'))) -Version 6.0.300 -InstallDir c:/onefuzz/tools/dotnet"
+
+# Set the variable for this current sessions
+$env:DOTNET_ROOT = "c:/onefuzz/tools/dotnet"
+# Set the variable for all future sessions
+[Environment]::SetEnvironmentVariable("DOTNET_ROOT", "c:/onefuzz/tools/dotnet", "Machine")
+
+# Install the necessary tools
+cd c:/onefuzz/tools/dotnet
+./dotnet.exe tool install dotnet-dump --tool-path c:/onefuzz/tools
+./dotnet.exe tool install dotnet-coverage --tool-path c:/onefuzz/tools
+./dotnet.exe tool install dotnet-sos --tool-path c:/onefuzz/tools
+
+# Verify they're working
+cd c:/onefuzz/tools
+./dotnet-dump.exe -h
+./dotnet-coverage.exe -h
+./dotnet-sos.exe -h


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_

This PR adds scripts to install dotnet and related tooling on ubuntu and windows.

## PR Checklist
* [ ] Closes #2005 
* [ ] Tests added/passed
* [ ] Requires documentation to be updated

## Info on Pull Request

_What does this include?_

These scripts were written with the following goals:
* A small footprint regarding system configuration (environment variables, files in 'standard' locations)
* Ease of use by the agent

I made the tradeoff by setting the `DOTNET_ROOT` environment variable/adding /etc/dotnet/install_location on linux in order to make it easier to call the dotnet tools from the agent.

The alternative approach is that every time we call the dotnet tools from the agent, we must set the DOTNET_ROOT env var for that process every time.

I'm open to both approaches, the reason I chose the current implementation is because there's no way to indicate on the agent that the env var is required so it's easy to make mistakes.

## Validation Steps Performed

_How does someone test & validate?_

* I spun up a fresh ubuntu docker image and ran the script
* I spun up a fresh Win10 VM and ran the script
