### PR TITLE
Adjust auto scale to scale down nodes on shutdown

### DIFF
--- a/src/api-service/__app__/onefuzzlib/azure/auto_scale.py
+++ b/src/api-service/__app__/onefuzzlib/azure/auto_scale.py
@@ -40,8 +40,11 @@ from .creds import (
 from .log_analytics import get_workspace_id
 from .monitor import get_monitor_client
 
+
 @retry_on_auth_failure()
-def get_auto_scale_settings(vmss: UUID) -> Union[Optional[AutoscaleSettingResource], Error]:
+def get_auto_scale_settings(
+    vmss: UUID,
+) -> Union[Optional[AutoscaleSettingResource], Error]:
     logging.info("Getting auto scale settings for %s" % vmss)
     client = get_monitor_client()
     resource_group = get_base_resource_group()
@@ -64,6 +67,7 @@ def get_auto_scale_settings(vmss: UUID) -> Union[Optional[AutoscaleSettingResour
         )
 
     return None
+
 
 @retry_on_auth_failure()
 def add_auto_scale_to_vmss(
@@ -94,7 +98,10 @@ def add_auto_scale_to_vmss(
 
     return None
 
-def update_auto_scale(auto_scale_setting_name: str, auto_scale_resource: AutoscaleSettingResource) -> Optional[Error]:
+
+def update_auto_scale(
+    auto_scale_setting_name: str, auto_scale_resource: AutoscaleSettingResource
+) -> Optional[Error]:
     logging.info("Updating auto scale resource: %s" % auto_scale_setting_name)
     client = get_monitor_client()
     resource_group = get_base_resource_group()
@@ -103,15 +110,19 @@ def update_auto_scale(auto_scale_setting_name: str, auto_scale_resource: Autosca
         auto_scale_resource = client.autoscale_settings.create_or_update(
             resource_group, auto_scale_setting_name, auto_scale_resource
         )
-        logging.info("Successfully updated auto scale resource: %s" % auto_scale_resource.name)
+        logging.info(
+            "Successfully updated auto scale resource: %s" % auto_scale_resource.name
+        )
     except (ResourceNotFoundError, CloudError):
         return Error(
             code=ErrorCode.UNABLE_TO_UPDATE,
             errors=[
-                "unable to update auto scale resource with name: %s and profile: %s" % (auto_scale_setting_name, auto_scale_resource)
+                "unable to update auto scale resource with name: %s and profile: %s"
+                % (auto_scale_setting_name, auto_scale_resource)
             ],
         )
     return None
+
 
 def create_auto_scale_resource_for(
     resource_id: UUID, location: Region, profile: AutoscaleProfile
@@ -225,31 +236,33 @@ def default_auto_scale_profile(queue_uri: str, scaleset_size: int) -> AutoscaleP
         queue_uri, 1, scaleset_size, scaleset_size, 1, 10, 1, 5
     )
 
+
 def default_scale_in_rule(queue_uri: str) -> ScaleRule:
     return ScaleRule(
-                # Scale in if no work in the past 20 mins
-                metric_trigger=MetricTrigger(
-                    metric_name="ApproximateMessageCount",
-                    metric_resource_uri=queue_uri,
-                    # Check every 10 minutes
-                    time_grain=timedelta(minutes=10),
-                    # The average amount of messages there are in the pool queue
-                    time_aggregation=TimeAggregationType.AVERAGE,
-                    statistic=MetricStatisticType.SUM,
-                    # Over the past 10 minutes
-                    time_window=timedelta(minutes=10),
-                    # When there's no messages in the pool queue
-                    operator=ComparisonOperationType.EQUALS,
-                    threshold=0,
-                    divide_per_instance=False,
-                ),
-                scale_action=ScaleAction(
-                    direction=ScaleDirection.DECREASE,
-                    type=ScaleType.CHANGE_COUNT,
-                    value=1,
-                    cooldown=timedelta(minutes=5),
-                ),
-            )
+        # Scale in if no work in the past 20 mins
+        metric_trigger=MetricTrigger(
+            metric_name="ApproximateMessageCount",
+            metric_resource_uri=queue_uri,
+            # Check every 10 minutes
+            time_grain=timedelta(minutes=10),
+            # The average amount of messages there are in the pool queue
+            time_aggregation=TimeAggregationType.AVERAGE,
+            statistic=MetricStatisticType.SUM,
+            # Over the past 10 minutes
+            time_window=timedelta(minutes=10),
+            # When there's no messages in the pool queue
+            operator=ComparisonOperationType.EQUALS,
+            threshold=0,
+            divide_per_instance=False,
+        ),
+        scale_action=ScaleAction(
+            direction=ScaleDirection.DECREASE,
+            type=ScaleType.CHANGE_COUNT,
+            value=1,
+            cooldown=timedelta(minutes=5),
+        ),
+    )
+
 
 def setup_auto_scale_diagnostics(
     auto_scale_resource_uri: str,

--- a/src/api-service/__app__/onefuzzlib/azure/vmss.py
+++ b/src/api-service/__app__/onefuzzlib/azure/vmss.py
@@ -37,7 +37,7 @@ from .image import get_os
 
 
 @retry_on_auth_failure()
-def list_vmss(name: UUID, vm_filter: Optional[Callable[[VirtualMachineScaleSetVMListResult], bool]]) -> Optional[List[str]]:
+def list_vmss(name: UUID, vm_filter: Optional[Callable[[VirtualMachineScaleSetVMListResult], bool]] = None) -> Optional[List[str]]:
     resource_group = get_base_resource_group()
     client = get_compute_client()
     try:

--- a/src/api-service/__app__/onefuzzlib/azure/vmss.py
+++ b/src/api-service/__app__/onefuzzlib/azure/vmss.py
@@ -18,8 +18,8 @@ from azure.mgmt.compute.models import (
     ResourceSkuRestrictionsType,
     VirtualMachineScaleSetVMInstanceIDs,
     VirtualMachineScaleSetVMInstanceRequiredIDs,
-    VirtualMachineScaleSetVMProtectionPolicy,
     VirtualMachineScaleSetVMListResult,
+    VirtualMachineScaleSetVMProtectionPolicy,
 )
 from memoization import cached
 from msrestazure.azure_exceptions import CloudError

--- a/src/api-service/__app__/onefuzzlib/azure/vmss.py
+++ b/src/api-service/__app__/onefuzzlib/azure/vmss.py
@@ -37,7 +37,10 @@ from .image import get_os
 
 
 @retry_on_auth_failure()
-def list_vmss(name: UUID, vm_filter: Optional[Callable[[VirtualMachineScaleSetVMListResult], bool]] = None) -> Optional[List[str]]:
+def list_vmss(
+    name: UUID,
+    vm_filter: Optional[Callable[[VirtualMachineScaleSetVMListResult], bool]] = None,
+) -> Optional[List[str]]:
     resource_group = get_base_resource_group()
     client = get_compute_client()
     try:
@@ -149,6 +152,7 @@ def get_instance_id(name: UUID, vm_id: UUID) -> Union[str, Error]:
         code=ErrorCode.UNABLE_TO_FIND,
         errors=["unable to find scaleset machine: %s:%s" % (name, vm_id)],
     )
+
 
 @retry_on_auth_failure()
 def update_scale_in_protection(

--- a/src/api-service/__app__/onefuzzlib/workers/scalesets.py
+++ b/src/api-service/__app__/onefuzzlib/workers/scalesets.py
@@ -721,7 +721,10 @@ class Scaleset(BASE_SCALESET, ORMMixin):
         for node in nodes:
             node.set_shutdown()
 
-        logging.info(SCALESET_LOG_PREFIX + "checking for existing auto scale settings")
+        logging.info(
+            SCALESET_LOG_PREFIX
+            + "checking for existing auto scale settings %s" % self.scaleset_id
+        )
         auto_scale_policy = get_auto_scale_settings(self.scaleset_id)
         if auto_scale_policy is not None and not isinstance(auto_scale_policy, Error):
             for profile in auto_scale_policy.profiles:
@@ -780,10 +783,7 @@ class Scaleset(BASE_SCALESET, ORMMixin):
                 str(self.scaleset_id), auto_scale_policy
             )
             if isinstance(updated_auto_scale, Error):
-                logging.error(
-                    "Failed to update auto scale for scale set %s error: %s"
-                    % (self.scaleset_id, updated_auto_scale)
-                )
+                logging.error("Failed to update auto scale %s" % updated_auto_scale)
         elif isinstance(auto_scale_policy, Error):
             logging.error(auto_scale_policy)
         else:

--- a/src/api-service/__app__/onefuzzlib/workers/scalesets.py
+++ b/src/api-service/__app__/onefuzzlib/workers/scalesets.py
@@ -745,9 +745,9 @@ class Scaleset(BASE_SCALESET, ORMMixin):
                 # Then: The number of nodes in the scale set with scale in
                 #   protection enabled _must_ strictly decrease over time.
                 #
-                #  This guarantees that _eventually_ the below check will pass,
-                #   allowing us to set the minimum instances to 0,
+                #  This guarantees that _eventually_
                 #   auto scale will scale in the remaining nodes,
+                #   the scale set will have 0 instances,
                 #   and once the scale set is empty, we will delete it.
                 logging.info(
                     SCALESET_LOG_PREFIX + "Getting nodes with scale in protection"

--- a/src/api-service/__app__/onefuzzlib/workers/scalesets.py
+++ b/src/api-service/__app__/onefuzzlib/workers/scalesets.py
@@ -9,7 +9,6 @@ import os
 from typing import Any, Dict, List, Optional, Tuple, Union
 from uuid import UUID
 
-from azure.mgmt.monitor.models import ScaleDirection
 from onefuzztypes.enums import (
     ErrorCode,
     NodeDisaposalStrategy,
@@ -36,8 +35,8 @@ from ..azure.auto_scale import (
     add_auto_scale_to_vmss,
     create_auto_scale_profile,
     default_auto_scale_profile,
-    shutdown_scaleset_rule,
     get_auto_scale_settings,
+    shutdown_scaleset_rule,
     update_auto_scale,
 )
 from ..azure.image import get_os
@@ -759,7 +758,12 @@ class Scaleset(BASE_SCALESET, ORMMixin):
                     and bool(vm.protection_policy.protect_from_scale_in),
                 )
                 logging.info(SCALESET_LOG_PREFIX + str(vms_with_protection))
-                profile.capacity.minimum = len(vms_with_protection)
+                if vms_with_protection is not None:
+                    profile.capacity.minimum = len(vms_with_protection)
+                else:
+                    logging.error(
+                        "Failed to list vmss for scaleset %s" % self.scaleset_id
+                    )
 
             updated_auto_scale = update_auto_scale(auto_scale_policy)
             if isinstance(updated_auto_scale, Error):

--- a/src/api-service/__app__/onefuzzlib/workers/scalesets.py
+++ b/src/api-service/__app__/onefuzzlib/workers/scalesets.py
@@ -37,7 +37,6 @@ from ..azure.auto_scale import (
     default_auto_scale_profile,
     default_scale_in_rule,
     get_auto_scale_settings,
-    setup_auto_scale_diagnostics,
     update_auto_scale,
 )
 from ..azure.image import get_os

--- a/src/api-service/__app__/onefuzzlib/workers/scalesets.py
+++ b/src/api-service/__app__/onefuzzlib/workers/scalesets.py
@@ -781,7 +781,7 @@ class Scaleset(BASE_SCALESET, ORMMixin):
             )
             if isinstance(updated_auto_scale, Error):
                 logging.error(
-                    "Failed to update auto scale for scale set %s - %s"
+                    "Failed to update auto scale for scale set %s error: %s"
                     % (self.scaleset_id, updated_auto_scale)
                 )
         elif isinstance(auto_scale_policy, Error):

--- a/src/deployment/azuredeploy.bicep
+++ b/src/deployment/azuredeploy.bicep
@@ -1,7 +1,10 @@
 param name string
 param owner string
 param clientId string
+
+@secure()
 param clientSecret string
+
 param signedExpiry string
 param app_func_issuer string
 param app_func_audiences array


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_

Auto scale can prevent scalesets from shutting down by continuing to spin up nodes even though the scale set is in shutdown state.

## PR Checklist
* [ ] Applies to work item: #2203
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/onefuzz) and sign the CLI.
* [*] Tests added/passed

## Info on Pull Request

_What does this include?_

When a scale set enters the shutdown state, onefuzz will do the following:
* Replace all existing auto scale rules with a single scale in rule that will always evaluate to `True` and will scale in 1 node at a time
* If no existing auto scale resources are configured for the scaleset, skip it

## Explanation why this works

### 1. No new nodes in the scale set

Since we remove all scale out rules, new nodes will never be created regardless of whether there continues to be work in the pool's queue (effectively isolating the scale set from the pool).


### 2. No node will acquire scale in protection


Since the scale set is in shutdown state, nodes can no longer be assigned work. Nodes that are not assigned work are never marked with `scale_in_protection`.

_Note: Nodes not marked with scale in protection can be scaled in by the auto scaling service._
_Note: Once a node completes a WorkSet, it releases its scale in protection._

**Based on 1. and 2. we can say that the number of nodes in the scale set must _strictly_ decrease over time (as the nodes complete their WorkSets).**

## Validation Steps Performed

_How does someone test & validate?_

1. Create a new scale set
4. Submit a job (choose a 'short' duration like 1 hour)
5. Wait for the nodes the pick up work
6. Shut down the scale set using `onefuzz scalesets shutdown {id}`
7. Validate the job continues to run
8. Wait for the job to complete
9. Watch the scale set scale down to 0 nodes
10. Validate the scale set resource is deleted


