### PR TITLE
Disable `macos` build for agent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,9 @@ jobs:
         os:
         - ubuntu-18.04
         - windows-2019
-        - macos-10.15
+        # we have no use for this yet: at the moment,
+        # the agent does not support macos
+        #- macos-10.15
   azcopy:
     runs-on: ubuntu-18.04
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,9 +59,6 @@ jobs:
         os:
         - ubuntu-18.04
         - windows-2019
-        # we have no use for this yet: at the moment,
-        # the agent does not support macos
-        #- macos-10.15
   azcopy:
     runs-on: ubuntu-18.04
     steps:


### PR DESCRIPTION
The agent does not actually run on `macos` as a lot of the functionality is stubbed out.