### PR TITLE
Editorconfig underscores rule

### DIFF
--- a/src/ApiService/.editorconfig
+++ b/src/ApiService/.editorconfig
@@ -68,6 +68,14 @@ dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_
 dotnet_naming_symbols.constant_fields.applicable_kinds            = field
 dotnet_naming_symbols.constant_fields.applicable_accessibilities  = *
 dotnet_naming_symbols.constant_fields.required_modifiers          = const
+# Prefix private fields with underscore
+dotnet_naming_rule.private_fields.symbols = private_fields
+dotnet_naming_rule.private_fields.style = prefix_underscore
+dotnet_naming_rule.private_fields.severity = suggestion
+dotnet_naming_symbols.private_fields.applicable_kinds = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private
+dotnet_naming_style.prefix_underscore.capitalization = camel_case
+dotnet_naming_style.prefix_underscore.required_prefix = _
 ###############################
 # C# Coding Conventions       #
 ###############################


### PR DESCRIPTION
Set up a naming rule in `.editorconfig` for private fields to start with an underscore. This ensures that OmniSharp will generate the desired names by default.