### PR TITLE
Provide a default for vm extension settings

### DIFF
--- a/src/ApiService/ApiService/onefuzzlib/VmExtensionWrapper.cs
+++ b/src/ApiService/ApiService/onefuzzlib/VmExtensionWrapper.cs
@@ -22,7 +22,9 @@ namespace Microsoft.OneFuzz.Service {
             Publisher.EnsureNotNull("Publisher required for VirtualMachineExtension");
             TypeHandlerVersion.EnsureNotNull("TypeHandlerVersion required for VirtualMachineExtension");
             AutoUpgradeMinorVersion.EnsureNotNull("AutoUpgradeMinorVersion required for VirtualMachineExtension");
-            Settings.EnsureNotNull("Settings required for VirtualMachineExtension");
+
+            var settings = Settings ?? new BinaryData(new Dictionary<string, string>());
+            var protectedSettings = ProtectedSettings ?? new BinaryData(new Dictionary<string, string>());
 
             return (Name!, new VirtualMachineExtensionData(Location.Value) {
                 TypePropertiesType = TypePropertiesType,
@@ -31,8 +33,8 @@ namespace Microsoft.OneFuzz.Service {
                 AutoUpgradeMinorVersion = AutoUpgradeMinorVersion,
                 EnableAutomaticUpgrade = EnableAutomaticUpgrade,
                 ForceUpdateTag = ForceUpdateTag,
-                Settings = Settings,
-                ProtectedSettings = ProtectedSettings
+                Settings = settings,
+                ProtectedSettings = protectedSettings
             });
         }
 
@@ -42,6 +44,10 @@ namespace Microsoft.OneFuzz.Service {
             Publisher.EnsureNotNull("Publisher required for VirtualMachineScaleSetExtension");
             TypeHandlerVersion.EnsureNotNull("TypeHandlerVersion required for VirtualMachineScaleSetExtension");
             AutoUpgradeMinorVersion.EnsureNotNull("AutoUpgradeMinorVersion required for VirtualMachineScaleSetExtension");
+
+            var settings = Settings ?? new BinaryData(new Dictionary<string, string>());
+            var protectedSettings = ProtectedSettings ?? new BinaryData(new Dictionary<string, string>());
+
             return new VirtualMachineScaleSetExtensionData() {
                 Name = Name,
                 TypePropertiesType = TypePropertiesType,
@@ -50,8 +56,8 @@ namespace Microsoft.OneFuzz.Service {
                 AutoUpgradeMinorVersion = AutoUpgradeMinorVersion,
                 EnableAutomaticUpgrade = EnableAutomaticUpgrade,
                 ForceUpdateTag = ForceUpdateTag,
-                Settings = Settings,
-                ProtectedSettings = ProtectedSettings
+                Settings = settings,
+                ProtectedSettings = protectedSettings
             };
         }
     }


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_

`Settings` and `ProtectedSettings` are required properties of VM Extensions but not all of our extension configurations need to set additional settings. In those cases, it's OK to create an empty dictionary.



## PR Checklist
* [ ] closes #2268 

## Info on Pull Request

_What does this include?_

* Don't throw if `Settings`/`ProtectedSettings` is not set
* Provide a default instead

## Validation Steps Performed

_How does someone test & validate?_

* TODO: Validate in check-pr
