### PR TITLE
Factor out generic libfuzzer task

### DIFF
--- a/src/agent/onefuzz-task/src/local/libfuzzer.rs
+++ b/src/agent/onefuzz-task/src/local/libfuzzer.rs
@@ -16,8 +16,8 @@ use crate::{
     },
     tasks::{
         analysis::generic::run as run_analysis, config::CommonConfig,
-        fuzz::libfuzzer_fuzz::LibFuzzerFuzzTask, regression::libfuzzer::LibFuzzerRegressionTask,
-        report::libfuzzer_report::ReportTask,
+        fuzz::libfuzzer::generic::LibFuzzerFuzzTask,
+        regression::libfuzzer::LibFuzzerRegressionTask, report::libfuzzer_report::ReportTask,
     },
 };
 #[cfg(any(target_os = "linux", target_os = "windows"))]

--- a/src/agent/onefuzz-task/src/local/libfuzzer_fuzz.rs
+++ b/src/agent/onefuzz-task/src/local/libfuzzer_fuzz.rs
@@ -9,7 +9,7 @@ use crate::{
     },
     tasks::{
         config::CommonConfig,
-        fuzz::libfuzzer_fuzz::{Config, LibFuzzerFuzzTask},
+        fuzz::libfuzzer::generic::{Config, LibFuzzerFuzzTask},
     },
 };
 use anyhow::Result;
@@ -51,6 +51,7 @@ pub fn build_fuzz_config(
         check_fuzzer_help,
         expect_crash_on_failure,
         common,
+        extra: (),
     };
 
     Ok(config)

--- a/src/agent/onefuzz-task/src/tasks/config.rs
+++ b/src/agent/onefuzz-task/src/tasks/config.rs
@@ -88,7 +88,7 @@ pub enum Config {
     DotnetCoverage(coverage::dotnet::Config),
 
     #[serde(alias = "libfuzzer_fuzz")]
-    LibFuzzerFuzz(fuzz::libfuzzer_fuzz::Config),
+    LibFuzzerFuzz(fuzz::libfuzzer::generic::Config),
 
     #[serde(alias = "libfuzzer_crash_report")]
     LibFuzzerReport(report::libfuzzer_report::Config),
@@ -225,7 +225,7 @@ impl Config {
                     .await
             }
             Config::LibFuzzerFuzz(config) => {
-                fuzz::libfuzzer_fuzz::LibFuzzerFuzzTask::new(config)?
+                fuzz::libfuzzer::generic::LibFuzzerFuzzTask::new(config)?
                     .run()
                     .await
             }

--- a/src/agent/onefuzz-task/src/tasks/fuzz/libfuzzer.rs
+++ b/src/agent/onefuzz-task/src/tasks/fuzz/libfuzzer.rs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-pub mod generator;
-pub mod libfuzzer;
-pub mod supervisor;
+pub mod common;
+pub mod generic;

--- a/src/agent/onefuzz-task/src/tasks/fuzz/libfuzzer/common.rs
+++ b/src/agent/onefuzz-task/src/tasks/fuzz/libfuzzer/common.rs
@@ -40,8 +40,14 @@ pub fn default_workers() -> usize {
     usize::max(1, cpus - 1)
 }
 
+pub trait LibFuzzerType {
+    type Config;
+
+    fn from_config(config: &Config<Self>) -> LibFuzzer;
+}
+
 #[derive(Debug, Deserialize, Clone)]
-pub struct Config {
+pub struct Config<L: LibFuzzerType + ?Sized> {
     pub inputs: SyncedDir,
     pub readonly_inputs: Option<Vec<SyncedDir>>,
     pub crashes: SyncedDir,
@@ -61,14 +67,23 @@ pub struct Config {
 
     #[serde(flatten)]
     pub common: CommonConfig,
+
+    #[serde(flatten)]
+    pub extra: L::Config,
 }
 
-pub struct LibFuzzerFuzzTask {
-    config: Config,
+pub struct LibFuzzerFuzzTask<L>
+where
+    L: LibFuzzerType,
+{
+    config: Config<L>,
 }
 
-impl LibFuzzerFuzzTask {
-    pub fn new(config: Config) -> Result<Self> {
+impl<L> LibFuzzerFuzzTask<L>
+where
+    L: LibFuzzerType,
+{
+    pub fn new(config: Config<L>) -> Result<Self> {
         Ok(Self { config })
     }
 
@@ -108,12 +123,8 @@ impl LibFuzzerFuzzTask {
             directories.append(&mut dirs);
         }
 
-        let fuzzer = LibFuzzer::new(
-            &self.config.target_exe,
-            &self.config.target_options,
-            &self.config.target_env,
-            &self.config.common.setup_dir,
-        );
+        let fuzzer = L::from_config(&self.config);
+
         fuzzer
             .verify(self.config.check_fuzzer_help, Some(directories))
             .await

--- a/src/agent/onefuzz-task/src/tasks/fuzz/libfuzzer/common.rs
+++ b/src/agent/onefuzz-task/src/tasks/fuzz/libfuzzer/common.rs
@@ -40,9 +40,15 @@ pub fn default_workers() -> usize {
     usize::max(1, cpus - 1)
 }
 
+/// LibFuzzer subtypes that share custom configuration or process initialization.
 pub trait LibFuzzerType {
+    /// Extra configuration values expected by the `Config` for this type.
     type Config;
 
+    /// Method that constructs a `LibFuzzer` configured as appropriate for the subtype.
+    ///
+    /// This may include things like setting special environment variables, or overriding
+    /// the defaults or values of some command arguments.
     fn from_config(config: &Config<Self>) -> LibFuzzer;
 }
 

--- a/src/agent/onefuzz-task/src/tasks/fuzz/libfuzzer/generic.rs
+++ b/src/agent/onefuzz-task/src/tasks/fuzz/libfuzzer/generic.rs
@@ -5,6 +5,10 @@ use onefuzz::libfuzzer::LibFuzzer;
 
 use crate::tasks::fuzz::libfuzzer::common;
 
+/// Generic LibFuzzer with no special extra configuration.
+///
+/// Its configuration is fully controlled by the user, up to the constraints of the
+/// `LibFuzzer` wrapper itself.
 #[derive(Debug)]
 pub struct GenericLibFuzzer;
 

--- a/src/agent/onefuzz-task/src/tasks/fuzz/libfuzzer/generic.rs
+++ b/src/agent/onefuzz-task/src/tasks/fuzz/libfuzzer/generic.rs
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use onefuzz::libfuzzer::LibFuzzer;
+
+use crate::tasks::fuzz::libfuzzer::common;
+
+#[derive(Debug)]
+pub struct GenericLibFuzzer;
+
+impl common::LibFuzzerType for GenericLibFuzzer {
+    type Config = ();
+
+    fn from_config(config: &common::Config<Self>) -> LibFuzzer {
+        LibFuzzer::new(
+            &config.target_exe,
+            &config.target_options,
+            &config.target_env,
+            &config.common.setup_dir,
+        )
+    }
+}
+
+pub type Config = common::Config<GenericLibFuzzer>;
+pub type LibFuzzerFuzzTask = common::LibFuzzerFuzzTask<GenericLibFuzzer>;


### PR DESCRIPTION
Abstract the existing `libfuzzer_fuzz` task implementation. This is done in a way that will support introducing variant `libfuzzer_fuzz` task types that have extra config and do special process setup for certain kinds of LibFuzzer targets (i.e. `libfuzzer-dotnet`). 

Without changing task behavior, use the abstracted API to express the _existing_ task via the `GenericLibFuzzer`, which has no special additional config.