### PR TITLE
Register '-net' application during deployment

### DIFF
--- a/src/deployment/deploy.py
+++ b/src/deployment/deploy.py
@@ -293,17 +293,14 @@ class Client:
             "cli_password", object_id, self.get_subscription_id()
         )
 
-    def get_instance_url(self) -> str:
+    def get_instance_urls(self) -> List[str]:
         # The url to access the instance
         # This also represents the legacy identifier_uris of the application
         # registration
         if self.multi_tenant_domain:
-            return "https://%s/%s" % (
-                self.multi_tenant_domain,
-                self.application_name,
-            )
+            return ["https://%s/%s" % (self.multi_tenant_domain, name) for name in [self.application_name, self.application_name + DOTNET_APPLICATION_SUFFIX]]
         else:
-            return "https://%s.azurewebsites.net" % self.application_name
+            return ["https://%s.azurewebsites.net" % name for name in [self.application_name, self.application_name + DOTNET_APPLICATION_SUFFIX]]
 
     def get_identifier_urls(self) -> List[str]:
         # This is used to identify the application registration via the
@@ -391,9 +388,7 @@ class Client:
                         "enableAccessTokenIssuance": False,
                         "enableIdTokenIssuance": True,
                     },
-                    "redirectUris": [
-                        f"{self.get_instance_url()}/.auth/login/aad/callback"
-                    ],
+                    "redirectUris": [f"{url}/.auth/login/aad/callback" for url in self.get_instance_urls()],
                 },
                 "requiredResourceAccess": [
                     {
@@ -455,7 +450,8 @@ class Client:
         else:
 
             identifier_uris: List[str] = app["identifierUris"]
-            api_ids = [id for id in self.get_identifier_urls() if id not in identifier_uris]
+            api_ids = [id for id in self.get_identifier_urls()
+                       if id not in identifier_uris]
 
             if len(api_ids) > 0:
                 identifier_uris.extend(api_ids)
@@ -466,7 +462,8 @@ class Client:
                     subscription=self.get_subscription_id(),
                 )
 
-            existing_role_values = [app_role["value"] for app_role in app["appRoles"]]
+            existing_role_values = [app_role["value"]
+                                    for app_role in app["appRoles"]]
 
             has_missing_roles = any(
                 [role["value"] not in existing_role_values for role in app_roles]
@@ -574,7 +571,7 @@ class Client:
         )
 
         app_func_audiences = self.get_identifier_urls().copy()
-        app_func_audiences.append(self.get_instance_url())
+        app_func_audiences.extend(self.get_instance_urls())
 
         if self.multi_tenant_domain:
             # clear the value in the Issuer Url field:
@@ -656,7 +653,7 @@ class Client:
             logger.info(
                 "Upgrading: Skipping assignment of current user to app role")
             return
-        logger.info("assinging user access to service principal")
+        logger.info("assigning user access to service principal")
         app = get_application(
             display_name=self.application_name,
             subscription_id=self.get_subscription_id(),


### PR DESCRIPTION
## Summary of the Pull Request

Adding the `-net` service to app registration so that OneFuzz CLI can access it by changing endpoint.

VS Code reformatted the file a bit.

## PR Checklist
* [ ] Applies to work item: #xxx
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/onefuzz) and sign the CLI.
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_

## Validation Steps Performed

_How does someone test & validate?_
