### PR TITLE
Remove lifetime param from `LibFuzzer`

### DIFF
--- a/src/agent/onefuzz-task/src/tasks/fuzz/libfuzzer/common.rs
+++ b/src/agent/onefuzz-task/src/tasks/fuzz/libfuzzer/common.rs
@@ -226,8 +226,8 @@ where
 
         let fuzzer = LibFuzzer::new(
             &self.config.target_exe,
-            &self.config.target_options,
-            &self.config.target_env,
+            self.config.target_options.clone(),
+            self.config.target_env.clone(),
             &self.config.common.setup_dir,
         );
         let mut running = fuzzer.fuzz(crash_dir.path(), local_inputs, &inputs).await?;

--- a/src/agent/onefuzz-task/src/tasks/fuzz/libfuzzer/generic.rs
+++ b/src/agent/onefuzz-task/src/tasks/fuzz/libfuzzer/generic.rs
@@ -18,8 +18,8 @@ impl common::LibFuzzerType for GenericLibFuzzer {
     fn from_config(config: &common::Config<Self>) -> LibFuzzer {
         LibFuzzer::new(
             &config.target_exe,
-            &config.target_options,
-            &config.target_env,
+            config.target_options.clone(),
+            config.target_env.clone(),
             &config.common.setup_dir,
         )
     }

--- a/src/agent/onefuzz-task/src/tasks/merge/libfuzzer_merge.rs
+++ b/src/agent/onefuzz-task/src/tasks/merge/libfuzzer_merge.rs
@@ -43,8 +43,8 @@ pub struct Config {
 pub async fn spawn(config: Arc<Config>) -> Result<()> {
     let fuzzer = LibFuzzer::new(
         &config.target_exe,
-        &config.target_options,
-        &config.target_env,
+        config.target_options.clone(),
+        config.target_env.clone(),
         &config.common.setup_dir,
     );
     fuzzer.verify(config.check_fuzzer_help, None).await?;
@@ -156,8 +156,8 @@ pub async fn merge_inputs(
     info!("Merging corpus");
     let merger = LibFuzzer::new(
         &config.target_exe,
-        &config.target_options,
-        &config.target_env,
+        config.target_options.clone(),
+        config.target_env.clone(),
         &config.common.setup_dir,
     );
     merger

--- a/src/agent/onefuzz-task/src/tasks/report/libfuzzer_report.rs
+++ b/src/agent/onefuzz-task/src/tasks/report/libfuzzer_report.rs
@@ -67,8 +67,8 @@ impl ReportTask {
     pub async fn verify(&self) -> Result<()> {
         let fuzzer = LibFuzzer::new(
             &self.config.target_exe,
-            &self.config.target_options,
-            &self.config.target_env,
+            self.config.target_options.clone(),
+            self.config.target_env.clone(),
             &self.config.common.setup_dir,
         );
         fuzzer.verify(self.config.check_fuzzer_help, None).await
@@ -121,8 +121,8 @@ pub struct TestInputArgs<'a> {
 pub async fn test_input(args: TestInputArgs<'_>) -> Result<CrashTestResult> {
     let fuzzer = LibFuzzer::new(
         args.target_exe,
-        args.target_options,
-        args.target_env,
+        args.target_options.to_vec(),
+        args.target_env.clone(),
         args.setup_dir,
     );
 

--- a/src/agent/onefuzz/src/libfuzzer.rs
+++ b/src/agent/onefuzz/src/libfuzzer.rs
@@ -430,7 +430,12 @@ mod tests {
         let input_file = temp_setup_dir.path().join("input.txt");
         write_file(&input_file, "input").await?;
 
-        let fuzzer = LibFuzzer::new(bad_bin, options.clone(), env.clone(), &temp_setup_dir.path());
+        let fuzzer = LibFuzzer::new(
+            bad_bin,
+            options.clone(),
+            env.clone(),
+            &temp_setup_dir.path(),
+        );
 
         // verify catching bad exits with -help=1
         assert!(
@@ -453,7 +458,12 @@ mod tests {
             "checking false without inputs"
         );
 
-        let fuzzer = LibFuzzer::new(good_bin, options.clone(), env.clone(), &temp_setup_dir.path());
+        let fuzzer = LibFuzzer::new(
+            good_bin,
+            options.clone(),
+            env.clone(),
+            &temp_setup_dir.path(),
+        );
         // verify good exits with -help=1
         assert!(
             fuzzer.verify(true, None).await.is_ok(),

--- a/src/agent/onefuzz/src/libfuzzer.rs
+++ b/src/agent/onefuzz/src/libfuzzer.rs
@@ -34,18 +34,18 @@ pub struct LibFuzzerMergeOutput {
     pub added_feature_count: i32,
 }
 
-pub struct LibFuzzer<'a> {
+pub struct LibFuzzer {
     setup_dir: PathBuf,
     exe: PathBuf,
-    options: &'a [String],
-    env: &'a HashMap<String, String>,
+    options: Vec<String>,
+    env: HashMap<String, String>,
 }
 
-impl<'a> LibFuzzer<'a> {
+impl LibFuzzer {
     pub fn new(
         exe: impl Into<PathBuf>,
-        options: &'a [String],
-        env: &'a HashMap<String, String>,
+        options: Vec<String>,
+        env: HashMap<String, String>,
         setup_dir: impl Into<PathBuf>,
     ) -> Self {
         Self {
@@ -102,19 +102,19 @@ impl<'a> LibFuzzer<'a> {
             .machine_id()
             .await?
             .target_exe(&self.exe)
-            .target_options(self.options)
+            .target_options(&self.options)
             .setup_dir(&self.setup_dir)
             .set_optional(corpus_dir, |tester, corpus_dir| {
                 tester.input_corpus(&corpus_dir)
             })
             .set_optional(fault_dir, |tester, fault_dir| tester.crashes(&fault_dir));
 
-        for (k, v) in self.env {
+        for (k, v) in &self.env {
             cmd.env(k, expand.evaluate_value(v)?);
         }
 
         // Pass custom option arguments.
-        for o in expand.evaluate(self.options)? {
+        for o in expand.evaluate(&self.options)? {
             cmd.arg(o);
         }
 
@@ -307,10 +307,10 @@ impl<'a> LibFuzzer<'a> {
         timeout: Option<u64>,
         retry: u64,
     ) -> Result<TestResult> {
-        let mut options = self.options.to_owned();
+        let mut options = self.options.clone();
         options.push("{input}".to_string());
 
-        let mut tester = Tester::new(&self.setup_dir, &self.exe, &options, self.env)
+        let mut tester = Tester::new(&self.setup_dir, &self.exe, &options, &self.env)
             .check_asan_stderr(true)
             .check_retry_count(retry)
             .add_setup_to_path(true)

--- a/src/agent/onefuzz/src/libfuzzer.rs
+++ b/src/agent/onefuzz/src/libfuzzer.rs
@@ -430,7 +430,7 @@ mod tests {
         let input_file = temp_setup_dir.path().join("input.txt");
         write_file(&input_file, "input").await?;
 
-        let fuzzer = LibFuzzer::new(bad_bin, &options, &env, &temp_setup_dir.path());
+        let fuzzer = LibFuzzer::new(bad_bin, options.clone(), env.clone(), &temp_setup_dir.path());
 
         // verify catching bad exits with -help=1
         assert!(
@@ -453,7 +453,7 @@ mod tests {
             "checking false without inputs"
         );
 
-        let fuzzer = LibFuzzer::new(good_bin, &options, &env, &temp_setup_dir.path());
+        let fuzzer = LibFuzzer::new(good_bin, options.clone(), env.clone(), &temp_setup_dir.path());
         // verify good exits with -help=1
         assert!(
             fuzzer.verify(true, None).await.is_ok(),


### PR DESCRIPTION
Modify the `LibFuzzer` struct to own its environment and option data. This enables passing copies of locally-mutated env/options structs in implementers of `LibFuzzerType::from_config()`. No functional changes.