### PR TITLE
Fix Racing condition in monitor.rs

### DIFF
--- a/src/agent/onefuzz/src/monitor.rs
+++ b/src/agent/onefuzz/src/monitor.rs
@@ -114,11 +114,12 @@ impl DirectoryMonitor {
                             continue;
                         }
                         Err(err) => {
-                            bail!(
+                            warn!(
                                 "error checking metadata for file. path = {}, error = {}",
                                 path.display(),
                                 err
                             );
+                            continue;
                         }
                     }
                 }

--- a/src/agent/onefuzz/src/monitor.rs
+++ b/src/agent/onefuzz/src/monitor.rs
@@ -1,7 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use std::path::{Path, PathBuf};
+use std::{
+    io::ErrorKind,
+    path::{Path, PathBuf},
+};
 
 use anyhow::{format_err, Result};
 use notify::{Event, EventKind, Watcher};
@@ -98,14 +101,25 @@ impl DirectoryMonitor {
                         return Ok(Some(path));
                     }
 
-                    let is_file = fs::metadata(&path)
-                        .await
-                        .ok()
-                        .map(|f| f.is_file())
-                        .unwrap_or_default();
-
-                    if is_file {
-                        return Ok(Some(path));
+                    match fs::metadata(&path).await {
+                        Ok(metadata) if metadata.is_file() => {
+                            return Ok(Some(path));
+                        }
+                        Ok(_) => {
+                            // Ignore directories.
+                            continue;
+                        }
+                        Err(err) if err.kind() == ErrorKind::NotFound => {
+                            // Ignore if deleted.
+                            continue;
+                        }
+                        Err(err) => {
+                            bail!(
+                                "error checking metadata for file. path = {}, error = {}",
+                                path.display(),
+                                err
+                            );
+                        }
                     }
                 }
                 EventKind::Remove(..) => {

--- a/src/agent/onefuzz/src/monitor.rs
+++ b/src/agent/onefuzz/src/monitor.rs
@@ -94,9 +94,17 @@ impl DirectoryMonitor {
                         .ok_or_else(|| format_err!("missing path for file create event"))?
                         .clone();
 
-                    if !self.report_directories && fs::metadata(&path).await?.is_dir() {
-                        // Ignore
-                    } else {
+                    if self.report_directories {
+                        return Ok(Some(path));
+                    }
+
+                    let is_dir = fs::metadata(&path)
+                        .await
+                        .ok()
+                        .map(|f| f.is_dir())
+                        .unwrap_or_default();
+
+                    if !is_dir {
                         return Ok(Some(path));
                     }
                 }

--- a/src/agent/onefuzz/src/monitor.rs
+++ b/src/agent/onefuzz/src/monitor.rs
@@ -98,13 +98,13 @@ impl DirectoryMonitor {
                         return Ok(Some(path));
                     }
 
-                    let is_dir = fs::metadata(&path)
+                    let is_file = fs::metadata(&path)
                         .await
                         .ok()
-                        .map(|f| f.is_dir())
+                        .map(|f| f.is_file())
                         .unwrap_or_default();
 
-                    if !is_dir {
+                    if is_file {
                         return Ok(Some(path));
                     }
                 }


### PR DESCRIPTION
## Summary of the Pull Request

This PR addresses the racing condition where a file could be discovered by the file monitor but disappear before the it reads its metadata.