### PR TITLE
Devcontainer: Set some default Omnisharp options

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,7 +15,9 @@
 		"rust-analyzer.linkedProjects": [
 			"/workspaces/onefuzz/src/agent/Cargo.toml"
 		],
-		"python.defaultInterpreterPath": "/workspaces/onefuzz/src/venv/bin/python"
+		"python.defaultInterpreterPath": "/workspaces/onefuzz/src/venv/bin/python",
+		"omnisharp.enableRoslynAnalyzers": true,
+		"omnisharp.enableEditorConfigSupport": true
 	},
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [


### PR DESCRIPTION
Enable Roslyn analyzers and `.editorconfig` support by default in devcontainer.
