### PR TITLE
Fixing Scaleset State Check.

### DIFF
--- a/src/api-service/__app__/onefuzzlib/workers/scalesets.py
+++ b/src/api-service/__app__/onefuzzlib/workers/scalesets.py
@@ -949,8 +949,8 @@ class Scaleset(BASE_SCALESET, ORMMixin):
     def sync_auto_scale_settings(self) -> Optional[Error]:
         from .pools import Pool
 
-        # No need to update tables when in shutdown state
-        if self.state == ScalesetState.shutdown:
+        # Only update settings when scaleset is running
+        if self.state != ScalesetState.running:
             return None
 
         logging.info(


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_
Because timer_workers runs every minute, it errors out when it checks for an autoscale profile for a scaleset that's still in init, i.e. it hasn't created a scaling profile yet. 

With this change, sync will only happen when the scaleset is running. 
## PR Checklist
* [ ] Applies to work item: #xxx
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/onefuzz) and sign the CLI.
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_

## Validation Steps Performed

_How does someone test & validate?_
