### PR TITLE
Add logging to `LibFuzzerDotnetLoader`

### DIFF
--- a/src/agent/LibFuzzerDotnetLoader/LibFuzzerDotnetLoader.csproj
+++ b/src/agent/LibFuzzerDotnetLoader/LibFuzzerDotnetLoader.csproj
@@ -11,6 +11,8 @@
   <ItemGroup>
     <!-- Requires commit ec28c46 or greater. -->
     <ProjectReference Include="../sharpfuzz/src/SharpFuzz/SharpFuzz.csproj" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Add logging
- Catch terminal exceptions and log as errors before re-throwing
- Nest some exceptions
- Warn when falling back to non-zero cost delegate for legacy compat

Closes #2129.