### PR TITLE
Add `libfuzzer_dotnet_fuzz` task to agent

### DIFF
--- a/src/agent/onefuzz-task/src/tasks/config.rs
+++ b/src/agent/onefuzz-task/src/tasks/config.rs
@@ -87,6 +87,10 @@ pub enum Config {
     #[serde(alias = "dotnet_coverage")]
     DotnetCoverage(coverage::dotnet::Config),
 
+    #[cfg(any(target_os = "linux", target_os = "windows"))]
+    #[serde(alias = "libfuzzer_dotnet_fuzz")]
+    LibFuzzerDotnetFuzz(fuzz::libfuzzer::dotnet::Config),
+
     #[serde(alias = "libfuzzer_fuzz")]
     LibFuzzerFuzz(fuzz::libfuzzer::generic::Config),
 
@@ -136,6 +140,7 @@ impl Config {
             Config::Coverage(c) => &mut c.common,
             #[cfg(any(target_os = "linux", target_os = "windows"))]
             Config::DotnetCoverage(c) => &mut c.common,
+            Config::LibFuzzerDotnetFuzz(c) => &mut c.common,
             Config::LibFuzzerFuzz(c) => &mut c.common,
             Config::LibFuzzerMerge(c) => &mut c.common,
             Config::LibFuzzerReport(c) => &mut c.common,
@@ -155,6 +160,7 @@ impl Config {
             Config::Coverage(c) => &c.common,
             #[cfg(any(target_os = "linux", target_os = "windows"))]
             Config::DotnetCoverage(c) => &c.common,
+            Config::LibFuzzerDotnetFuzz(c) => &c.common,
             Config::LibFuzzerFuzz(c) => &c.common,
             Config::LibFuzzerMerge(c) => &c.common,
             Config::LibFuzzerReport(c) => &c.common,
@@ -174,6 +180,7 @@ impl Config {
             Config::Coverage(_) => "coverage",
             #[cfg(any(target_os = "linux", target_os = "windows"))]
             Config::DotnetCoverage(_) => "dotnet_coverage",
+            Config::LibFuzzerDotnetFuzz(_) => "libfuzzer_fuzz",
             Config::LibFuzzerFuzz(_) => "libfuzzer_fuzz",
             Config::LibFuzzerMerge(_) => "libfuzzer_merge",
             Config::LibFuzzerReport(_) => "libfuzzer_crash_report",
@@ -221,6 +228,11 @@ impl Config {
             #[cfg(any(target_os = "linux", target_os = "windows"))]
             Config::DotnetCoverage(config) => {
                 coverage::dotnet::DotnetCoverageTask::new(config)
+                    .run()
+                    .await
+            }
+            Config::LibFuzzerDotnetFuzz(config) => {
+                fuzz::libfuzzer::dotnet::LibFuzzerDotnetFuzzTask::new(config)?
                     .run()
                     .await
             }

--- a/src/agent/onefuzz-task/src/tasks/fuzz/libfuzzer.rs
+++ b/src/agent/onefuzz-task/src/tasks/fuzz/libfuzzer.rs
@@ -2,4 +2,5 @@
 // Licensed under the MIT License.
 
 pub mod common;
+pub mod dotnet;
 pub mod generic;

--- a/src/agent/onefuzz-task/src/tasks/fuzz/libfuzzer/dotnet.rs
+++ b/src/agent/onefuzz-task/src/tasks/fuzz/libfuzzer/dotnet.rs
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use onefuzz::libfuzzer::LibFuzzer;
+
+use crate::tasks::fuzz::libfuzzer::common;
+
+#[cfg(target_os = "linux")]
+const LIBFUZZER_DOTNET_PATH: &str =
+    "/onefuzz/third-party/dotnet-fuzzing-linux/libfuzzer-dotnet/libfuzzer-dotnet";
+
+#[cfg(target_os = "windows")]
+const LIBFUZZER_DOTNET_PATH: &str =
+    "/onefuzz/third-party/dotnet-fuzzing-windows/libfuzzer-dotnet/libfuzzer-dotnet.exe";
+
+#[cfg(target_os = "linux")]
+const LOADER_PATH: &str =
+    "/onefuzz/third-party/dotnet-fuzzing-linux/LibFuzzerDotnetLoader/LibFuzzerDotnetLoader";
+
+#[cfg(target_os = "windows")]
+const LOADER_PATH: &str =
+    "/onefuzz/third-party/dotnet-fuzzing-windows/LibFuzzerDotnetLoader/LibFuzzerDotnetLoader.exe";
+
+pub struct LibFuzzerDotnet;
+
+#[derive(Debug, Deserialize)]
+pub struct LibFuzzerDotnetConfig {
+    pub target_assembly: String,
+    pub target_class: String,
+    pub target_method: String,
+}
+
+impl common::LibFuzzerType for LibFuzzerDotnet {
+    type Config = LibFuzzerDotnetConfig;
+
+    fn from_config(config: &common::Config<Self>) -> LibFuzzer {
+        // Configure loader to fuzz user target DLL.
+        let mut env = config.target_env.clone();
+        env.insert(
+            "LIBFUZZER_DOTNET_TARGET_ASSEMBLY".into(),
+            config.extra.target_assembly.clone(),
+        );
+        env.insert(
+            "LIBFUZZER_DOTNET_TARGET_CLASS".into(),
+            config.extra.target_class.clone(),
+        );
+        env.insert(
+            "LIBFUZZER_DOTNET_TARGET_METHOD".into(),
+            config.extra.target_method.clone(),
+        );
+
+        let mut options = config.target_options.clone();
+        options.push(format!("--target_path={}", LOADER_PATH));
+
+        LibFuzzer::new(
+            LIBFUZZER_DOTNET_PATH,
+            options,
+            env,
+            &config.common.setup_dir,
+        )
+    }
+}
+
+pub type Config = common::Config<LibFuzzerDotnet>;
+pub type LibFuzzerDotnetFuzzTask = common::LibFuzzerFuzzTask<LibFuzzerDotnet>;

--- a/src/agent/onefuzz-task/src/tasks/fuzz/libfuzzer/dotnet.rs
+++ b/src/agent/onefuzz-task/src/tasks/fuzz/libfuzzer/dotnet.rs
@@ -21,6 +21,7 @@ const LOADER_PATH: &str =
 const LOADER_PATH: &str =
     "/onefuzz/third-party/dotnet-fuzzing-windows/LibFuzzerDotnetLoader/LibFuzzerDotnetLoader.exe";
 
+#[derive(Debug)]
 pub struct LibFuzzerDotnet;
 
 #[derive(Debug, Deserialize)]

--- a/src/agent/onefuzz-task/src/tasks/fuzz/libfuzzer/generic.rs
+++ b/src/agent/onefuzz-task/src/tasks/fuzz/libfuzzer/generic.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+use async_trait::async_trait;
 use onefuzz::libfuzzer::LibFuzzer;
 
 use crate::tasks::fuzz::libfuzzer::common;
@@ -12,6 +13,7 @@ use crate::tasks::fuzz::libfuzzer::common;
 #[derive(Debug)]
 pub struct GenericLibFuzzer;
 
+#[async_trait]
 impl common::LibFuzzerType for GenericLibFuzzer {
     type Config = ();
 


### PR DESCRIPTION
Add a new `libfuzzer_dotnet_fuzz` task to the agent.

This task has a config which is an extension to the `libfuzzer_fuzz` with 3 extra parameters: `target_assembly`, `target_class`, and `target_method`. At runtime, it uses the new `LibFuzzerType::extra_setup()` hook to to instrument the `target_assembly` for coverage feedback using SharpFuzz, and generates `libfuzzer-dotnet`-based fuzzer invocations of `LibFuzzer`. These use `LibFuzzerDotnetLoader` as the `--target_path` arg for `libfuzzer-dotnet`, and sets the env vars that tell `LibFuzzerDotnetLoader` what to fuzz.