### PR TITLE
Add extensions functionality for C# refactor

### DIFF
--- a/src/ApiService/ApiService/Program.cs
+++ b/src/ApiService/ApiService/Program.cs
@@ -109,6 +109,7 @@ public class Program {
             .AddScoped<INodeTasksOperations, NodeTasksOperations>()
             .AddScoped<INodeMessageOperations, NodeMessageOperations>()
             .AddScoped<IRequestHandling, RequestHandling>()
+            .AddScoped<IImageOperations, ImageOperations>()
             .AddScoped<IOnefuzzContext, OnefuzzContext>()
             .AddScoped<IEndpointAuthorization, EndpointAuthorization>()
             .AddScoped<INodeMessageOperations, NodeMessageOperations>()

--- a/src/ApiService/ApiService/onefuzzlib/Extension.cs
+++ b/src/ApiService/ApiService/onefuzzlib/Extension.cs
@@ -89,6 +89,7 @@ public class Extensions : IExtensions {
         if (vmOs == Os.Windows) {
             return new VMExtenionWrapper {
                 Location = region,
+                Name = "KVVMExtensionForWindows",
                 Publisher = "Microsoft.Azure.KeyVault",
                 TypePropertiesType = "KeyVaultForWindows",
                 TypeHandlerVersion = "1.0",
@@ -111,6 +112,7 @@ public class Extensions : IExtensions {
 
             return new VMExtenionWrapper {
                 Location = region,
+                Name = "KVVMExtensionForLinux",
                 Publisher = "Microsoft.Azure.KeyVault",
                 TypePropertiesType = "KeyVaultForLinux",
                 TypeHandlerVersion = "2.0",
@@ -132,6 +134,7 @@ public class Extensions : IExtensions {
     public static VMExtenionWrapper AzSecExtension(AzureLocation region) {
         return new VMExtenionWrapper {
             Location = region,
+            Name = "AzureSecurityLinuxAgent",
             Publisher = "Microsoft.Azure.Security.Monitoring",
             TypePropertiesType = "AzureSecurityLinuxAgent",
             TypeHandlerVersion = "2.0",
@@ -152,6 +155,7 @@ public class Extensions : IExtensions {
 
         return new VMExtenionWrapper {
             Location = region,
+            Name = "AzureMonitorLinuxAgent",
             Publisher = "Microsoft.Azure.Monitor",
             TypePropertiesType = "AzureMonitorLinuxAgent",
             AutoUpgradeMinorVersion = true,
@@ -175,6 +179,7 @@ public class Extensions : IExtensions {
     public static VMExtenionWrapper GenevaExtension(AzureLocation region) {
         return new VMExtenionWrapper {
             Location = region,
+            Name = "Microsoft.Azure.Geneva.GenevaMonitoring",
             Publisher = "Microsoft.Azure.Geneva",
             TypePropertiesType = "GenevaMonitoring",
             TypeHandlerVersion = "2.0",
@@ -188,6 +193,7 @@ public class Extensions : IExtensions {
         if (vmOs == Os.Windows) {
             return new VMExtenionWrapper {
                 Location = region,
+                Name = "DependencyAgentWindows",
                 AutoUpgradeMinorVersion = true,
                 Publisher = "Microsoft.Azure.Monitoring.DependencyAgent",
                 TypePropertiesType = "DependencyAgentWindows",
@@ -383,18 +389,18 @@ public class Extensions : IExtensions {
 
         var urls = new List<Uri>()
         {
-            (await _context.Containers.GetFileSasUrl(
+            await _context.Containers.GetFileSasUrl(
                 reproConfig.Container,
                 reproConfig.Path,
                 StorageType.Corpus,
                 BlobSasPermissions.Read
-            )),
-            (await _context.Containers.GetFileSasUrl(
+            ),
+            await _context.Containers.GetFileSasUrl(
                 report?.InputBlob?.container!,
                 report?.InputBlob?.Name!,
                 StorageType.Corpus,
                 BlobSasPermissions.Read
-            ))
+            )
         };
 
         List<string> reproFiles;
@@ -428,18 +434,18 @@ public class Extensions : IExtensions {
         foreach (var reproFile in reproFiles) {
             urls.AddRange(new List<Uri>()
             {
-                (await _context.Containers.GetFileSasUrl(
+                await _context.Containers.GetFileSasUrl(
                     new Container("repro-scripts"),
                     reproFile,
                     StorageType.Config,
                     BlobSasPermissions.Read
-                )),
-                (await _context.Containers.GetFileSasUrl(
+                ),
+                await _context.Containers.GetFileSasUrl(
                     new Container("task-configs"),
                     $"{reproId}/{scriptName}",
                     StorageType.Config,
                     BlobSasPermissions.Read
-                ))
+                )
             });
         }
 

--- a/src/ApiService/ApiService/onefuzzlib/Extension.cs
+++ b/src/ApiService/ApiService/onefuzzlib/Extension.cs
@@ -14,40 +14,27 @@ public interface IExtensions {
 }
 
 public class Extensions : IExtensions {
-    IServiceConfig _serviceConfig;
-    ICreds _creds;
-    IQueue _queue;
-    IContainers _containers;
-    IConfigOperations _instanceConfigOps;
-    ILogAnalytics _logAnalytics;
-
     IOnefuzzContext _context;
 
     private static readonly JsonSerializerOptions _extensionSerializerOptions = new JsonSerializerOptions {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase
     };
 
-    public Extensions(IServiceConfig config, ICreds creds, IQueue queue, IContainers containers, IConfigOperations instanceConfigOps, ILogAnalytics logAnalytics, IOnefuzzContext context) {
-        _serviceConfig = config;
-        _creds = creds;
-        _queue = queue;
-        _containers = containers;
-        _instanceConfigOps = instanceConfigOps;
-        _logAnalytics = logAnalytics;
+    public Extensions(IOnefuzzContext context) {
         _context = context;
     }
 
     public async Async.Task<Uri?> ConfigUrl(Container container, string fileName, bool withSas) {
         if (withSas)
-            return await _containers.GetFileSasUrl(container, fileName, StorageType.Config, BlobSasPermissions.Read);
+            return await _context.Containers.GetFileSasUrl(container, fileName, StorageType.Config, BlobSasPermissions.Read);
         else
-            return await _containers.GetFileUrl(container, fileName, StorageType.Config);
+            return await _context.Containers.GetFileUrl(container, fileName, StorageType.Config);
     }
 
-    public async Async.Task<IList<VMExtenionWrapper>> GenericExtensions(AzureLocation region, Os vmOs) {
-        var extensions = new List<VMExtenionWrapper>();
+    public async Async.Task<IList<VMExtensionWrapper>> GenericExtensions(AzureLocation region, Os vmOs) {
+        var extensions = new List<VMExtensionWrapper>();
 
-        var instanceConfig = await _instanceConfigOps.Fetch();
+        var instanceConfig = await _context.ConfigOperations.Fetch();
         extensions.Add(await MonitorExtension(region, vmOs));
 
         var depenency = DependencyExtension(region, vmOs);
@@ -81,13 +68,13 @@ public class Extensions : IExtensions {
         return extensions;
     }
 
-    public static VMExtenionWrapper KeyVaultExtension(AzureLocation region, KeyvaultExtensionConfig keyVault, Os vmOs) {
+    public static VMExtensionWrapper KeyVaultExtension(AzureLocation region, KeyvaultExtensionConfig keyVault, Os vmOs) {
         var keyVaultName = keyVault.KeyVaultName;
         var certName = keyVault.CertName;
         var uri = keyVaultName + certName;
 
         if (vmOs == Os.Windows) {
-            return new VMExtenionWrapper {
+            return new VMExtensionWrapper {
                 Location = region,
                 Name = "KVVMExtensionForWindows",
                 Publisher = "Microsoft.Azure.KeyVault",
@@ -110,7 +97,7 @@ public class Extensions : IExtensions {
             var extensionStore = keyVault.ExtensionStore;
             var certLocation = certPath + extensionStore;
 
-            return new VMExtenionWrapper {
+            return new VMExtensionWrapper {
                 Location = region,
                 Name = "KVVMExtensionForLinux",
                 Publisher = "Microsoft.Azure.KeyVault",
@@ -131,8 +118,8 @@ public class Extensions : IExtensions {
         }
     }
 
-    public static VMExtenionWrapper AzSecExtension(AzureLocation region) {
-        return new VMExtenionWrapper {
+    public static VMExtensionWrapper AzSecExtension(AzureLocation region) {
+        return new VMExtensionWrapper {
             Location = region,
             Name = "AzureSecurityLinuxAgent",
             Publisher = "Microsoft.Azure.Security.Monitoring",
@@ -144,7 +131,7 @@ public class Extensions : IExtensions {
 
     }
 
-    public static VMExtenionWrapper AzMonExtension(AzureLocation region, AzureMonitorExtensionConfig azureMonitor) {
+    public static VMExtensionWrapper AzMonExtension(AzureLocation region, AzureMonitorExtensionConfig azureMonitor) {
         var authId = azureMonitor.MonitoringGCSAuthId;
         var configVersion = azureMonitor.ConfigVersion;
         var moniker = azureMonitor.Moniker;
@@ -153,7 +140,7 @@ public class Extensions : IExtensions {
         var account = azureMonitor.MonitoringGCSAccount;
         var authIdType = azureMonitor.MonitoringGCSAuthIdType;
 
-        return new VMExtenionWrapper {
+        return new VMExtensionWrapper {
             Location = region,
             Name = "AzureMonitorLinuxAgent",
             Publisher = "Microsoft.Azure.Monitor",
@@ -176,8 +163,8 @@ public class Extensions : IExtensions {
         };
     }
 
-    public static VMExtenionWrapper GenevaExtension(AzureLocation region) {
-        return new VMExtenionWrapper {
+    public static VMExtensionWrapper GenevaExtension(AzureLocation region) {
+        return new VMExtensionWrapper {
             Location = region,
             Name = "Microsoft.Azure.Geneva.GenevaMonitoring",
             Publisher = "Microsoft.Azure.Geneva",
@@ -188,10 +175,10 @@ public class Extensions : IExtensions {
         };
     }
 
-    public static VMExtenionWrapper? DependencyExtension(AzureLocation region, Os vmOs) {
+    public static VMExtensionWrapper? DependencyExtension(AzureLocation region, Os vmOs) {
 
         if (vmOs == Os.Windows) {
-            return new VMExtenionWrapper {
+            return new VMExtensionWrapper {
                 Location = region,
                 Name = "DependencyAgentWindows",
                 AutoUpgradeMinorVersion = true,
@@ -216,22 +203,22 @@ public class Extensions : IExtensions {
 
 
     public async Async.Task<Uri?> BuildPoolConfig(Pool pool) {
-        var instanceId = await _containers.GetInstanceId();
+        var instanceId = await _context.Containers.GetInstanceId();
 
-        var queueSas = await _queue.GetQueueSas("node-heartbeat", StorageType.Config, QueueSasPermissions.Add);
+        var queueSas = await _context.Queue.GetQueueSas("node-heartbeat", StorageType.Config, QueueSasPermissions.Add);
         var config = new AgentConfig(
             ClientCredentials: null,
-            OneFuzzUrl: _creds.GetInstanceUrl(),
+            OneFuzzUrl: _context.Creds.GetInstanceUrl(),
             PoolName: pool.Name,
             HeartbeatQueue: queueSas,
-            InstanceTelemetryKey: _serviceConfig.ApplicationInsightsInstrumentationKey,
-            MicrosoftTelemetryKey: _serviceConfig.OneFuzzTelemetry,
-            MultiTenantDomain: _serviceConfig.MultiTenantDomain,
+            InstanceTelemetryKey: _context.ServiceConfiguration.ApplicationInsightsInstrumentationKey,
+            MicrosoftTelemetryKey: _context.ServiceConfiguration.OneFuzzTelemetry,
+            MultiTenantDomain: _context.ServiceConfiguration.MultiTenantDomain,
             InstanceId: instanceId
             );
 
         var fileName = $"{pool.Name}/config.json";
-        await _containers.SaveBlob(new Container("vm-scripts"), fileName, (JsonSerializer.Serialize(config, EntityConverter.GetJsonSerializerOptions())), StorageType.Config);
+        await _context.Containers.SaveBlob(new Container("vm-scripts"), fileName, (JsonSerializer.Serialize(config, EntityConverter.GetJsonSerializerOptions())), StorageType.Config);
         return await ConfigUrl(new Container("vm-scripts"), fileName, false);
     }
 
@@ -248,24 +235,24 @@ public class Extensions : IExtensions {
             commands.Add($"Set-Content -Path {sshPath} -Value \"{sshKey}\"");
         }
 
-        await _containers.SaveBlob(new Container("vm-scripts"), fileName, string.Join(sep, commands) + sep, StorageType.Config);
-        return await _containers.GetFileUrl(new Container("vm-scripts"), fileName, StorageType.Config);
+        await _context.Containers.SaveBlob(new Container("vm-scripts"), fileName, string.Join(sep, commands) + sep, StorageType.Config);
+        return await _context.Containers.GetFileUrl(new Container("vm-scripts"), fileName, StorageType.Config);
     }
 
     public async Async.Task UpdateManagedScripts() {
-        var instanceSpecificSetupSas = await _containers.GetContainerSasUrl(new Container("instance-specific-setup"), StorageType.Config, BlobContainerSasPermissions.List | BlobContainerSasPermissions.Read);
-        var toolsSas = await _containers.GetContainerSasUrl(new Container("tools"), StorageType.Config, BlobContainerSasPermissions.List | BlobContainerSasPermissions.Read);
+        var instanceSpecificSetupSas = await _context.Containers.GetContainerSasUrl(new Container("instance-specific-setup"), StorageType.Config, BlobContainerSasPermissions.List | BlobContainerSasPermissions.Read);
+        var toolsSas = await _context.Containers.GetContainerSasUrl(new Container("tools"), StorageType.Config, BlobContainerSasPermissions.List | BlobContainerSasPermissions.Read);
 
         string[] commands = {
             $"azcopy sync '{instanceSpecificSetupSas}' instance-specific-setup",
             $"azcopy sync '{toolsSas}' tools"
         };
 
-        await _containers.SaveBlob(new Container("vm-scripts"), "managed.ps1", string.Join("\r\n", commands) + "\r\n", StorageType.Config);
-        await _containers.SaveBlob(new Container("vm-scripts"), "managed.sh", string.Join("\n", commands) + "\n", StorageType.Config);
+        await _context.Containers.SaveBlob(new Container("vm-scripts"), "managed.ps1", string.Join("\r\n", commands) + "\r\n", StorageType.Config);
+        await _context.Containers.SaveBlob(new Container("vm-scripts"), "managed.sh", string.Join("\n", commands) + "\n", StorageType.Config);
     }
 
-    public async Async.Task<VMExtenionWrapper> AgentConfig(AzureLocation region, Os vmOs, AgentMode mode, List<Uri>? urls = null, bool withSas = false) {
+    public async Async.Task<VMExtensionWrapper> AgentConfig(AzureLocation region, Os vmOs, AgentMode mode, List<Uri>? urls = null, bool withSas = false) {
         await UpdateManagedScripts();
         var urlsUpdated = urls ?? new();
 
@@ -282,7 +269,7 @@ public class Extensions : IExtensions {
 
             var toExecuteCmd = $"powershell -ExecutionPolicy Unrestricted -File win64/setup.ps1 -mode {mode.ToString().ToLowerInvariant()}";
 
-            var extension = new VMExtenionWrapper {
+            var extension = new VMExtensionWrapper {
                 Name = "CustomScriptExtension",
                 TypePropertiesType = "CustomScriptExtension",
                 Publisher = "Microsoft.Compute",
@@ -308,7 +295,7 @@ public class Extensions : IExtensions {
             var extensionSettings = JsonSerializer.Serialize(new { CommandToExecute = toExecuteCmd, FileUris = urlsUpdated }, _extensionSerializerOptions);
             var protectedExtensionSettings = JsonSerializer.Serialize(new { ManagedIdentity = new Dictionary<string, string>() }, _extensionSerializerOptions);
 
-            var extension = new VMExtenionWrapper {
+            var extension = new VMExtensionWrapper {
                 Name = "CustomScript",
                 Publisher = "Microsoft.Azure.Extensions",
                 TypePropertiesType = "CustomScript",
@@ -325,12 +312,12 @@ public class Extensions : IExtensions {
         throw new NotImplementedException($"unsupported OS: {vmOs}");
     }
 
-    public async Async.Task<VMExtenionWrapper> MonitorExtension(AzureLocation region, Os vmOs) {
-        var settings = await _logAnalytics.GetMonitorSettings();
+    public async Async.Task<VMExtensionWrapper> MonitorExtension(AzureLocation region, Os vmOs) {
+        var settings = await _context.LogAnalytics.GetMonitorSettings();
         var extensionSettings = JsonSerializer.Serialize(new { WorkspaceId = settings.Id }, _extensionSerializerOptions);
         var protectedExtensionSettings = JsonSerializer.Serialize(new { WorkspaceKey = settings.Key }, _extensionSerializerOptions);
         if (vmOs == Os.Windows) {
-            return new VMExtenionWrapper {
+            return new VMExtensionWrapper {
                 Location = region,
                 Name = "OMSExtension",
                 TypePropertiesType = "MicrosoftMonitoringAgent",
@@ -341,7 +328,7 @@ public class Extensions : IExtensions {
                 ProtectedSettings = new BinaryData(protectedExtensionSettings)
             };
         } else if (vmOs == Os.Linux) {
-            return new VMExtenionWrapper {
+            return new VMExtensionWrapper {
                 Location = region,
                 Name = "OMSExtension",
                 TypePropertiesType = "OmsAgentForLinux",

--- a/src/ApiService/ApiService/onefuzzlib/ImageOperations.cs
+++ b/src/ApiService/ApiService/onefuzzlib/ImageOperations.cs
@@ -1,4 +1,4 @@
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Azure;
 using Azure.ResourceManager.Compute;
 
@@ -20,7 +20,7 @@ public class ImageOperations : IImageOperations {
         string? name = null;
         try {
             var parsed = _context.Creds.ParseResourceId(image);
-            var _ = !parsed.HasData ? await parsed.GetAsync() : null;
+            parsed = await _context.Creds.GetData(parsed);
             if (string.Equals(parsed.Id.ResourceType, "galleries", StringComparison.OrdinalIgnoreCase)) {
                 try {
                     // This is not _exactly_ the same as the python code  

--- a/src/ApiService/ApiService/onefuzzlib/ImageOperations.cs
+++ b/src/ApiService/ApiService/onefuzzlib/ImageOperations.cs
@@ -1,0 +1,115 @@
+using System.Threading.Tasks;
+using Azure;
+using Azure.ResourceManager.Compute;
+
+namespace Microsoft.OneFuzz.Service;
+
+public interface IImageOperations {
+    public Async.Task<OneFuzzResult<Os>> GetOs(string region, string image);
+}
+
+public class ImageOperations : IImageOperations {
+    private IOnefuzzContext _context;
+    private ILogTracer _logTracer;
+
+    public ImageOperations(ILogTracer logTracer, IOnefuzzContext context) {
+        _logTracer = logTracer;
+        _context = context;
+    }
+    public async Task<OneFuzzResult<Os>> GetOs(string region, string image) {
+        string? name = null;
+        try {
+            var parsed = _context.Creds.ParseResourceId(image);
+            var _ = !parsed.HasData ? await parsed.GetAsync() : null;
+            if (string.Equals(parsed.Id.ResourceType, "galleries", StringComparison.OrdinalIgnoreCase)) {
+                try {
+                    // This is not _exactly_ the same as the python code  
+                    // because in C# we don't have access to child_name_1
+                    var gallery = await _context.Creds.GetResourceGroupResource().GetGalleries().GetAsync(
+                        parsed.Data.Name
+                    );
+
+                    var galleryImage = gallery.Value.GetGalleryImages()
+                        .ToEnumerable()
+                        .Where(galleryImage => string.Equals(galleryImage.Id, parsed.Id, StringComparison.OrdinalIgnoreCase))
+                        .First();
+
+                    galleryImage = await galleryImage.GetAsync();
+
+                    name = galleryImage.Data?.OSType?.ToString().ToLowerInvariant()!;
+
+                } catch (Exception ex) when (
+                      ex is RequestFailedException ||
+                      ex is NullReferenceException
+                  ) {
+                    return OneFuzzResult<Os>.Error(
+                        ErrorCode.INVALID_IMAGE,
+                        ex.ToString()
+                    );
+                }
+            } else {
+                try {
+                    name = (await _context.Creds.GetResourceGroupResource().GetImages().GetAsync(
+                        parsed.Data.Name
+                    )).Value.Data.StorageProfile.OSDisk.OSType.ToString().ToLowerInvariant();
+                } catch (Exception ex) when (
+                    ex is RequestFailedException ||
+                    ex is NullReferenceException
+                ) {
+                    return OneFuzzResult<Os>.Error(
+                        ErrorCode.INVALID_IMAGE,
+                        ex.ToString()
+                    );
+                }
+            }
+        } catch (FormatException) {
+            var imageParts = image.Split(":");
+
+            // The python code would throw if more than 4 parts are found in the split
+            System.Diagnostics.Trace.Assert(imageParts.Length == 4, $"Expected 4 ':' separated parts in {image}");
+
+            var publisher = imageParts[0];
+            var offer = imageParts[1];
+            var sku = imageParts[2];
+            var version = imageParts[3];
+
+            try {
+                var subscription = await _context.Creds.ArmClient.GetDefaultSubscriptionAsync();
+                if (string.Equals(version, "latest", StringComparison.Ordinal)) {
+                    version = (await subscription.GetVirtualMachineImagesAsync(
+                        region,
+                        publisher,
+                        offer,
+                        sku,
+                        top: 1
+                    ).FirstAsync()).Name;
+                }
+
+                name = (await subscription.GetVirtualMachineImageAsync(
+                    region,
+                    publisher,
+                    offer,
+                    sku
+                    , version
+                )).Value.OSDiskImageOperatingSystem.ToString().ToLower();
+            } catch (RequestFailedException ex) {
+                return OneFuzzResult<Os>.Error(
+                    ErrorCode.INVALID_IMAGE,
+                    ex.ToString()
+                );
+            }
+        }
+
+        if (name != null) {
+            name = string.Concat(name[0].ToString().ToUpper(), name.AsSpan(1));
+            if (Enum.TryParse(name, out Os os)) {
+                return OneFuzzResult<Os>.Ok(os);
+            }
+        }
+
+        return OneFuzzResult<Os>.Error(
+            ErrorCode.INVALID_IMAGE,
+            $"Unexpected image os type: {name}"
+        );
+    }
+}

--- a/src/ApiService/ApiService/onefuzzlib/OnefuzzContext.cs
+++ b/src/ApiService/ApiService/onefuzzlib/OnefuzzContext.cs
@@ -38,6 +38,7 @@ public interface IOnefuzzContext {
     IRequestHandling RequestHandling { get; }
     INsgOperations NsgOperations { get; }
     ISubnet Subnet { get; }
+    IImageOperations ImageOperations { get; }
 }
 
 public class OnefuzzContext : IOnefuzzContext {
@@ -81,4 +82,5 @@ public class OnefuzzContext : IOnefuzzContext {
     public IRequestHandling RequestHandling => _serviceProvider.GetRequiredService<IRequestHandling>();
     public INsgOperations NsgOperations => _serviceProvider.GetRequiredService<INsgOperations>();
     public ISubnet Subnet => _serviceProvider.GetRequiredService<ISubnet>();
+    public IImageOperations ImageOperations => _serviceProvider.GetRequiredService<IImageOperations>();
 }

--- a/src/ApiService/ApiService/onefuzzlib/Reports.cs
+++ b/src/ApiService/ApiService/onefuzzlib/Reports.cs
@@ -1,10 +1,12 @@
 ﻿using System.Text.Json;
+using System.Threading.Tasks;
 using Microsoft.OneFuzz.Service.OneFuzzLib.Orm;
 
 namespace Microsoft.OneFuzz.Service;
 
 public interface IReports {
     public Async.Task<IReport?> GetReportOrRegression(Container container, string fileName, bool expectReports = false, params string[] args);
+    public Async.Task<Report?> GetReport(Container container, string fileName);
 }
 
 public class Reports : IReports {
@@ -13,6 +15,15 @@ public class Reports : IReports {
     public Reports(ILogTracer log, IContainers containers) {
         _log = log;
         _containers = containers;
+    }
+
+    public async Task<Report?> GetReport(Container container, string fileName) {
+        var result = await GetReportOrRegression(container, fileName);
+        if (result != null && result is Report) {
+            return result as Report;
+        }
+
+        return null;
     }
 
     public async Async.Task<IReport?> GetReportOrRegression(Container container, string fileName, bool expectReports = false, params string[] args) {

--- a/src/ApiService/ApiService/onefuzzlib/VmExtensionWrapper.cs
+++ b/src/ApiService/ApiService/onefuzzlib/VmExtensionWrapper.cs
@@ -1,4 +1,4 @@
-using Azure.Core;
+﻿using Azure.Core;
 using Azure.ResourceManager.Compute;
 
 namespace Microsoft.OneFuzz.Service {

--- a/src/ApiService/ApiService/onefuzzlib/VmExtensionWrapper.cs
+++ b/src/ApiService/ApiService/onefuzzlib/VmExtensionWrapper.cs
@@ -1,0 +1,62 @@
+using Azure.Core;
+using Azure.ResourceManager.Compute;
+
+namespace Microsoft.OneFuzz.Service {
+    public class VMExtenionWrapper {
+        public AzureLocation? Location { get; init; }
+        public string? Name { get; init; }
+        public string? TypePropertiesType { get; init; }
+        public string? Publisher { get; init; }
+        public string? TypeHandlerVersion { get; init; }
+        public string? ForceUpdateTag { get; init; }
+        public bool? AutoUpgradeMinorVersion { get; init; }
+        public bool? EnableAutomaticUpgrade { get; init; }
+        public BinaryData? Settings { get; init; }
+        public BinaryData? ProtectedSettings { get; init; }
+
+        public (string, VirtualMachineExtensionData) GetAsVirtualMachineExtension() {
+            if (Location == null) { // EnsureNotNull does not satisfy the nullability checker
+                throw new ArgumentNullException("Location required for VirtualMachineExtension");
+            }
+            TypePropertiesType.EnsureNotNull("TypePropertiesType required for VirtualMachineExtension");
+            Publisher.EnsureNotNull("Publisher required for VirtualMachineExtension");
+            TypeHandlerVersion.EnsureNotNull("TypeHandlerVersion required for VirtualMachineExtension");
+            AutoUpgradeMinorVersion.EnsureNotNull("AutoUpgradeMinorVersion required for VirtualMachineExtension");
+            Settings.EnsureNotNull("Settings required for VirtualMachineExtension");
+            ProtectedSettings.EnsureNotNull("ProtectedSettings required for VirtualMachineExtension");
+
+            return (Name!, new VirtualMachineExtensionData(Location.Value) {
+                TypePropertiesType = TypePropertiesType,
+                Publisher = Publisher,
+                TypeHandlerVersion = TypeHandlerVersion,
+                AutoUpgradeMinorVersion = AutoUpgradeMinorVersion,
+                EnableAutomaticUpgrade = EnableAutomaticUpgrade,
+                ForceUpdateTag = ForceUpdateTag,
+                Settings = Settings,
+                ProtectedSettings = ProtectedSettings
+            });
+        }
+
+        public VirtualMachineScaleSetExtensionData GetAsVirtualMachineScaleSetExtension() {
+            Name.EnsureNotNull("Name required for VirtualMachineScaleSetExtension");
+            TypePropertiesType.EnsureNotNull("TypePropertiesType required for VirtualMachineScaleSetExtension");
+            Publisher.EnsureNotNull("Publisher required for VirtualMachineScaleSetExtension");
+            TypeHandlerVersion.EnsureNotNull("TypeHandlerVersion required for VirtualMachineScaleSetExtension");
+            AutoUpgradeMinorVersion.EnsureNotNull("AutoUpgradeMinorVersion required for VirtualMachineScaleSetExtension");
+            Settings.EnsureNotNull("Settings required for VirtualMachineScaleSetExtension");
+            ProtectedSettings.EnsureNotNull("ProtectedSettings required for VirtualMachineScaleSetExtension");
+            return new VirtualMachineScaleSetExtensionData() {
+                Name = Name,
+                TypePropertiesType = TypePropertiesType,
+                Publisher = Publisher,
+                TypeHandlerVersion = TypeHandlerVersion,
+                AutoUpgradeMinorVersion = AutoUpgradeMinorVersion,
+                EnableAutomaticUpgrade = EnableAutomaticUpgrade,
+                ForceUpdateTag = ForceUpdateTag,
+                Settings = Settings,
+                ProtectedSettings = ProtectedSettings
+            };
+        }
+    }
+
+}

--- a/src/ApiService/ApiService/onefuzzlib/VmExtensionWrapper.cs
+++ b/src/ApiService/ApiService/onefuzzlib/VmExtensionWrapper.cs
@@ -2,7 +2,7 @@
 using Azure.ResourceManager.Compute;
 
 namespace Microsoft.OneFuzz.Service {
-    public class VMExtenionWrapper {
+    public class VMExtensionWrapper {
         public AzureLocation? Location { get; init; }
         public string? Name { get; init; }
         public string? TypePropertiesType { get; init; }

--- a/src/ApiService/ApiService/onefuzzlib/orm/Orm.cs
+++ b/src/ApiService/ApiService/onefuzzlib/orm/Orm.cs
@@ -211,6 +211,9 @@ namespace ApiService.OneFuzzLib.Orm {
                 _logTracer.Info($"processing state update: {typeof(T)} - PartitionKey {_partitionKeyGetter?.Value()} {_rowKeyGetter?.Value()} - %s");
                 return await func(entity);
             }
+            else {
+                _logTracer.Info($"State function for state: '{state}' not found on type {typeof(T)}");
+            }
             return null;
         }
 

--- a/src/ApiService/ApiService/onefuzzlib/orm/Orm.cs
+++ b/src/ApiService/ApiService/onefuzzlib/orm/Orm.cs
@@ -210,8 +210,7 @@ namespace ApiService.OneFuzzLib.Orm {
             if (func != null) {
                 _logTracer.Info($"processing state update: {typeof(T)} - PartitionKey {_partitionKeyGetter?.Value()} {_rowKeyGetter?.Value()} - %s");
                 return await func(entity);
-            }
-            else {
+            } else {
                 _logTracer.Info($"State function for state: '{state}' not found on type {typeof(T)}");
             }
             return null;

--- a/src/ApiService/IntegrationTests/Fakes/TestContext.cs
+++ b/src/ApiService/IntegrationTests/Fakes/TestContext.cs
@@ -109,4 +109,6 @@ public sealed class TestContext : IOnefuzzContext {
     public INsgOperations NsgOperations => throw new NotImplementedException();
 
     public ISubnet Subnet => throw new NotImplementedException();
+
+    public IImageOperations ImageOperations => throw new NotImplementedException();
 }


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_

Related to migrating `timer_repro`.

Highlights of changes:
* Added `ImageOperations` which is used for working with VM images.
* Made generic wrapper type over `VirtualMachineScaleSetExtensionData` and `VirtualMachineExtensionData`. We use the same extensions (and same extension properties) for both and since I can't add a shared interface between the types ( and instead of duplicating the extension configuration functions), I created `VMExtensionWrapper`.
* Fixed some bugs in the existing extensions functions (ex: making sure our types are serialized as Azure expects, a couple of missing `await`s)

## PR Checklist
* [ ] Applies to work item: #1837