### PR TITLE
Implement `info` Function in C#

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,13 +282,13 @@ jobs:
         dotnet format --verify-no-changes --no-restore
     - name: Build Service
       run: |
+        version=$(./src/ci/get-version.sh)
+
         cd src/ApiService/
 
         # Store GitHub RunID and SHA to be read by the 'info' function
         echo ${GITHUB_RUN_ID} | tee ApiService/onefuzzlib/build.id
         echo ${GITHUB_SHA} | tee ApiService/onefuzzlib/git.version
-
-        version=$(./src/ci/get-version.sh)
 
         # stamp the build with version
         # note that version might have a suffix of '-{sha}' from get-version.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,12 +283,27 @@ jobs:
     - name: Build Service
       run: |
         cd src/ApiService/
-        dotnet build -warnaserror --configuration Release
+
+        # Store GitHub RunID and SHA to be read by the 'info' function
+        echo ${GITHUB_RUN_ID} | tee onefuzzlib/build.id
+        echo ${GITHUB_SHA} | tee onefuzzlib/git.version
+
+        version=$(./src/ci/get-version.sh)
+
+        # stamp the build with version
+        # note that version might have a suffix of '-{sha}' from get-version.sh
+        if [[ "$version" =~ '-' ]]; then
+          # if it has a suffix, split it into two parts
+          dotnet build -warnaserror --configuration Release /p:VersionPrefix=${version%-*} /p:VersionSuffix=${version#*-}
+        else 
+          dotnet build -warnaserror --configuration Release /p:VersionPrefix=${version}
+        fi
+
     - name: Test & Collect coverage info
       run: |
         cd src/ApiService/
         azurite --silent &
-        dotnet test --no-restore --collect:"XPlat Code Coverage" --filter 'Category!=Integration'
+        dotnet test --no-build --collect:"XPlat Code Coverage" --filter 'Category!=Integration'
         dotnet tool run reportgenerator -reports:Tests/TestResults/*/coverage.cobertura.xml -targetdir:coverage -reporttypes:MarkdownSummary
         kill %1
         cat coverage/*.md > $GITHUB_STEP_SUMMARY
@@ -296,8 +311,6 @@ jobs:
       run: |
         ./src/ci/get-version.sh > src/deployment/VERSION
         cd src/ApiService/ApiService/
-        echo ${GITHUB_RUN_ID} | tee onefuzzlib/build.id
-        echo ${GITHUB_SHA} | tee onefuzzlib/git.version
         mv az-local.settings.json bin/Release/net6.0/local.settings.json
         cd bin/Release/net6.0/
         zip -r api-service-net.zip .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -280,6 +280,20 @@ jobs:
       run: |
         cd src/ApiService/
         dotnet format --verify-no-changes --no-restore
+
+    # note that Test comes before Build:
+    # Test will build things in Debug mode, Build will build them in Release
+    # Build comes second in case Test would do something (unspecified) that 
+    # would somehow alter the binaries that we want to package.
+    - name: Test & Collect coverage info
+      run: |
+        cd src/ApiService/
+        azurite --silent &
+        dotnet test --no-restore --collect:"XPlat Code Coverage" --filter 'Category!=Integration'
+        dotnet tool run reportgenerator -reports:Tests/TestResults/*/coverage.cobertura.xml -targetdir:coverage -reporttypes:MarkdownSummary
+        kill %1
+        cat coverage/*.md > $GITHUB_STEP_SUMMARY
+
     - name: Build Service
       run: |
         version=$(./src/ci/get-version.sh)
@@ -299,14 +313,6 @@ jobs:
           dotnet build -warnaserror --configuration Release /p:VersionPrefix=${version}
         fi
 
-    - name: Test & Collect coverage info
-      run: |
-        cd src/ApiService/
-        azurite --silent &
-        dotnet test --no-build --collect:"XPlat Code Coverage" --filter 'Category!=Integration'
-        dotnet tool run reportgenerator -reports:Tests/TestResults/*/coverage.cobertura.xml -targetdir:coverage -reporttypes:MarkdownSummary
-        kill %1
-        cat coverage/*.md > $GITHUB_STEP_SUMMARY
     - name: copy artifacts
       run: |
         ./src/ci/get-version.sh > src/deployment/VERSION

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,8 +285,8 @@ jobs:
         cd src/ApiService/
 
         # Store GitHub RunID and SHA to be read by the 'info' function
-        echo ${GITHUB_RUN_ID} | tee onefuzzlib/build.id
-        echo ${GITHUB_SHA} | tee onefuzzlib/git.version
+        echo ${GITHUB_RUN_ID} | tee ApiService/onefuzzlib/build.id
+        echo ${GITHUB_SHA} | tee ApiService/onefuzzlib/git.version
 
         version=$(./src/ci/get-version.sh)
 

--- a/src/ApiService/ApiService/ApiService.csproj
+++ b/src/ApiService/ApiService/ApiService.csproj
@@ -44,5 +44,11 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>Never</CopyToPublishDirectory>
     </None>
+    <EmbeddedResource Include="onefuzzlib/build.id" Condition="Exists('onefuzzlib/build.id')">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </EmbeddedResource>
+    <EmbeddedResource Include="onefuzzlib/git.version" Condition="Exists('onefuzzlib/git.version')">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/src/ApiService/ApiService/Info.cs
+++ b/src/ApiService/ApiService/Info.cs
@@ -15,6 +15,12 @@ public class Info {
         _context = context;
         _auth = auth;
 
+        // TODO: this isn’t actually shared between calls at the moment,
+        // this needs to be placed into a class that can be registered into the
+        // DI container and shared amongst instances.
+        //
+        // However, we need to be careful about auth and caching between different
+        // credentials.
         _response = new Lazy<Async.Task<InfoResponse>>(async () => {
             var config = _context.ServiceConfiguration;
 

--- a/src/ApiService/ApiService/Info.cs
+++ b/src/ApiService/ApiService/Info.cs
@@ -1,0 +1,40 @@
+﻿using System.Threading;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+
+namespace Microsoft.OneFuzz.Service;
+
+public class Info {
+    private readonly IOnefuzzContext _context;
+    private readonly IEndpointAuthorization _auth;
+    private readonly Lazy<Async.Task<InfoResponse>> _response;
+
+    public Info(IEndpointAuthorization auth, IOnefuzzContext context) {
+        _context = context;
+        _auth = auth;
+
+        _response = new Lazy<Async.Task<InfoResponse>>(async () => {
+            var config = _context.ServiceConfiguration;
+
+            var resourceGroup = _context.Creds.GetBaseResourceGroup();
+            var subscription = _context.Creds.GetSubscription();
+            var region = await _context.Creds.GetBaseRegion();
+
+            return new InfoResponse(
+                ResourceGroup: resourceGroup,
+                Subscription: subscription,
+                Region: region,
+                Versions: new Dictionary<string, InfoVersion> { { "onefuzz", new("TODO", "TODO", config.OneFuzzVersion) } },
+                InstanceId: await _context.Containers.GetInstanceId(),
+                InsightsAppid: config.ApplicationInsightsAppId,
+                InsightsInstrumentationKey: config.ApplicationInsightsInstrumentationKey);
+        }, LazyThreadSafetyMode.PublicationOnly);
+    }
+
+    private async Async.Task<HttpResponseData> GetResponse(HttpRequestData req)
+        => await RequestHandling.Ok(req, await _response.Value);
+
+    // [Function("Info")]
+    public Async.Task<HttpResponseData> Run([HttpTrigger("GET")] HttpRequestData req)
+        => _auth.CallIfUser(req, GetResponse);
+}

--- a/src/ApiService/ApiService/OneFuzzTypes/Responses.cs
+++ b/src/ApiService/ApiService/OneFuzzTypes/Responses.cs
@@ -19,6 +19,20 @@ public record BoolResult(
     bool Result
 ) : BaseResponse();
 
+public record InfoResponse(
+    string ResourceGroup,
+    string Region,
+    string Subscription,
+    IReadOnlyDictionary<string, InfoVersion> Versions,
+    Guid? InstanceId,
+    string? InsightsAppid,
+    string? InsightsInstrumentationKey
+) : BaseResponse();
+
+public record InfoVersion(
+    string Git,
+    string Build,
+    string Version);
 
 public class BaseResponseConverter : JsonConverter<BaseResponse> {
     public override BaseResponse? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) {

--- a/src/ApiService/ApiService/Program.cs
+++ b/src/ApiService/ApiService/Program.cs
@@ -106,6 +106,7 @@ public class Program {
             .AddScoped<INodeMessageOperations, NodeMessageOperations>()
             .AddScoped<IRequestHandling, RequestHandling>()
             .AddScoped<IOnefuzzContext, OnefuzzContext>()
+            .AddScoped<IEndpointAuthorization, EndpointAuthorization>()
 
             .AddSingleton<ICreds, Creds>()
             .AddSingleton<IServiceConfig, ServiceConfiguration>()

--- a/src/ApiService/ApiService/ServiceConfiguration.cs
+++ b/src/ApiService/ApiService/ServiceConfiguration.cs
@@ -39,10 +39,10 @@ public interface IServiceConfig {
 
     public string OneFuzzVersion { get; }
 
-    // Prefix to add to the name of any tables created. This allows
+    // Prefix to add to the name of any tables & containers created. This allows
     // multiple instances to run against the same storage account, which
     // is useful for things like integration testing.
-    public string OneFuzzTablePrefix { get; }
+    public string OneFuzzStoragePrefix { get; }
 }
 
 public class ServiceConfiguration : IServiceConfig {
@@ -87,5 +87,5 @@ public class ServiceConfiguration : IServiceConfig {
     public string OneFuzzVersion { get => Environment.GetEnvironmentVariable("ONEFUZZ_VERSION") ?? "0.0.0"; }
 
     public string OneFuzzNodeDisposalStrategy { get => Environment.GetEnvironmentVariable("ONEFUZZ_NODE_DISPOSAL_STRATEGY") ?? "scale_in"; }
-    public string OneFuzzTablePrefix => ""; // in production we never prefix the tables
+    public string OneFuzzStoragePrefix => ""; // in production we never prefix the tables
 }

--- a/src/ApiService/ApiService/onefuzzlib/EndpointAuthorization.cs
+++ b/src/ApiService/ApiService/onefuzzlib/EndpointAuthorization.cs
@@ -3,16 +3,31 @@ using Microsoft.Azure.Functions.Worker.Http;
 
 namespace Microsoft.OneFuzz.Service;
 
-public class EndpointAuthorization {
+public interface IEndpointAuthorization {
+    Async.Task<HttpResponseData> CallIfAgent(
+        HttpRequestData req,
+        Func<HttpRequestData, Async.Task<HttpResponseData>> method)
+        => CallIf(req, method, allowAgent: true);
+
+    Async.Task<HttpResponseData> CallIfUser(
+        HttpRequestData req,
+        Func<HttpRequestData, Async.Task<HttpResponseData>> method)
+        => CallIf(req, method, allowUser: true);
+
+    Async.Task<HttpResponseData> CallIf(
+        HttpRequestData req,
+        Func<HttpRequestData, Async.Task<HttpResponseData>> method,
+        bool allowUser = false,
+        bool allowAgent = false);
+}
+
+public class EndpointAuthorization : IEndpointAuthorization {
     private readonly IOnefuzzContext _context;
     private readonly ILogTracer _log;
 
     public EndpointAuthorization(IOnefuzzContext context, ILogTracer log) {
         _context = context;
         _log = log;
-    }
-    public async Async.Task<HttpResponseData> CallIfAgent(HttpRequestData req, Func<HttpRequestData, Async.Task<HttpResponseData>> method) {
-        return await CallIf(req, method, allowAgent: true);
     }
 
     public async Async.Task<HttpResponseData> CallIf(HttpRequestData req, Func<HttpRequestData, Async.Task<HttpResponseData>> method, bool allowUser = false, bool allowAgent = false) {

--- a/src/ApiService/ApiService/onefuzzlib/orm/Orm.cs
+++ b/src/ApiService/ApiService/onefuzzlib/orm/Orm.cs
@@ -93,7 +93,7 @@ namespace ApiService.OneFuzzLib.Orm {
 
         public async Task<TableClient> GetTableClient(string table, string? accountId = null) {
             // TODO: do this less often, instead of once per request:
-            var tableName = _context.ServiceConfiguration.OneFuzzTablePrefix + table;
+            var tableName = _context.ServiceConfiguration.OneFuzzStoragePrefix + table;
 
             var account = accountId ?? _context.ServiceConfiguration.OneFuzzFuncStorage ?? throw new ArgumentNullException(nameof(accountId));
             var (name, key) = await _context.Storage.GetStorageAccountNameAndKey(account);

--- a/src/ApiService/Tests/Fakes/TestContext.cs
+++ b/src/ApiService/Tests/Fakes/TestContext.cs
@@ -10,10 +10,12 @@ namespace Tests.Fakes;
 // TestContext provides a minimal IOnefuzzContext implementation to allow running
 // of functions as unit or integration tests.
 public sealed class TestContext : IOnefuzzContext {
-    public TestContext(ILogTracer logTracer, IStorage storage, string tablePrefix, string accountId) {
-        ServiceConfiguration = new TestServiceConfiguration(tablePrefix, accountId);
+    public TestContext(ILogTracer logTracer, IStorage storage, ICreds creds, string storagePrefix) {
+        ServiceConfiguration = new TestServiceConfiguration(storagePrefix);
 
         Storage = storage;
+        Creds = creds;
+        Containers = new Containers(logTracer, Storage, Creds, ServiceConfiguration);
 
         RequestHandling = new RequestHandling(logTracer);
         TaskOperations = new TaskOperations(logTracer, this);
@@ -44,6 +46,8 @@ public sealed class TestContext : IOnefuzzContext {
     public IServiceConfig ServiceConfiguration { get; }
 
     public IStorage Storage { get; }
+    public ICreds Creds { get; }
+    public IContainers Containers { get; }
 
     public IRequestHandling RequestHandling { get; }
 
@@ -59,10 +63,6 @@ public sealed class TestContext : IOnefuzzContext {
     public IConfig Config => throw new System.NotImplementedException();
 
     public IConfigOperations ConfigOperations => throw new System.NotImplementedException();
-
-    public IContainers Containers => throw new System.NotImplementedException();
-
-    public ICreds Creds => throw new System.NotImplementedException();
 
     public IDiskOperations DiskOperations => throw new System.NotImplementedException();
 

--- a/src/ApiService/Tests/Fakes/TestCreds.cs
+++ b/src/ApiService/Tests/Fakes/TestCreds.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Identity;
+using Azure.ResourceManager;
+using Azure.ResourceManager.Resources;
+using Microsoft.OneFuzz.Service;
+using Task = System.Threading.Tasks.Task;
+
+namespace Tests.Fakes;
+
+class TestCreds : ICreds {
+
+    private readonly Guid _subscriptionId;
+    private readonly string _resourceGroup;
+    private readonly string _region;
+
+    public TestCreds(Guid subscriptionId, string resourceGroup, string region) {
+        _subscriptionId = subscriptionId;
+        _resourceGroup = resourceGroup;
+        _region = region;
+    }
+
+    public ArmClient ArmClient => null!;
+    // we have to return something in some test cases, even if it isn’t used
+
+    public Task<string> GetBaseRegion() => Task.FromResult(_region);
+
+    public string GetBaseResourceGroup() => _resourceGroup;
+
+    public string GetSubscription() => _subscriptionId.ToString();
+
+    public DefaultAzureCredential GetIdentity() {
+        throw new NotImplementedException();
+    }
+
+    public string GetInstanceName() {
+        throw new NotImplementedException();
+    }
+
+    public Uri GetInstanceUrl() {
+        throw new NotImplementedException();
+    }
+
+    public ResourceGroupResource GetResourceGroupResource() {
+        throw new NotImplementedException();
+    }
+
+    public ResourceIdentifier GetResourceGroupResourceIdentifier() {
+        throw new NotImplementedException();
+    }
+
+    public Guid GetScalesetPrincipalId() {
+        throw new NotImplementedException();
+    }
+}

--- a/src/ApiService/Tests/Fakes/TestEndpointAuthorization.cs
+++ b/src/ApiService/Tests/Fakes/TestEndpointAuthorization.cs
@@ -1,0 +1,44 @@
+﻿
+using System;
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.OneFuzz.Service;
+
+enum RequestType {
+    NoAuthorization,
+    User,
+    Agent,
+}
+
+sealed class TestEndpointAuthorization : IEndpointAuthorization {
+    private readonly RequestType _type;
+    private readonly IOnefuzzContext _context;
+
+    public TestEndpointAuthorization(RequestType type, IOnefuzzContext context) {
+        _type = type;
+        _context = context;
+    }
+
+    public Task<HttpResponseData> CallIf(
+        HttpRequestData req,
+        Func<HttpRequestData, Task<HttpResponseData>> method,
+        bool allowUser = false,
+        bool allowAgent = false) {
+
+        if ((_type == RequestType.User && allowUser) ||
+            (_type == RequestType.Agent && allowAgent)) {
+            return method(req);
+        }
+
+        return _context.RequestHandling.NotOk(
+            req,
+            new Error(
+                ErrorCode.UNAUTHORIZED,
+                new string[] { "Unrecognized agent" }
+            ),
+            "token verification",
+            HttpStatusCode.Unauthorized
+        );
+    }
+}

--- a/src/ApiService/Tests/Fakes/TestHttpRequestData.cs
+++ b/src/ApiService/Tests/Fakes/TestHttpRequestData.cs
@@ -44,6 +44,9 @@ sealed class TestHttpRequestData : HttpRequestData {
     public static TestHttpRequestData FromJson<T>(string method, T obj)
         => new(method, Serializer.Serialize(obj));
 
+    public static TestHttpRequestData Empty(string method)
+        => new(method, new BinaryData(Array.Empty<byte>()));
+
     public TestHttpRequestData(string method, BinaryData body)
         : base(NewFunctionContext()) {
         Method = method;

--- a/src/ApiService/Tests/Fakes/TestServiceConfiguration.cs
+++ b/src/ApiService/Tests/Fakes/TestServiceConfiguration.cs
@@ -1,19 +1,23 @@
-﻿using Microsoft.ApplicationInsights.DataContracts;
+﻿using System;
+using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.OneFuzz.Service;
 
 namespace Tests.Fakes;
 
-sealed class TestServiceConfiguration : IServiceConfig {
-    public TestServiceConfiguration(string tablePrefix, string accountId) {
-        OneFuzzTablePrefix = tablePrefix;
-        OneFuzzFuncStorage = accountId;
+public sealed class TestServiceConfiguration : IServiceConfig {
+    public TestServiceConfiguration(string tablePrefix) {
+        OneFuzzStoragePrefix = tablePrefix;
     }
 
-    public string OneFuzzTablePrefix { get; }
+    public string OneFuzzStoragePrefix { get; }
 
-    public string? OneFuzzFuncStorage { get; }
+    public string? OneFuzzFuncStorage { get; } = "UNUSED_ACCOUNT_ID"; // test implementations do not use this
 
     public string OneFuzzVersion => "9999.0.0"; // very big version to pass any >= checks
+
+    public string? ApplicationInsightsAppId { get; set; } = "TestAppInsightsAppId";
+
+    public string? ApplicationInsightsInstrumentationKey { get; set; } = "TestAppInsightsInstrumentationKey";
 
     // -- Remainder not implemented --
 
@@ -21,9 +25,6 @@ sealed class TestServiceConfiguration : IServiceConfig {
 
     public SeverityLevel LogSeverityLevel => throw new System.NotImplementedException();
 
-    public string? ApplicationInsightsAppId => throw new System.NotImplementedException();
-
-    public string? ApplicationInsightsInstrumentationKey => throw new System.NotImplementedException();
 
     public string? AzureSignalRConnectionString => throw new System.NotImplementedException();
 
@@ -39,8 +40,6 @@ sealed class TestServiceConfiguration : IServiceConfig {
 
     public string? MultiTenantDomain => throw new System.NotImplementedException();
 
-    public string? OneFuzzDataStorage => throw new System.NotImplementedException();
-
     public string? OneFuzzInstance => throw new System.NotImplementedException();
 
     public string? OneFuzzInstanceName => throw new System.NotImplementedException();
@@ -53,7 +52,9 @@ sealed class TestServiceConfiguration : IServiceConfig {
 
     public string OneFuzzNodeDisposalStrategy => throw new System.NotImplementedException();
 
-    public string? OneFuzzResourceGroup => throw new System.NotImplementedException();
-
     public string? OneFuzzTelemetry => throw new System.NotImplementedException();
+
+    public string? OneFuzzDataStorage => throw new NotImplementedException();
+
+    public string? OneFuzzResourceGroup => throw new NotImplementedException();
 }

--- a/src/ApiService/Tests/Functions/AgentEventsTests.cs
+++ b/src/ApiService/Tests/Functions/AgentEventsTests.cs
@@ -13,17 +13,17 @@ namespace Tests.Functions;
 [Trait("Category", "Integration")]
 public class AzureStorageAgentEventsTest : AgentEventsTestsBase {
     public AzureStorageAgentEventsTest(ITestOutputHelper output)
-        : base(output, Integration.AzureStorage.FromEnvironment(), "UNUSED") { }
+        : base(output, Integration.AzureStorage.FromEnvironment()) { }
 }
 
 public class AzuriteAgentEventsTest : AgentEventsTestsBase {
     public AzuriteAgentEventsTest(ITestOutputHelper output)
-        : base(output, new Integration.AzuriteStorage(), "devstoreaccount1") { }
+        : base(output, new Integration.AzuriteStorage()) { }
 }
 
 public abstract class AgentEventsTestsBase : FunctionTestBase {
-    public AgentEventsTestsBase(ITestOutputHelper output, IStorage storage, string accountId)
-        : base(output, storage, accountId) { }
+    public AgentEventsTestsBase(ITestOutputHelper output, IStorage storage)
+        : base(output, storage) { }
 
     // shared helper variables (per-test)
     readonly Guid jobId = Guid.NewGuid();

--- a/src/ApiService/Tests/Functions/InfoTests.cs
+++ b/src/ApiService/Tests/Functions/InfoTests.cs
@@ -1,0 +1,64 @@
+﻿
+using System;
+using System.Net;
+using Microsoft.OneFuzz.Service;
+using Tests.Fakes;
+using Xunit;
+using Xunit.Abstractions;
+
+using Async = System.Threading.Tasks;
+
+namespace Tests.Functions;
+
+[Trait("Category", "Integration")]
+public class AzureStorageInfoTest : InfoTestBase {
+    public AzureStorageInfoTest(ITestOutputHelper output)
+        : base(output, Integration.AzureStorage.FromEnvironment()) { }
+}
+
+public class AzuriteInfoTest : InfoTestBase {
+    public AzuriteInfoTest(ITestOutputHelper output)
+        : base(output, new Integration.AzuriteStorage()) { }
+}
+
+public abstract class InfoTestBase : FunctionTestBase {
+    public InfoTestBase(ITestOutputHelper output, IStorage storage)
+        : base(output, storage) { }
+
+    [Fact]
+    public async Async.Task TestInfo_WithoutAuthorization_IsRejected() {
+        var auth = new TestEndpointAuthorization(RequestType.NoAuthorization, Context);
+        var func = new Info(auth, Context);
+
+        var result = await func.Run(TestHttpRequestData.Empty("GET"));
+        Assert.Equal(HttpStatusCode.Unauthorized, result.StatusCode);
+    }
+
+    [Fact]
+    public async Async.Task TestInfo_WithAgentCredentials_IsRejected() {
+        var auth = new TestEndpointAuthorization(RequestType.Agent, Context);
+        var func = new Info(auth, Context);
+
+        var result = await func.Run(TestHttpRequestData.Empty("GET"));
+        Assert.Equal(HttpStatusCode.Unauthorized, result.StatusCode);
+    }
+
+    [Fact]
+    public async Async.Task TestInfo_WithUserCredentials_Succeeds() {
+        // store the instance ID in the expected location:
+        var instanceId = Guid.NewGuid().ToString();
+        var containerClient = GetContainerClient("base-config");
+        await containerClient.CreateAsync();
+        await containerClient.GetBlobClient("instance_id").UploadAsync(new BinaryData(instanceId));
+
+        var auth = new TestEndpointAuthorization(RequestType.User, Context);
+        var func = new Info(auth, Context);
+
+        var result = await func.Run(TestHttpRequestData.Empty("GET"));
+        Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+
+        // the instance ID should be somewhere in the result,
+        // indicating it was read from the blob
+        Assert.Contains(instanceId, BodyAsString(result));
+    }
+}

--- a/src/ApiService/Tests/Functions/InfoTests.cs
+++ b/src/ApiService/Tests/Functions/InfoTests.cs
@@ -46,6 +46,7 @@ public abstract class InfoTestBase : FunctionTestBase {
     [Fact]
     public async Async.Task TestInfo_WithUserCredentials_Succeeds() {
         // store the instance ID in the expected location:
+        // for production this is done by the deploy script
         var instanceId = Guid.NewGuid().ToString();
         var containerClient = GetContainerClient("base-config");
         await containerClient.CreateAsync();

--- a/src/ApiService/Tests/Functions/_FunctionTestBase.cs
+++ b/src/ApiService/Tests/Functions/_FunctionTestBase.cs
@@ -1,7 +1,10 @@
 ﻿using System;
 using System.IO;
+using System.Linq;
 using ApiService.OneFuzzLib.Orm;
 using Azure.Data.Tables;
+using Azure.Storage;
+using Azure.Storage.Blobs;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.OneFuzz.Service;
 using Tests.Fakes;
@@ -22,19 +25,33 @@ namespace Tests.Functions;
 public abstract class FunctionTestBase : IDisposable {
     private readonly IStorage _storage;
 
-    // each test will use a different table prefix so they don't interfere
+    // each test will use a different prefix for storage (tables, blobs) so they don't interfere
     // with each other - generate a prefix like t12345678 (table names must start with letter)
-    private readonly string _tablePrefix = "t" + Guid.NewGuid().ToString()[..8];
+    private readonly string _storagePrefix = "t" + Guid.NewGuid().ToString()[..8];
+
+    private readonly Guid _subscriptionId = Guid.NewGuid();
+    private readonly string _resourceGroup = "FakeResourceGroup";
+    private readonly string _region = "fakeregion";
 
     protected ILogTracer Logger { get; }
 
     protected TestContext Context { get; }
 
-    public FunctionTestBase(ITestOutputHelper output, IStorage storage, string accountId) {
+    private readonly BlobServiceClient _blobClient;
+    protected BlobContainerClient GetContainerClient(string container)
+        => _blobClient.GetBlobContainerClient(_storagePrefix + container);
+
+    public FunctionTestBase(ITestOutputHelper output, IStorage storage) {
         Logger = new TestLogTracer(output);
         _storage = storage;
 
-        Context = new TestContext(Logger, _storage, _tablePrefix, accountId);
+        var creds = new TestCreds(_subscriptionId, _resourceGroup, _region);
+        Context = new TestContext(Logger, _storage, creds, _storagePrefix);
+
+        // set up blob client for test purposes:
+        var (accountName, accountKey) = _storage.GetStorageAccountNameAndKey("").Result; // for test impls this is always sync
+        var endpoint = _storage.GetBlobEndpoint("");
+        _blobClient = new BlobServiceClient(endpoint, new StorageSharedKeyCredential(accountName, accountKey));
     }
 
     protected static string BodyAsString(HttpResponseData data) {
@@ -44,27 +61,43 @@ public abstract class FunctionTestBase : IDisposable {
     }
 
     public void Dispose() {
-        // TODO, a bit ugly, tidy this up:
-        // delete any tables we created during the run
-        if (_storage is Integration.AzureStorage storage) {
-            var accountName = storage.AccountName;
-            var accountKey = storage.AccountKey;
-            if (accountName is not null && accountKey is not null) {
-                // we are running against live storage
-                var tableClient = new TableServiceClient(
-                    _storage.GetTableEndpoint(accountName),
-                    new TableSharedKeyCredential(accountName, accountKey));
+        var (accountName, accountKey) = _storage.GetStorageAccountNameAndKey("").Result; // sync for test impls
+        if (accountName is not null && accountKey is not null) {
+            // clean up any tables & blobs that this test created
 
-                var tablesToDelete = tableClient.Query(filter: Query.StartsWith("TableName", _tablePrefix));
-                foreach (var table in tablesToDelete) {
-                    try {
-                        tableClient.DeleteTable(table.Name);
-                        Logger.Info($"cleaned up table {table.Name}");
-                    } catch (Exception ex) {
-                        // swallow any exceptions: this is a best-effort attempt to cleanup
-                        Logger.Exception(ex, "error deleting table at end of test");
-                    }
-                }
+            CleanupTables(_storage.GetTableEndpoint(accountName),
+                new TableSharedKeyCredential(accountName, accountKey));
+
+            CleanupBlobs(_storage.GetBlobEndpoint(accountName),
+                new StorageSharedKeyCredential(accountName, accountKey));
+        }
+    }
+    private void CleanupBlobs(Uri endpoint, StorageSharedKeyCredential creds) {
+        var blobClient = new BlobServiceClient(endpoint, creds);
+
+        var containersToDelete = blobClient.GetBlobContainers(prefix: _storagePrefix);
+        foreach (var container in containersToDelete.Where(c => c.IsDeleted != true)) {
+            try {
+                blobClient.DeleteBlobContainer(container.Name);
+                Logger.Info($"cleaned up container {container.Name}");
+            } catch (Exception ex) {
+                // swallow any exceptions: this is a best-effort attempt to cleanup
+                Logger.Exception(ex, "error deleting container at end of test");
+            }
+        }
+    }
+
+    private void CleanupTables(Uri endpoint, TableSharedKeyCredential creds) {
+        var tableClient = new TableServiceClient(endpoint, creds);
+
+        var tablesToDelete = tableClient.Query(filter: Query.StartsWith("TableName", _storagePrefix));
+        foreach (var table in tablesToDelete) {
+            try {
+                tableClient.DeleteTable(table.Name);
+                Logger.Info($"cleaned up table {table.Name}");
+            } catch (Exception ex) {
+                // swallow any exceptions: this is a best-effort attempt to cleanup
+                Logger.Exception(ex, "error deleting table at end of test");
             }
         }
     }

--- a/src/ApiService/Tests/Integration/AzureStorage.cs
+++ b/src/ApiService/Tests/Integration/AzureStorage.cs
@@ -33,23 +33,13 @@ sealed class AzureStorage : IStorage {
         AccountKey = accountKey;
     }
 
-    public IEnumerable<string> CorpusAccounts() {
-        throw new System.NotImplementedException();
-    }
-
-    public IEnumerable<string> GetAccounts(StorageType storageType) {
-        throw new System.NotImplementedException();
-    }
-
-    public string GetPrimaryAccount(StorageType storageType) {
-        throw new System.NotImplementedException();
-    }
-
     public Task<(string?, string?)> GetStorageAccountNameAndKey(string accountId)
         => Async.Task.FromResult((AccountName, AccountKey));
 
-    public Task<string?> GetStorageAccountNameAndKeyByName(string accountName) {
-        throw new System.NotImplementedException();
+    public IEnumerable<string> GetAccounts(StorageType storageType) {
+        if (AccountName != null) {
+            yield return AccountName;
+        }
     }
 
     public Uri GetTableEndpoint(string accountId)
@@ -60,4 +50,16 @@ sealed class AzureStorage : IStorage {
 
     public Uri GetBlobEndpoint(string accountId)
         => new($"https://{AccountName}.blob.core.windows.net/");
+
+    public IEnumerable<string> CorpusAccounts() {
+        throw new System.NotImplementedException();
+    }
+
+    public string GetPrimaryAccount(StorageType storageType) {
+        throw new System.NotImplementedException();
+    }
+
+    public Task<string?> GetStorageAccountNameAndKeyByName(string accountName) {
+        throw new System.NotImplementedException();
+    }
 }

--- a/src/ApiService/Tests/Integration/AzuriteStorage.cs
+++ b/src/ApiService/Tests/Integration/AzuriteStorage.cs
@@ -8,31 +8,32 @@ using Async = System.Threading.Tasks;
 namespace Tests.Integration;
 
 sealed class AzuriteStorage : IStorage {
-    public Uri GetBlobEndpoint(string accountId)
-        => new($"http://127.0.0.1:10000/{accountId}");
+    public Uri GetBlobEndpoint(string _accountId)
+        => new($"http://127.0.0.1:10000/devstoreaccount1");
 
-    public Uri GetQueueEndpoint(string accountId)
-        => new($"http://127.0.0.1:10001/{accountId}");
+    public Uri GetQueueEndpoint(string _accountId)
+        => new($"http://127.0.0.1:10001/devstoreaccount1");
 
-    public Uri GetTableEndpoint(string accountId)
-        => new($"http://127.0.0.1:10002/{accountId}");
+    public Uri GetTableEndpoint(string _accountId)
+        => new($"http://127.0.0.1:10002/devstoreaccount1");
 
-    // This is the fixed account key used by Azurite (derived from devstorage emulator);
+    // This is the fixed name & account key used by Azurite (derived from devstorage emulator);
     // https://docs.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string#configure-a-connection-string-for-azurite
+    const string AccountName = "devstoreaccount1";
     const string AccountKey = "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
 
-    public Task<(string?, string?)> GetStorageAccountNameAndKey(string accountId)
-        => Async.Task.FromResult<(string?, string?)>((accountId, AccountKey));
+    public Task<(string?, string?)> GetStorageAccountNameAndKey(string _accountId)
+        => Async.Task.FromResult<(string?, string?)>((AccountName, AccountKey));
+
+    public IEnumerable<string> GetAccounts(StorageType storageType) {
+        yield return AccountName;
+    }
 
     public Task<string?> GetStorageAccountNameAndKeyByName(string accountName) {
         throw new System.NotImplementedException();
     }
 
     public IEnumerable<string> CorpusAccounts() {
-        throw new System.NotImplementedException();
-    }
-
-    public IEnumerable<string> GetAccounts(StorageType storageType) {
         throw new System.NotImplementedException();
     }
 


### PR DESCRIPTION
## Summary of the Pull Request

Adds implementation of the `info` function. 

Added support for blobs in the function integration test stuff.

Simplified usage of integration test classes by removing the account name parameter.

## PR Checklist
* [x] Applies to work item: #2060
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/onefuzz) and sign the CLI.
* [x] Tests added/passed
* ~~Requires documentation to be updated~~
* ~~I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx~~
