### PR TITLE
Ignore info advisory about unmaintained `ansi_term` crate

### DIFF
--- a/src/ci/agent.sh
+++ b/src/ci/agent.sh
@@ -54,7 +54,8 @@ cargo fmt -- --check
 # RUSTSEC-2020-0159: potential segfault in `time`, not yet patched (#1366)
 # RUSTSEC-2020-0071: potential segfault in `chrono`, not yet patched (#1366)
 # RUSTSEC-2022-0048: xml-rs is unmaintained
-cargo audit --deny warnings --deny unmaintained --deny unsound --deny yanked --ignore RUSTSEC-2020-0016 --ignore RUSTSEC-2020-0036 --ignore RUSTSEC-2019-0036 --ignore RUSTSEC-2021-0065 --ignore RUSTSEC-2020-0159 --ignore RUSTSEC-2020-0071 --ignore RUSTSEC-2020-0077 --ignore RUSTSEC-2022-0048
+# RUSTSEC-2021-0139: ansi_term is unmaintained
+cargo audit --deny warnings --deny unmaintained --deny unsound --deny yanked --ignore RUSTSEC-2020-0016 --ignore RUSTSEC-2020-0036 --ignore RUSTSEC-2019-0036 --ignore RUSTSEC-2021-0065 --ignore RUSTSEC-2020-0159 --ignore RUSTSEC-2020-0071 --ignore RUSTSEC-2020-0077 --ignore RUSTSEC-2022-0048 --ignore RUSTSEC-2021-0139
 cargo-license -j > data/licenses.json
 cargo build --release --locked
 cargo clippy --release --locked --all-targets -- -D warnings

--- a/src/ci/proxy.sh
+++ b/src/ci/proxy.sh
@@ -17,7 +17,8 @@ cargo clippy --release --all-targets -- -D warnings
 # RUSTSEC-2020-0159: potential segfault in `time`, not yet patched (#1366)
 # RUSTSEC-2020-0071: potential segfault in `chrono`, not yet patched (#1366)
 # RUSTSEC-2022-0048: xml-rs is unmaintained
-cargo audit --deny warnings --deny unmaintained --deny unsound --deny yanked --ignore RUSTSEC-2020-0016 --ignore RUSTSEC-2021-0065 --ignore RUSTSEC-2020-0159 --ignore RUSTSEC-2020-0071 --ignore RUSTSEC-2022-0048
+# RUSTSEC-2021-0139: ansi_term is unmaintained
+cargo audit --deny warnings --deny unmaintained --deny unsound --deny yanked --ignore RUSTSEC-2020-0016 --ignore RUSTSEC-2021-0065 --ignore RUSTSEC-2020-0159 --ignore RUSTSEC-2020-0071 --ignore RUSTSEC-2022-0048 --ignore RUSTSEC-2021-0139
 cargo-license -j > data/licenses.json
 cargo build --release --locked
 # export RUST_LOG=trace


### PR DESCRIPTION
The `ansi_term` crate is unmaintained, as described by the INFO-level advisory [RUSTSEC-2021-0139](https://rustsec.org/advisories/RUSTSEC-2021-0139.html).

Allow continued use of it for now, and ignore the advisory when invoking `cargo audit`.