### PR TITLE
Improvement to unique report generation

### DIFF
--- a/src/agent/onefuzz-task/src/tasks/report/crash_report.rs
+++ b/src/agent/onefuzz-task/src/tasks/report/crash_report.rs
@@ -139,6 +139,19 @@ impl CrashTestResult {
     ) -> Result<()> {
         match self {
             Self::CrashReport(report) => {
+                // try to save the report first — if it already exists, that
+                // means this is an already-tested input, so we shouldn’t save
+                // a unique report for it:
+                if let Some(reports) = reports {
+                    let name = report.blob_name();
+                    if upload_or_save_local(&report, &name, reports).await? {
+                        event!(new_report; EventData::Path = name);
+                    } else {
+                        // report already exists; don’t save a unique report
+                        return Ok(());
+                    }
+                }
+
                 // Use SHA-256 of call stack as dedupe key.
                 if let Some(unique_reports) = unique_reports {
                     let name = report.unique_blob_name();
@@ -147,12 +160,7 @@ impl CrashTestResult {
                     }
                 }
 
-                if let Some(reports) = reports {
-                    let name = report.blob_name();
-                    if upload_or_save_local(&report, &name, reports).await? {
-                        event!(new_report; EventData::Path = name);
-                    }
-                }
+                Ok(())
             }
 
             Self::NoRepro(report) => {
@@ -162,9 +170,10 @@ impl CrashTestResult {
                         event!(new_unable_to_reproduce; EventData::Path = name);
                     }
                 }
+
+                Ok(())
             }
         }
-        Ok(())
     }
 }
 


### PR DESCRIPTION
This is a small change to improve the behaviour described in #2065.

Previously the crash reporter would do:

1. use input to generate failing call stack
2. save unique report keyed by `hash(call_stack)`
3. save report keyed by `hash(input)`

However (as describe in #2065), the output containers can be shared by multiple different versions of the same program, which are likely to generate different callstacks for the same input, which leads to `#unique_reports > #reports`.

This PR changes the flow to:

1. use input to generate a failing call stack
2. attempt to save report keyed by `hash(input)`
3. if a fresh report was _not_ saved, save unique report keyed by `hash(call_stack)`