### PR TITLE
Treat warnings as errors

### DIFF
--- a/src/ApiService/Directory.Build.props
+++ b/src/ApiService/Directory.Build.props
@@ -14,6 +14,9 @@
         -->
         <InvariantGlobalization>true</InvariantGlobalization>
 
+        <!-- warnings as errors, for compatibility with CI -->
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+
         <!-- enable code analysis -->
         <EnableNETAnalyzers>true</EnableNETAnalyzers>
         <AnalysisLevel>6.0-Recommended</AnalysisLevel>


### PR DESCRIPTION
Treat all warnings as errors, so that local development matches the CI build.