### PR TITLE
Cache radamsa builds in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -349,7 +349,15 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/cache@v3
+      id: cache-radamsa-build-linux
+      with:
+        # key on the shell script only: this script fixes the 
+        # version to a particular commit, so if it changes we need to rebuild
+        key: radamsa-linux-${{ hashFiles('src/ci/radamsa-linux.sh') }}
+        path: artifacts
     - run: src/ci/radamsa-linux.sh
+      if: steps.cache-radamsa-build-linux.outputs.cache-hit != 'true'
     - uses: actions/upload-artifact@v2.2.2
       with:
         name: build-artifacts
@@ -358,7 +366,15 @@ jobs:
     runs-on: windows-2019
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/cache@v3
+      id: cache-radamsa-build-windows
+      with:
+        # key on the shell script only: this script fixes the 
+        # version to a particular commit, so if it changes we need to rebuild
+        key: radamsa-windows-${{ hashFiles('src/ci/radamsa-windows.sh') }}
+        path: artifacts
     - run: c:\msys64\usr\bin\bash src/ci/radamsa-windows.sh
+      if: steps.cache-radamsa-build-windows.outputs.cache-hit != 'true'
     - uses: actions/upload-artifact@v2.2.2
       with:
         name: build-artifacts


### PR DESCRIPTION
Some CI builds are getting spurious failures trying to clone the radamsa repository.

We don't need to build this every time so cache the built artifacts.