### PR TITLE
Add bash-completion to devcontainer image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -16,7 +16,8 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive && apt-get install -
 # Install packages required for build:
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends \
-    libunwind-dev clang build-essential libssl-dev pkg-config lldb
+    libunwind-dev clang build-essential libssl-dev pkg-config lldb \
+    bash-completion 
 
 ### Setup Rust for 'vscode' user:
 USER vscode


### PR DESCRIPTION
This will give (e.g.) git branch name completion, among many other things.