### PR TITLE
Allow autoscale with a minimum of 0

### DIFF
--- a/src/pytypes/onefuzztypes/models.py
+++ b/src/pytypes/onefuzztypes/models.py
@@ -668,9 +668,9 @@ class Scaleset(BaseModel):
 
 class AutoScale(BaseModel):
     scaleset_id: UUID
-    min: int = Field(ge=1)
+    min: int = Field(ge=0)
     max: int = Field(ge=1)
-    default: int = Field(ge=1)
+    default: int = Field(ge=0)
     scale_out_amount: int = Field(ge=1)
     scale_out_cooldown: int = Field(ge=1)
     scale_in_amount: int = Field(ge=1)

--- a/src/pytypes/onefuzztypes/requests.py
+++ b/src/pytypes/onefuzztypes/requests.py
@@ -172,7 +172,7 @@ class ScalesetUpdate(BaseRequest):
 class AutoScaleOptions(BaseModel):
     min: int = Field(ge=0)
     max: int = Field(ge=1)
-    default: int = Field(ge=1)
+    default: int = Field(ge=0)
     scale_out_amount: int = Field(ge=1)
     scale_out_cooldown: int = Field(ge=1)
     scale_in_amount: int = Field(ge=1)


### PR DESCRIPTION
`check-pr` failed during setup with:

```
1 validation error for AutoScale min ensure this value is greater than or equal to 1
```

Possibly due to #2112; needed a server-side change to match.
