### PR TITLE
Include state filter when searching for expired jobs and tasks

### DIFF
--- a/src/ApiService/ApiService/onefuzzlib/JobOperations.cs
+++ b/src/ApiService/ApiService/onefuzzlib/JobOperations.cs
@@ -29,7 +29,10 @@ public class JobOperations : StatefulOrm<Job, JobState, JobOperations>, IJobOper
     }
 
     public IAsyncEnumerable<Job> SearchExpired() {
-        return QueryAsync(filter: $"end_time lt datetime'{DateTimeOffset.UtcNow.ToString("o")}'");
+        var timeFilter = $"end_time lt datetime'{DateTimeOffset.UtcNow.ToString("o")}'";
+        var stateFilter = Query.EqualAnyEnum("state", JobStateHelper.Available);
+        var filter = Query.And(stateFilter, timeFilter);
+        return QueryAsync(filter: filter);
     }
 
     public IAsyncEnumerable<Job> SearchState(IEnumerable<JobState> states) {

--- a/src/ApiService/ApiService/onefuzzlib/TaskOperations.cs
+++ b/src/ApiService/ApiService/onefuzzlib/TaskOperations.cs
@@ -68,8 +68,10 @@ public class TaskOperations : StatefulOrm<Task, TaskState, TaskOperations>, ITas
     }
 
     public IAsyncEnumerable<Task> SearchExpired() {
-        var timeFilter = $"end_time lt Datetime'{DateTimeOffset.UtcNow.ToString("o")}'";
-        return QueryAsync(filter: timeFilter);
+        var timeFilter = $"end_time lt datetime'{DateTimeOffset.UtcNow.ToString("o")}'";
+        var stateFilter = Query.EqualAnyEnum("state", TaskStateHelper.AvailableStates);
+        var filter = Query.And(stateFilter, timeFilter);
+        return QueryAsync(filter: filter);
     }
 
     public async Async.Task MarkStopping(Task task) {


### PR DESCRIPTION
The state filter from the original python code was omitted when porting this logic