### PR TITLE
Add support for dotnet_endpoint/dotnet_functions to integration-test.py

### DIFF
--- a/src/integration-tests/integration-test.py
+++ b/src/integration-tests/integration-test.py
@@ -917,12 +917,16 @@ class Run(Command):
         poll: bool = False,
         stop_on_complete_check: bool = False,
         job_ids: List[UUID] = [],
+        dotnet_endpoint: Optional[str] = None,
+        dotnet_functions: Optional[List[str]] = None,
     ) -> None:
         self.onefuzz.__setup__(
             endpoint=endpoint,
             client_id=client_id,
             client_secret=client_secret,
             authority=authority,
+            _dotnet_endpoint=dotnet_endpoint,
+            _dotnet_functions=dotnet_functions,
         )
         tester = TestOnefuzz(self.onefuzz, self.logger, test_id)
         result = tester.check_jobs(
@@ -940,12 +944,16 @@ class Run(Command):
         client_secret: Optional[str],
         authority: Optional[str] = None,
         job_ids: List[UUID] = [],
+        dotnet_endpoint: Optional[str] = None,
+        dotnet_functions: Optional[List[str]] = None,
     ) -> None:
         self.onefuzz.__setup__(
             endpoint=endpoint,
             client_id=client_id,
             client_secret=client_secret,
             authority=authority,
+            _dotnet_endpoint=dotnet_endpoint,
+            _dotnet_functions=dotnet_functions,
         )
         tester = TestOnefuzz(self.onefuzz, self.logger, test_id)
         launch_result, repros = tester.launch_repro(job_ids=job_ids)
@@ -964,6 +972,8 @@ class Run(Command):
         region: Optional[Region] = None,
         os_list: List[OS] = [OS.linux, OS.windows],
         test_id: Optional[UUID] = None,
+        dotnet_endpoint: Optional[str] = None,
+        dotnet_functions: Optional[List[str]] = None,
     ) -> None:
         if test_id is None:
             test_id = uuid4()
@@ -975,6 +985,8 @@ class Run(Command):
                 client_id=client_id,
                 client_secret=client_secret,
                 authority=authority,
+                _dotnet_endpoint=dotnet_endpoint,
+                _dotnet_functions=dotnet_functions,
             )
 
         retry(try_setup, "trying to configure")
@@ -994,6 +1006,8 @@ class Run(Command):
         targets: List[str] = list(TARGETS.keys()),
         test_id: Optional[UUID] = None,
         duration: int = 1,
+        dotnet_endpoint: Optional[str] = None,
+        dotnet_functions: Optional[List[str]] = None,
     ) -> None:
         if test_id is None:
             test_id = uuid4()
@@ -1005,6 +1019,8 @@ class Run(Command):
                 client_id=client_id,
                 client_secret=client_secret,
                 authority=authority,
+                _dotnet_endpoint=dotnet_endpoint,
+                _dotnet_functions=dotnet_functions,
             )
 
         retry(try_setup, "trying to configure")
@@ -1026,12 +1042,16 @@ class Run(Command):
         authority: Optional[str],
         client_id: Optional[str],
         client_secret: Optional[str],
+        dotnet_endpoint: Optional[str] = None,
+        dotnet_functions: Optional[List[str]] = None,
     ) -> None:
         self.onefuzz.__setup__(
             endpoint=endpoint,
             client_id=client_id,
             client_secret=client_secret,
             authority=authority,
+            _dotnet_endpoint=dotnet_endpoint,
+            _dotnet_functions=dotnet_functions,
         )
         tester = TestOnefuzz(self.onefuzz, self.logger, test_id=test_id)
         tester.cleanup()
@@ -1044,12 +1064,16 @@ class Run(Command):
         authority: Optional[str] = None,
         client_id: Optional[str],
         client_secret: Optional[str],
+        dotnet_endpoint: Optional[str] = None,
+        dotnet_functions: Optional[List[str]] = None,
     ) -> None:
         self.onefuzz.__setup__(
             endpoint=endpoint,
             client_id=client_id,
             client_secret=client_secret,
             authority=authority,
+            _dotnet_endpoint=dotnet_endpoint,
+            _dotnet_functions=dotnet_functions,
         )
         tester = TestOnefuzz(self.onefuzz, self.logger, test_id=test_id)
         tester.check_logs_for_errors()
@@ -1064,6 +1088,8 @@ class Run(Command):
         skip_repro: bool = False,
         test_id: UUID,
         job_ids: List[UUID] = [],
+        dotnet_endpoint: Optional[str] = None,
+        dotnet_functions: Optional[List[str]] = None,
     ) -> None:
 
         self.check_jobs(
@@ -1075,6 +1101,8 @@ class Run(Command):
             poll=True,
             stop_on_complete_check=True,
             job_ids=job_ids,
+            dotnet_endpoint=dotnet_endpoint,
+            dotnet_functions=dotnet_functions,
         )
 
         if skip_repro:
@@ -1087,6 +1115,8 @@ class Run(Command):
                 client_id=client_id,
                 client_secret=client_secret,
                 job_ids=job_ids,
+                dotnet_endpoint=dotnet_endpoint,
+                dotnet_functions=dotnet_functions,
             )
 
     def test(
@@ -1103,6 +1133,8 @@ class Run(Command):
         targets: List[str] = list(TARGETS.keys()),
         skip_repro: bool = False,
         duration: int = 1,
+        dotnet_endpoint: Optional[str] = None,
+        dotnet_functions: Optional[List[str]] = None,
     ) -> None:
         success = True
 
@@ -1116,6 +1148,8 @@ class Run(Command):
                     client_id=client_id,
                     client_secret=client_secret,
                     authority=authority,
+                    _dotnet_endpoint=dotnet_endpoint,
+                    _dotnet_functions=dotnet_functions,
                 )
 
             retry(try_setup, "trying to configure")
@@ -1150,6 +1184,8 @@ class Run(Command):
                 client_id=client_id,
                 client_secret=client_secret,
                 authority=authority,
+                dotnet_endpoint=dotnet_endpoint,
+                dotnet_functions=dotnet_functions,
             )
         except Exception as e:
             self.logger.error("testing failed: %s", repr(e))

--- a/src/integration-tests/integration-test.py
+++ b/src/integration-tests/integration-test.py
@@ -978,6 +978,7 @@ class Run(Command):
         if test_id is None:
             test_id = uuid4()
         self.logger.info("launching test_id: %s", test_id)
+        self.logger.info("dotnet configuration: %s, %s", dotnet_endpoint, dotnet_functions)
 
         def try_setup(data: Any) -> None:
             self.onefuzz.__setup__(

--- a/src/integration-tests/integration-test.py
+++ b/src/integration-tests/integration-test.py
@@ -230,13 +230,13 @@ OperationResult = TypeVar("OperationResult")
 
 
 def retry(
+    logger: logging.Logger,
     operation: Callable[[Any], OperationResult],
     description: str,
     tries: int = 10,
     wait_duration: int = 10,
     data: Any = None,
 ) -> OperationResult:
-    logger = logging.Logger
     count = 0
     while True:
         try:
@@ -280,7 +280,7 @@ class TestOnefuzz:
         def try_info_get(data: Any) -> None:
             self.of.info.get()
 
-        retry(try_info_get, "testing endpoint")
+        retry(self.logger, try_info_get, "testing endpoint")
 
         self.inject_log(self.start_log_marker)
         for entry in os_list:
@@ -989,7 +989,7 @@ class Run(Command):
                 _dotnet_functions=dotnet_functions,
             )
 
-        retry(try_setup, "trying to configure")
+        retry(self.logger, try_setup, "trying to configure")
 
         tester = TestOnefuzz(self.onefuzz, self.logger, test_id)
         tester.setup(region=region, pool_size=pool_size, os_list=os_list)
@@ -1023,7 +1023,7 @@ class Run(Command):
                 _dotnet_functions=dotnet_functions,
             )
 
-        retry(try_setup, "trying to configure")
+        retry(self.logger, try_setup, "trying to configure")
 
         tester = TestOnefuzz(self.onefuzz, self.logger, test_id)
 
@@ -1152,7 +1152,7 @@ class Run(Command):
                     _dotnet_functions=dotnet_functions,
                 )
 
-            retry(try_setup, "trying to configure")
+            retry(self.logger, try_setup, "trying to configure")
             tester = TestOnefuzz(self.onefuzz, self.logger, test_id)
             tester.setup(region=region, pool_size=pool_size, os_list=os_list)
             tester.launch(samples, os_list=os_list, targets=targets, duration=duration)


### PR DESCRIPTION
This will allow testing client-facing .NET Functions during integration tests (`check-pr`).