### PR TITLE
Use 'os-provided' Python for devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -16,4 +16,4 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive && apt-get install -
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends \
     libunwind-dev clang build-essential libssl-dev pkg-config lldb \
-    bash-completion npm
+    bash-completion npm python-is-python3

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -42,7 +42,7 @@
 	// Note: available features are listed in: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/container-features/src/devcontainer-features.json
 	"features": {
 		"azure-cli": "latest",
-		"python": "3.8",
+		"python": "os-provided",
 		"dotnet": {
 			"version": "latest"
 		},


### PR DESCRIPTION
Using `3.8` for the Python devcontainer feature version means it builds from source every time the devcontainer is rebuilt, which is very slow. Using `os-provided` will give us a recent enough version (3.10).

Also install `python-is-python3` so that the bare `python` command points to Python 3 (our scripts seem to expect this).
