### PR TITLE
Remove some allow(clippy::uninit_vec)

### DIFF
--- a/src/agent/debugger/src/breakpoint.rs
+++ b/src/agent/debugger/src/breakpoint.rs
@@ -267,10 +267,16 @@ impl BreakpointCollection {
 
     fn bulk_read_process_memory(&self, process_handle: HANDLE) -> Result<Vec<u8>> {
         let mut buffer: Vec<u8> = Vec::with_capacity(self.bulk_region_size());
+        process::read_memory_array(
+            process_handle,
+            self.min_breakpoint_addr as _,
+            buffer.spare_capacity_mut(),
+        )?;
+
         unsafe {
             buffer.set_len(self.bulk_region_size());
         }
-        process::read_memory_array(process_handle, self.min_breakpoint_addr as _, &mut buffer)?;
+
         Ok(buffer)
     }
 

--- a/src/agent/debugger/src/breakpoint.rs
+++ b/src/agent/debugger/src/breakpoint.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::uninit_vec)]
-
 use std::{
     collections::{btree_map::Range, BTreeMap},
     ops::RangeBounds,

--- a/src/agent/win-util/src/pipe_handle.rs
+++ b/src/agent/win-util/src/pipe_handle.rs
@@ -3,6 +3,8 @@
 
 //! This module implements a wrapper around Win32 named pipes to support non-blocking reads.
 
+#![allow(clippy::uninit_vec)]
+
 use std::os::windows::io::{AsRawHandle, RawHandle};
 
 use anyhow::{Context, Result};

--- a/src/agent/win-util/src/pipe_handle.rs
+++ b/src/agent/win-util/src/pipe_handle.rs
@@ -3,8 +3,6 @@
 
 //! This module implements a wrapper around Win32 named pipes to support non-blocking reads.
 
-#![allow(clippy::uninit_vec)]
-
 use std::os::windows::io::{AsRawHandle, RawHandle};
 
 use anyhow::{Context, Result};

--- a/src/agent/win-util/src/process.rs
+++ b/src/agent/win-util/src/process.rs
@@ -110,10 +110,10 @@ pub fn read_narrow_string(
     len: usize,
 ) -> Result<String> {
     let mut buf: Vec<u8> = Vec::with_capacity(len);
+    read_memory_array(process_handle, remote_address, buf.spare_capacity_mut())?;
     unsafe {
         buf.set_len(len);
     }
-    read_memory_array::<u8>(process_handle, remote_address, &mut buf[..])?;
     Ok(String::from_utf8_lossy(&buf).into())
 }
 
@@ -123,10 +123,10 @@ pub fn read_wide_string(
     len: usize,
 ) -> Result<OsString> {
     let mut buf: Vec<u16> = Vec::with_capacity(len);
+    read_memory_array(process_handle, remote_address, buf.spare_capacity_mut())?;
     unsafe {
         buf.set_len(len);
     }
-    read_memory_array::<u16>(process_handle, remote_address, &mut buf[..])?;
     Ok(OsString::from_wide(&buf))
 }
 

--- a/src/agent/win-util/src/process.rs
+++ b/src/agent/win-util/src/process.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::uninit_vec)]
-
 use std::{
     ffi::OsString,
     mem::{size_of, MaybeUninit},


### PR DESCRIPTION
Closes #1595. Leaving one instance of `allow(clippy::uninit_vec)` in `pipe_handle.rs` as it is more difficult to remove. (Maybe there's  another crate we could use for pipes?)

To satisfy clippy, instead of creating the vec and then resizing it straight away (exposing uninitialized data), write into the `spare_capacity_mut()` (which is `&mut [MaybeUninit<_>]`) and then resize it afterwards.