### PR TITLE
Update `onefuzz-agent` to clap 3

### DIFF
--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -262,7 +262,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "clap",
+ "clap 2.34.0",
  "env_logger 0.8.4",
  "lazy_static",
  "lazycell",
@@ -427,10 +427,49 @@ dependencies = [
  "ansi_term",
  "atty",
  "bitflags",
- "strsim",
- "textwrap",
+ "strsim 0.8.0",
+ "textwrap 0.11.0",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "clap"
+version = "3.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d20de3739b4fb45a17837824f40aa1769cc7655d7a83e68739a77fe7b30c87a"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "indexmap",
+ "once_cell",
+ "strsim 0.10.0",
+ "termcolor",
+ "textwrap 0.15.0",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "026baf08b89ffbd332836002ec9378ef0e69648cbfadd68af7cd398ca5bf98f7"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro-error",
+ "proc-macro2 1.0.39",
+ "quote 1.0.9",
+ "syn 1.0.95",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5538cd660450ebeb4234cfecf8f2284b844ffc4c50531e66d584ad5b91293613"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -1809,9 +1848,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.8.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
+checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
 
 [[package]]
 name = "onefuzz"
@@ -1872,7 +1911,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "backtrace",
- "clap",
+ "clap 3.2.4",
  "downcast-rs",
  "env_logger 0.9.0",
  "futures",
@@ -1885,7 +1924,6 @@ dependencies = [
  "serde",
  "serde_json",
  "storage-queue",
- "structopt",
  "tokio",
  "url",
  "users",
@@ -1906,7 +1944,7 @@ dependencies = [
  "azure_storage_blobs",
  "backoff",
  "chrono",
- "clap",
+ "clap 2.34.0",
  "coverage",
  "crossterm 0.22.1",
  "env_logger 0.9.0",
@@ -1968,6 +2006,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21326818e99cfe6ce1e524c2a805c189a99b5ae555a35d19f9a284b427d86afa"
 
 [[package]]
 name = "output_vt100"
@@ -2942,12 +2986,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "structopt"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
 dependencies = [
- "clap",
+ "clap 2.34.0",
  "lazy_static",
  "structopt-derive",
 ]
@@ -3124,6 +3174,12 @@ checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
 ]
+
+[[package]]
+name = "textwrap"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"

--- a/src/agent/onefuzz-agent/Cargo.toml
+++ b/src/agent/onefuzz-agent/Cargo.toml
@@ -18,11 +18,10 @@ reqwest = { version = "0.11", features = ["json", "stream", "rustls-tls"], defau
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 storage-queue = { path = "../storage-queue" }
-structopt = "0.3"
 tokio = { version = "1.16", features = ["full"] }
 url = { version = "2.2", features = ["serde"] }
 uuid = { version = "0.8", features = ["serde", "v4"] }
-clap = "2.34"
+clap = { version = "3.2.4", features = ["derive", "cargo"] }
 reqwest-retry = { path = "../reqwest-retry" }
 onefuzz-telemetry = { path = "../onefuzz-telemetry" }
 backtrace = "0.3"

--- a/src/agent/onefuzz-agent/src/coordinator.rs
+++ b/src/agent/onefuzz-agent/src/coordinator.rs
@@ -52,7 +52,7 @@ pub struct ClaimNodeCommandRequest {
     message_id: String,
 }
 
-#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize, clap::ValueEnum)]
 #[serde(rename_all = "snake_case")]
 pub enum NodeState {
     Init,

--- a/src/agent/onefuzz-agent/src/debug.rs
+++ b/src/agent/onefuzz-agent/src/debug.rs
@@ -4,9 +4,9 @@
 use std::path::PathBuf;
 
 use anyhow::Result;
+use clap::Parser;
 use onefuzz::blob::BlobContainerUrl;
 use onefuzz::process::ExitStatus;
-use structopt::StructOpt;
 use url::Url;
 use uuid::Uuid;
 
@@ -14,10 +14,12 @@ use crate::coordinator::*;
 use crate::work::*;
 use crate::worker::*;
 
-#[derive(StructOpt, Debug)]
-#[structopt(rename_all = "snake_case")]
+#[derive(Parser, Debug)]
+#[clap(rename_all = "snake_case")]
 pub enum DebugOpt {
+    #[clap(subcommand)]
     NodeEvent(NodeEventOpt),
+
     RunWorker(RunWorkerOpt),
 }
 
@@ -30,13 +32,15 @@ pub fn debug(opt: DebugOpt) -> Result<()> {
     Ok(())
 }
 
-#[derive(StructOpt, Debug)]
-#[structopt(rename_all = "snake_case")]
+#[derive(Parser, Debug)]
+#[clap(rename_all = "snake_case")]
 pub enum NodeEventOpt {
     StateUpdate {
-        #[structopt(parse(try_from_str = serde_json::from_str))]
+        #[clap(value_enum)]
         state: NodeState,
     },
+
+    #[clap(subcommand)]
     WorkerEvent(WorkerEventOpt),
 }
 
@@ -69,14 +73,14 @@ fn debug_node_event_state_update(state: NodeState) -> Result<()> {
     print_json(into_envelope(event))
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
 pub enum WorkerEventOpt {
     Running,
     Done {
-        #[structopt(short, long)]
+        #[clap(short, long)]
         code: Option<i32>,
 
-        #[structopt(short, long)]
+        #[clap(short, long)]
         signal: Option<i32>,
     },
 }
@@ -127,16 +131,16 @@ fn print_json(data: impl serde::Serialize) -> Result<()> {
     Ok(())
 }
 
-#[derive(StructOpt, Debug)]
-#[structopt(rename_all = "snake_case")]
+#[derive(Parser, Debug)]
+#[clap(rename_all = "snake_case")]
 pub struct RunWorkerOpt {
-    #[structopt(long)]
+    #[clap(long)]
     config: PathBuf,
 
-    #[structopt(long)]
+    #[clap(long)]
     setup_url: Url,
 
-    #[structopt(long)]
+    #[clap(long)]
     script: bool,
 }
 

--- a/src/agent/onefuzz-agent/src/main.rs
+++ b/src/agent/onefuzz-agent/src/main.rs
@@ -6,8 +6,6 @@ extern crate async_trait;
 #[macro_use]
 extern crate downcast_rs;
 #[macro_use]
-extern crate clap;
-#[macro_use]
 extern crate anyhow;
 #[macro_use]
 extern crate onefuzz_telemetry;
@@ -22,13 +20,13 @@ use std::path::PathBuf;
 use std::process::{Command, Stdio};
 
 use anyhow::{Context, Result};
+use clap::Parser;
 use onefuzz::{
     machine_id::{get_machine_id, get_scaleset_name},
     process::ExitStatus,
 };
 use onefuzz_telemetry::{self as telemetry, EventData, Role};
 use std::io::{self, Write};
-use structopt::StructOpt;
 use uuid::Uuid;
 
 pub mod agent;
@@ -47,28 +45,29 @@ pub mod setup;
 pub mod work;
 pub mod worker;
 
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
 enum Opt {
     Run(RunOpt),
+    #[clap(subcommand)]
     Debug(debug::DebugOpt),
     Licenses,
     Version,
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
 struct RunOpt {
-    #[structopt(short, long = "--config", parse(from_os_str))]
+    #[clap(short, long = "--config", parse(from_os_str))]
     config_path: Option<PathBuf>,
     /// re-executes as a child process, recording stdout/stderr to files in
     /// the specified directory
-    #[structopt(short, long = "--redirect-output", parse(from_os_str))]
+    #[clap(short, long = "--redirect-output", parse(from_os_str))]
     redirect_output: Option<PathBuf>,
 }
 
 fn main() -> Result<()> {
     env_logger::init();
 
-    let opt = Opt::from_args();
+    let opt = Opt::parse();
 
     set_panic_handler();
 
@@ -85,7 +84,7 @@ fn main() -> Result<()> {
 fn version() {
     println!(
         "{} onefuzz:{} git:{}",
-        crate_version!(),
+        clap::crate_version!(),
         env!("ONEFUZZ_VERSION"),
         env!("GIT_VERSION")
     );


### PR DESCRIPTION
Mostly a maintenance update (dependabot was trying to do this and failing), but it does have a small improvement in that the `debug node_event state_update` help:

```console
$ target/debug/onefuzz-agent debug node_event state_update --help
onefuzz-agent-debug-node_event-state_update 0.1.0

USAGE:
    onefuzz-agent debug node_event state_update <state>

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

ARGS:
    <state>    
```

Now displays the applicable enum values:

```console
$ target/debug/onefuzz-agent debug node_event state_update --help
onefuzz-agent-debug-node_event-state_update 

USAGE:
    onefuzz-agent debug node_event state_update <STATE>

ARGS:
    <STATE>    [possible values: init, free, setting-up, rebooting, ready, busy, done]

OPTIONS:
    -h, --help    Print help information
```

`structopt` dependency removed as it was integrated into `clap`.

Updating the other projects that use `clap` is more involved as they use the lower-level interface.