### PR TITLE
Use rust-cache action for Rust build cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ env:
   CARGO_TERM_COLOR: always
   SCCACHE_DIR: ${{github.workspace}}/sccache/
   SCCACHE_CACHE_SIZE: 1G
-  ACTIONS_CACHE_KEY_DATE: 2022-06-02-01
+  ACTIONS_CACHE_KEY_DATE: 2022-06-17-01
   CI: true
 
 jobs:
@@ -36,9 +36,7 @@ jobs:
     - name: Rust Compile Cache
       uses: actions/cache@v2
       with:
-        path: |
-          sccache
-          src/agent/target
+        path: sccache
         key: agent-${{ runner.os }}-${{ hashFiles('src/agent/Cargo.lock') }}-${{ env.ACTIONS_CACHE_KEY_DATE }}
         restore-keys: |
           agent-${{ runner.os }}-${{ hashFiles('src/agent/Cargo.lock') }}-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,15 +20,13 @@ jobs:
     runs-on: "${{ matrix.os }}"
     steps:
     - uses: actions/checkout@v2
-    - name: Rust Prereq Cache
-      uses: actions/cache@v2
+    - name: Rust Cache
+      uses: Swatinem/rust-cache@v1.4.0
       id: cache-rust-prereqs
       with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-          ~/.cargo/bin
-        key: rust-${{ runner.os }}-${{ env.ACTIONS_CACHE_KEY_DATE }}
+        working-directory: src/agent
+        # additional key for cache-busting:
+        key: ${{ env.ACTIONS_CACHE_KEY_DATE }}
     - name: Install Rust Prereqs
       if: steps.cache-rust-prereqs.outputs.cache-hit != 'true'
       shell: bash


### PR DESCRIPTION
This has some [smarts](https://github.com/Swatinem/rust-cache#cache-details) built in about what should and shouldn't be cached, which 1) removes our need to specify exactly what should be cached and 2) helps stop the cache size growing over time.