### PR TITLE
Pin Rust to 1.62

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,10 @@ jobs:
     runs-on: "${{ matrix.os }}"
     steps:
     - uses: actions/checkout@v2
+    - name: Install specific Rust version
+      run: |
+        rustup default 1.62 
+        rustup component add clippy rustfmt
     - name: Rust Prereq Cache
       uses: actions/cache@v2
       id: cache-rust-prereqs

--- a/src/ci/rust-prereqs.sh
+++ b/src/ci/rust-prereqs.sh
@@ -16,5 +16,3 @@ cargo install cargo-audit
 if ! cargo-license --help; then
     cargo install cargo-license
 fi
-
-rustup component add clippy


### PR DESCRIPTION
By default we get whatever Rust version is installed in the Github Actions image. Pin it to latest Rust so it doesn't change unless we want it to.