### PR TITLE
Make log sinks a singleton

### DIFF
--- a/src/ApiService/ApiService/Log.cs
+++ b/src/ApiService/ApiService/Log.cs
@@ -276,3 +276,27 @@ public class LogTracerFactory : ILogTracerFactory {
     }
 
 }
+
+public interface ILogSinks {
+    List<ILog> GetLogSinks();
+}
+
+public class LogSinks : ILogSinks {
+    private readonly List<ILog> _loggers;
+
+    public LogSinks(IServiceConfig config) {
+        _loggers = new List<ILog>();
+        foreach (var dest in config.LogDestinations) {
+            _loggers.Add(
+                dest switch {
+                    LogDestination.AppInsights => new AppInsights(config.ApplicationInsightsInstrumentationKey!),
+                    LogDestination.Console => new Console(),
+                    _ => throw new Exception($"Unhandled Log Destination type: {dest}"),
+                }
+            );
+        }
+    }
+    public List<ILog> GetLogSinks() {
+        return _loggers;
+    }
+}

--- a/src/ApiService/ApiService/Program.cs
+++ b/src/ApiService/ApiService/Program.cs
@@ -72,8 +72,9 @@ public class Program {
 
             services
             .AddScoped<ILogTracer>(s => {
+                var logSinks = s.GetRequiredService<ILogSinks>();
                 var cfg = s.GetRequiredService<IServiceConfig>();
-                return new LogTracerFactory(GetLoggers(cfg))
+                return new LogTracerFactory(logSinks.GetLogSinks())
                     .CreateLogTracer(
                         Guid.Empty,
                         severityLevel: cfg.LogSeverityLevel);
@@ -118,6 +119,7 @@ public class Program {
             .AddSingleton<ICreds, Creds>()
             .AddSingleton<IServiceConfig, ServiceConfiguration>()
             .AddSingleton<IStorage, Storage>()
+            .AddSingleton<ILogSinks, LogSinks>()
             .AddHttpClient()
             .AddMemoryCache();
         }

--- a/src/ApiService/ApiService/Program.cs
+++ b/src/ApiService/ApiService/Program.cs
@@ -36,22 +36,6 @@ public class Program {
         }
     }
 
-
-    public static List<ILog> GetLoggers(IServiceConfig config) {
-        List<ILog> loggers = new List<ILog>();
-        foreach (var dest in config.LogDestinations) {
-            loggers.Add(
-                dest switch {
-                    LogDestination.AppInsights => new AppInsights(config.ApplicationInsightsInstrumentationKey!),
-                    LogDestination.Console => new Console(),
-                    _ => throw new Exception($"Unhandled Log Destination type: {dest}"),
-                }
-            );
-        }
-        return loggers;
-    }
-
-
     //Move out expensive resources into separate class, and add those as Singleton
     // ArmClient, Table Client(s), Queue Client(s), HttpClient, etc.
     public async static Async.Task Main() {


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_

This should fix our OOM Exceptions caused by initializing telemetry for every function invocation.

## PR Checklist
* [ ] Applies to work item: #2246
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/onefuzz) and sign the CLI.


## Info on Pull Request

_What does this include?_

* Makes the log sinks singletons
* `LogTracer` remains scoped since it has "single threaded only" functions (`ReplaceCorrelationId`, `AddTags`)

## Validation Steps Performed

_How does someone test & validate?_

1. Run .net functions locally
2. Validate telemetry is showing up in App Insights in a dev instance.
