### PR TITLE
Add test for StatefulOrm static constructor

### DIFF
--- a/src/ApiService/ApiService/onefuzzlib/ScalesetOperations.cs
+++ b/src/ApiService/ApiService/onefuzzlib/ScalesetOperations.cs
@@ -123,7 +123,7 @@ public class ScalesetOperations : StatefulOrm<Scaleset, ScalesetState, ScalesetO
             }
         }
 
-        return scaleset with  { State = ScalesetState.Halt }; 
+        return scaleset;
     }
 
     /// <summary>

--- a/src/ApiService/ApiService/onefuzzlib/ScalesetOperations.cs
+++ b/src/ApiService/ApiService/onefuzzlib/ScalesetOperations.cs
@@ -100,7 +100,7 @@ public class ScalesetOperations : StatefulOrm<Scaleset, ScalesetState, ScalesetO
     }
 
 
-    public async Async.Task Halt(Scaleset scaleset) {
+    public async Async.Task<Scaleset> Halt(Scaleset scaleset) {
         var shrinkQueue = new ShrinkQueue(scaleset.ScalesetId, _context.Queue, _log);
         await shrinkQueue.Delete();
 
@@ -122,6 +122,8 @@ public class ScalesetOperations : StatefulOrm<Scaleset, ScalesetState, ScalesetO
                 _log.WithHttpStatus(r.ErrorV).Error($"Failed to save scaleset record {scaleset.ScalesetId}");
             }
         }
+
+        return scaleset with  { State = ScalesetState.Halt }; 
     }
 
     /// <summary>

--- a/src/ApiService/Tests/StatefulOrmTests.cs
+++ b/src/ApiService/Tests/StatefulOrmTests.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using ApiService.OneFuzzLib.Orm;
+using Xunit;
+
+namespace Tests;
+
+public class StatefulOrmTests {
+    public static IEnumerable<object[]> GetStatefulOrmTypes() {
+        var statefulOrmType = typeof(StatefulOrm<,,>);
+        foreach (var type in statefulOrmType.Assembly.GetTypes()) {
+            var baseType = type.BaseType;
+            if (baseType is not null
+                && baseType.IsGenericType
+                && baseType.GetGenericTypeDefinition() == statefulOrmType) {
+                yield return new object[] { type };
+            }
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(GetStatefulOrmTypes))]
+    public void EnsureValid(Type statefulOrmType) {
+        // make sure that the classes are all valid,
+        // there is a static constructor on StatefulOrm that performs checks,
+        // so explicitly run the class constructor for the base type:
+        RuntimeHelpers.RunClassConstructor(statefulOrmType.BaseType!.TypeHandle);
+    }
+}


### PR DESCRIPTION
`StatefulOrm` performs checks in the static constructor. Make sure that all these checks pass.

Currently `ReproOperations` and `ScalesetOperations` do not pass:

```
State transition method 'Stopping' in 'ReproOperations' does not have the correct signature.
Expected 'System.Threading.Tasks.Task`1[Microsoft.OneFuzz.Service.Repro] Invoke(Microsoft.OneFuzz.Service.Repro)' 
actual 'System.Threading.Tasks.Task Stopping(Microsoft.OneFuzz.Service.Repro)' 
```

```
State transition method 'Halt' in 'ScalesetOperations' does not have the correct signature.
Expected 'System.Threading.Tasks.Task`1[Microsoft.OneFuzz.Service.Scaleset] Invoke(Microsoft.OneFuzz.Service.Scaleset)'
actual 'System.Threading.Tasks.Task Halt(Microsoft.OneFuzz.Service.Scaleset)' 
```