### PR TITLE
Fix Queue Issue for WebhookOperations.

### DIFF
--- a/src/ApiService/ApiService/onefuzzlib/WebhookOperations.cs
+++ b/src/ApiService/ApiService/onefuzzlib/WebhookOperations.cs
@@ -47,6 +47,8 @@ public class WebhookOperations : Orm<Webhook>, IWebhookOperations {
             var (status, reason) = r.ErrorV;
             _logTracer.Error($"Failed to replace webhook message log due to [{status}] {reason}");
         }
+        
+        await _context.WebhookMessageLogOperations.QueueWebhook(message);
     }
 
     public async Async.Task<bool> Send(WebhookMessageLog messageLog) {
@@ -113,6 +115,7 @@ public class WebhookOperations : Orm<Webhook>, IWebhookOperations {
 public interface IWebhookMessageLogOperations : IOrm<WebhookMessageLog> {
     IAsyncEnumerable<WebhookMessageLog> SearchExpired();
     public Async.Task ProcessFromQueue(WebhookMessageQueueObj obj);
+    public Async.Task QueueWebhook(WebhookMessageLog webhookLog);
 }
 
 

--- a/src/ApiService/ApiService/onefuzzlib/WebhookOperations.cs
+++ b/src/ApiService/ApiService/onefuzzlib/WebhookOperations.cs
@@ -47,7 +47,6 @@ public class WebhookOperations : Orm<Webhook>, IWebhookOperations {
             var (status, reason) = r.ErrorV;
             _logTracer.Error($"Failed to replace webhook message log due to [{status}] {reason}");
         }
-        
         await _context.WebhookMessageLogOperations.QueueWebhook(message);
     }
 


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_
During the original refactor, I'd left out a function call that properly queues webhook events. Updating to fix. 

## PR Checklist
* [ ] Applies to work item: #xxx
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/onefuzz) and sign the CLI.
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_

## Validation Steps Performed

_How does someone test & validate?_
Manual validation: 

- Deploying an instance
- Enabling csharp timerTasks
- creating a webhook for job_created, job_stopped, task_failed
- deployed a job
- confirmed webhooks were sent for above events