### PR TITLE
Import `LibFuzzerDotnetLoader`, build .NET fuzzing tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,7 +283,7 @@ jobs:
 
     # note that Test comes before Build:
     # Test will build things in Debug mode, Build will build them in Release
-    # Build comes second in case Test would do something (unspecified) that 
+    # Build comes second in case Test would do something (unspecified) that
     # would somehow alter the binaries that we want to package.
     - name: Test & Collect coverage info
       run: |
@@ -309,7 +309,7 @@ jobs:
         if [[ "$version" =~ '-' ]]; then
           # if it has a suffix, split it into two parts
           dotnet build -warnaserror --configuration Release /p:VersionPrefix=${version%-*} /p:VersionSuffix=${version#*-}
-        else 
+        else
           dotnet build -warnaserror --configuration Release /p:VersionPrefix=${version}
         fi
 
@@ -341,6 +341,26 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - run: src/ci/aflpp.sh
+    - uses: actions/upload-artifact@v2.2.2
+      with:
+        name: build-artifacts
+        path: artifacts
+  dotnet-fuzzing-tools-linux:
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v2
+    - run: src/ci/dotnet-fuzzing-tools.sh
+      shell: bash
+    - uses: actions/upload-artifact@v2.2.2
+      with:
+        name: build-artifacts
+        path: artifacts
+  dotnet-fuzzing-tools-windows:
+    runs-on: windows-2022
+    steps:
+    - uses: actions/checkout@v2
+    - run: src/ci/dotnet-fuzzing-tools.ps1
+      shell: pwsh
     - uses: actions/upload-artifact@v2.2.2
       with:
         name: build-artifacts

--- a/src/agent/LibFuzzerDotnetLoader/LibFuzzerDotnetLoader.csproj
+++ b/src/agent/LibFuzzerDotnetLoader/LibFuzzerDotnetLoader.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <LangVersion>10.0</LangVersion>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Requires commit ec28c46 or greater. -->
+    <ProjectReference Include="../sharpfuzz/src/SharpFuzz/SharpFuzz.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/agent/LibFuzzerDotnetLoader/Program.cs
+++ b/src/agent/LibFuzzerDotnetLoader/Program.cs
@@ -1,0 +1,84 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Reflection;
+using System.Runtime;
+using System.Runtime.InteropServices;
+using System.Text;
+
+using TestOneSpan = SharpFuzz.ReadOnlySpanAction;
+delegate void TestOneArray(byte[] data);
+
+namespace LibFuzzerDotnetLoader {
+    public class Program {
+        public static void Main(string[] args) {
+            var target = Environment.GetEnvironmentVariable("LIBFUZZER_DOTNET_TARGET");
+
+            if (target == null) {
+                throw new Exception("`LIBFUZZER_DOTNET_TARGET` not set. " +
+                                    "Expected format: \"<assembly-path>:<class>:<static-method>\"");
+            }
+
+            var parts = target.Split(':');
+
+            var assemPath = parts[0];
+            var typeName = parts[1];
+            var methodName = parts[2];
+
+            var assem = Assembly.LoadFrom(assemPath);
+
+            var ty = assem.GetType(typeName);
+
+            if (ty == null) {
+                throw new Exception($"unable to resolve type: {typeName}");
+            }
+
+            var method = ty.GetMethod(methodName);
+
+            if (method == null) {
+                throw new Exception($"unable to resolve method: {methodName}");
+            }
+
+            if (TryTestOneSpan(method)) {
+                return;
+            }
+
+            if (TryTestOneArray(method)) {
+                return;
+            }
+
+            throw new Exception($"unable to bind method to a known delegate type: {methodName}");
+        }
+
+        // Returns `true` if delegate binding succeeded.
+        static bool TryTestOne<T>(MethodInfo method, Func<T, SharpFuzz.ReadOnlySpanAction> createAction)
+            where T : System.Delegate
+        {
+            T testOneInput;
+
+            try {
+                testOneInput = (T) Delegate.CreateDelegate(typeof(T), method);
+            } catch {
+                // We failed to bind to the target method.
+                //
+                // Return `false`, so the caller can try a binding with a legacy signature.
+                return false;
+            }
+
+            var action = createAction(testOneInput);
+            SharpFuzz.Fuzzer.LibFuzzer.Run(action);
+
+            return true;
+        }
+
+        static bool TryTestOneSpan(MethodInfo method) {
+            return TryTestOne<TestOneSpan>(method, t => t);
+        }
+
+        static bool TryTestOneArray(MethodInfo method) {
+            // Copy span data into a `byte[]` to support assemblies that target pre-`Span`
+            // frameworks.
+            return TryTestOne<TestOneArray>(method, t => span => t(span.ToArray()));
+        }
+    }
+}

--- a/src/ci/dotnet-fuzzing-tools.ps1
+++ b/src/ci/dotnet-fuzzing-tools.ps1
@@ -8,10 +8,13 @@ $LIBFUZZER_DOTNET_REPO = 'https://github.com/Metalnem/libfuzzer-dotnet'
 $LIBFUZZER_DOTNET_COMMIT = '55d84f84b3540c864371e855c2a5ecb728865d97'
 
 # Script below assumes an absolute path.
-$INSTALL_DIR = "${env:GITHUB_WORKSPACE}/artifacts/third-party/dotnet-fuzzing-windows"
+$ARTIFACTS = "${env:GITHUB_WORKSPACE}/artifacts/third-party/dotnet-fuzzing-windows"
 
-# Create install destination.
-mkdir $INSTALL_DIR
+# Create install destinations.
+mkdir $ARTIFACTS
+mkdir $ARTIFACTS/libfuzzer-dotnet
+mkdir $ARTIFACTS/LibFuzzerDotnetLoader
+mkdir $ARTIFACTS/sharpfuzz
 
 # Prepare SharpFuzz dependency for sibling project reference, build instrumentor.
 #
@@ -20,17 +23,13 @@ pushd src/agent
 git clone $SHARPFUZZ_REPO
 pushd sharpfuzz
 git checkout $SHARPFUZZ_COMMIT
-mkdir $INSTALL_DIR/sharpfuzz
-dotnet publish src/SharpFuzz.CommandLine -f net6.0 -c Release -o $INSTALL_DIR/sharpfuzz --sc -r win10-x64
+dotnet publish src/SharpFuzz.CommandLine -f net6.0 -c Release -o $ARTIFACTS/sharpfuzz --sc -r win10-x64
 popd
 popd
 
 # Build SharpFuzz and our dynamic loader harness for `libfuzzer-dotnet`.
 pushd src/agent/LibFuzzerDotnetLoader
-mkdir out
-dotnet publish . -c Release -o out --sc -r win10-x64 -p:PublishSingleFile=true
-cp out/LibFuzzerDotnetLoader.exe $INSTALL_DIR
-cp out/LibFuzzerDotnetLoader.pdb $INSTALL_DIR
+dotnet publish . -c Release -o $ARTIFACTS/LibFuzzerDotnetLoader --sc -r win10-x64 -p:PublishSingleFile=true
 popd
 
 # Build `libfuzzer-dotnet`.
@@ -38,6 +37,6 @@ git clone $LIBFUZZER_DOTNET_REPO
 pushd libfuzzer-dotnet
 git checkout $LIBFUZZER_DOTNET_COMMIT
 clang -g -O2 -fsanitize=fuzzer libfuzzer-dotnet-windows.cc -o libfuzzer-dotnet.exe
-cp libfuzzer-dotnet.exe $INSTALL_DIR
-cp libfuzzer-dotnet.pdb $INSTALL_DIR
+cp libfuzzer-dotnet.exe $ARTIFACTS/libfuzzer-dotnet
+cp libfuzzer-dotnet.pdb $ARTIFACTS/libfuzzer-dotnet
 popd

--- a/src/ci/dotnet-fuzzing-tools.ps1
+++ b/src/ci/dotnet-fuzzing-tools.ps1
@@ -1,0 +1,43 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+$SHARPFUZZ_REPO = 'https://github.com/Metalnem/sharpfuzz'
+$SHARPFUZZ_COMMIT = 'ec28c461b35fd917ae04cb1afc1028912f60a901'
+
+$LIBFUZZER_DOTNET_REPO = 'https://github.com/Metalnem/libfuzzer-dotnet'
+$LIBFUZZER_DOTNET_COMMIT = '55d84f84b3540c864371e855c2a5ecb728865d97'
+
+# Script below assumes an absolute path.
+$INSTALL_DIR = "${env:GITHUB_WORKSPACE}/artifacts/third-party/dotnet-fuzzing-windows"
+
+# Create install destination.
+mkdir $INSTALL_DIR
+
+# Prepare SharpFuzz dependency for sibling project reference, build instrumentor.
+#
+# Redundant when commit ec28c46 is released.
+pushd src/agent
+git clone $SHARPFUZZ_REPO
+pushd sharpfuzz
+git checkout $SHARPFUZZ_COMMIT
+mkdir $INSTALL_DIR/sharpfuzz
+dotnet publish src/SharpFuzz.CommandLine -f net6.0 -c Release -o $INSTALL_DIR/sharpfuzz --sc -r win10-x64
+popd
+popd
+
+# Build SharpFuzz and our dynamic loader harness for `libfuzzer-dotnet`.
+pushd src/agent/LibFuzzerDotnetLoader
+mkdir out
+dotnet publish . -c Release -o out --sc -r win10-x64 -p:PublishSingleFile=true
+cp out/LibFuzzerDotnetLoader.exe $INSTALL_DIR
+cp out/LibFuzzerDotnetLoader.pdb $INSTALL_DIR
+popd
+
+# Build `libfuzzer-dotnet`.
+git clone $LIBFUZZER_DOTNET_REPO
+pushd libfuzzer-dotnet
+git checkout $LIBFUZZER_DOTNET_COMMIT
+clang -g -O2 -fsanitize=fuzzer libfuzzer-dotnet-windows.cc -o libfuzzer-dotnet.exe
+cp libfuzzer-dotnet.exe $INSTALL_DIR
+cp libfuzzer-dotnet.pdb $INSTALL_DIR
+popd

--- a/src/ci/dotnet-fuzzing-tools.sh
+++ b/src/ci/dotnet-fuzzing-tools.sh
@@ -11,10 +11,13 @@ export LIBFUZZER_DOTNET_REPO='https://github.com/Metalnem/libfuzzer-dotnet'
 export LIBFUZZER_DOTNET_COMMIT='55d84f84b3540c864371e855c2a5ecb728865d97'
 
 # Script below assumes an absolute path.
-export INSTALL_DIR="${GITHUB_WORKSPACE}/artifacts/third-party/dotnet-fuzzing-linux"
+export ARTIFACTS="${GITHUB_WORKSPACE}/artifacts/third-party/dotnet-fuzzing-linux"
 
-# Create install destination.
-mkdir -p $INSTALL_DIR
+# Create install destinations.
+mkdir -p $ARTIFACTS
+mkdir -p $ARTIFACTS/libfuzzer-dotnet
+mkdir -p $ARTIFACTS/LibFuzzerDotnetLoader
+mkdir -p $ARTIFACTS/sharpfuzz
 
 # Install `libfuzzer-dotnet` pre-reqs.
 sudo apt-get install -y llvm-10 llvm-10-dev clang-10
@@ -29,17 +32,13 @@ pushd src/agent
 git clone $SHARPFUZZ_REPO
 pushd sharpfuzz
 git checkout $SHARPFUZZ_COMMIT
-mkdir $INSTALL_DIR/sharpfuzz
-dotnet publish src/SharpFuzz.CommandLine -f net6.0 -c Release -o $INSTALL_DIR/sharpfuzz --sc -r linux-x64
+dotnet publish src/SharpFuzz.CommandLine -f net6.0 -c Release -o $ARTIFACTS/sharpfuzz --sc -r linux-x64
 popd
 popd
 
 # Build SharpFuzz and our dynamic loader harness for `libfuzzer-dotnet`.
 pushd src/agent/LibFuzzerDotnetLoader
-mkdir out
-dotnet publish . -c Release -o out --sc -r linux-x64 -p:PublishSingleFile=true
-cp out/LibFuzzerDotnetLoader $INSTALL_DIR
-cp out/LibFuzzerDotnetLoader.pdb $INSTALL_DIR
+dotnet publish . -c Release -o $ARTIFACTS/LibFuzzerDotnetLoader --sc -r linux-x64 -p:PublishSingleFile=true
 popd
 
 # Build `libfuzzer-dotnet`.
@@ -47,5 +46,5 @@ git clone $LIBFUZZER_DOTNET_REPO
 pushd libfuzzer-dotnet
 git checkout $LIBFUZZER_DOTNET_COMMIT
 clang -g -O2 -fsanitize=fuzzer libfuzzer-dotnet.cc -o libfuzzer-dotnet
-cp libfuzzer-dotnet $INSTALL_DIR
+cp libfuzzer-dotnet $ARTIFACTS/libfuzzer-dotnet
 popd

--- a/src/ci/dotnet-fuzzing-tools.sh
+++ b/src/ci/dotnet-fuzzing-tools.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+set -ex -o pipefail
+
+export SHARPFUZZ_REPO='https://github.com/Metalnem/sharpfuzz'
+export SHARPFUZZ_COMMIT='ec28c461b35fd917ae04cb1afc1028912f60a901'
+
+export LIBFUZZER_DOTNET_REPO='https://github.com/Metalnem/libfuzzer-dotnet'
+export LIBFUZZER_DOTNET_COMMIT='55d84f84b3540c864371e855c2a5ecb728865d97'
+
+# Script below assumes an absolute path.
+export INSTALL_DIR="${GITHUB_WORKSPACE}/artifacts/third-party/dotnet-fuzzing-linux"
+
+# Create install destination.
+mkdir -p $INSTALL_DIR
+
+# Install `libfuzzer-dotnet` pre-reqs.
+sudo apt-get install -y llvm-10 llvm-10-dev clang-10
+
+# Install `SharpFuzz` and `LibFuzzerDotnetLoader` pre-reqs.
+sudo apt-get install -y dotnet-sdk-6.0
+
+# Prepare SharpFuzz dependency for sibling project reference, build instrumentor.
+#
+# Redundant when commit ec28c46 is released.
+pushd src/agent
+git clone $SHARPFUZZ_REPO
+pushd sharpfuzz
+git checkout $SHARPFUZZ_COMMIT
+mkdir $INSTALL_DIR/sharpfuzz
+dotnet publish src/SharpFuzz.CommandLine -f net6.0 -c Release -o $INSTALL_DIR/sharpfuzz --sc -r linux-x64
+popd
+popd
+
+# Build SharpFuzz and our dynamic loader harness for `libfuzzer-dotnet`.
+pushd src/agent/LibFuzzerDotnetLoader
+mkdir out
+dotnet publish . -c Release -o out --sc -r linux-x64 -p:PublishSingleFile=true
+cp out/LibFuzzerDotnetLoader $INSTALL_DIR
+cp out/LibFuzzerDotnetLoader.pdb $INSTALL_DIR
+popd
+
+# Build `libfuzzer-dotnet`.
+git clone $LIBFUZZER_DOTNET_REPO
+pushd libfuzzer-dotnet
+git checkout $LIBFUZZER_DOTNET_COMMIT
+clang -g -O2 -fsanitize=fuzzer libfuzzer-dotnet.cc -o libfuzzer-dotnet
+cp libfuzzer-dotnet $INSTALL_DIR
+popd


### PR DESCRIPTION
### Summary

To support .NET fuzzing, we want an end-user API that requires as little tool expertise as possible, but is effective and coverage-driven. These preliminary changes to the build are not yet used, but will be shortly by upcoming tasks. The new tools are:
- SharpFuzz's CLI tool for instrumenting user-submitted assemblies with coverage feedback. This does not appear to publishable as a self-contained executable at the moment. This is a CLI that simply accepts a path to an uninstrumented assembly. Its presence is not required to use `libfuzzer-dotnet`/`LibFuzzerDotnetLoader`, but will be applied to user assemblies in a setup stage.
- `libfuzzer-dotnet` (for both Linux and Windows), to enable using LibFuzzer with SharpFuzz instrumentation. This is actually a specially-parameterized native LibFuzzer binary which spawns `LibFuzzerDotnetLoader` as a child process, and is configured to use IPC to share data with the child's SharpFuzz runtime code.
- `LibFuzzerDotnetLoader`, which links to SharpFuzz, and uses dynamic loading so users don't have to link (or even be aware of) SharpFuzz or LibFuzzer. Users normally have to write and publish their own self-contained harness that is compatible with SharpFuzz. This removes that step / constraint.

Closes #2131.

### Changes

- Build pinned `SharpFuzz`, `libfuzzer-dotnet` tools for .NET fuzzing (Linux and Windows)
- Import and build `LibFuzzerDotnetLoader` project

### Testing

Manually checked that the expected artifacts get built and uploaded in CI. Downloaded the artifacts, and tested both fuzzing and crash repro against a sample .NET target library (on both Ubuntu 18.04 and Windows 10).