### PR TITLE
Retry on "No connection could be made because target machine actively…

### DIFF
--- a/src/cli/onefuzz/api.py
+++ b/src/cli/onefuzz/api.py
@@ -567,11 +567,13 @@ class Repro(Endpoint):
         ):
             raise Exception("vm setup failed: %s" % repro.state)
 
+        NUM_RETRIES = 10
         bind_all = which("wslpath") is not None and repro.os == enums.OS.windows
         proxy = "*:" + REPRO_SSH_FORWARD if bind_all else REPRO_SSH_FORWARD
         with ssh_connect(repro.ip, repro.auth.private_key, proxy=proxy):
             dbg = ["cdb.exe", "-remote", "tcp:port=1337,server=localhost"]
-            while True:
+            while NUM_RETRIES > 0:
+                NUM_RETRIES = NUM_RETRIES - 1
                 if debug_command:
                     dbg_script = [debug_command, "qq"]
                     with temp_file(

--- a/src/cli/onefuzz/ssh.py
+++ b/src/cli/onefuzz/ssh.py
@@ -60,6 +60,7 @@ def build_ssh_command(
     proxy: Optional[str] = None,
     port: Optional[int] = None,
     command: Optional[str] = None,
+    num_auth_retries: Optional[int] = None,
 ) -> Generator:
     with temp_file("id_rsa", private_key, set_owner_only=True) as ssh_key:
         cmd = [
@@ -82,6 +83,9 @@ def build_ssh_command(
         if log_level <= logging.DEBUG:
             cmd += ["-v"]
 
+        if num_auth_retries:
+            cmd += ["authentication-retries", str(num_auth_retries)]
+
         if command:
             cmd += [command]
 
@@ -97,9 +101,15 @@ def ssh_connect(
     call: bool = False,
     port: Optional[int] = None,
     command: Optional[str] = None,
+    num_auth_retries: Optional[int] = None,
 ) -> Generator:
     with build_ssh_command(
-        ip, private_key, proxy=proxy, port=port, command=command
+        ip,
+        private_key,
+        proxy=proxy,
+        port=port,
+        command=command,
+        num_auth_retries=num_auth_retries,
     ) as cmd:
         logging.info("launching ssh: %s", " ".join(cmd))
 


### PR DESCRIPTION
Added retries when CLI fails to connect to CDB on a repro VM.

CLI will retry every 10 seconds on failure in a forever loop until it succeeds or user presses CTRL-C to kill the CLI process.

Closes #2217 