### PR TITLE
Devcontainer updates

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,17 +3,14 @@
 ARG VARIANT="ubuntu-22.04"
 FROM mcr.microsoft.com/vscode/devcontainers/base:0-${VARIANT}
 
-# Setup MS package signing key:
-# NB: needs changing if VARIANT changes
-RUN wget https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb && \
-    dpkg -i packages-microsoft-prod.deb && \
-    rm packages-microsoft-prod.deb
-
-# Install APT HTTPS transport required for MS packages:
-RUN apt-get update && export DEBIAN_FRONTEND=noninteractive && apt-get install -y apt-transport-https
-
 # Install packages required for build:
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends \
     libunwind-dev clang build-essential libssl-dev pkg-config lldb \
-    bash-completion npm python-is-python3
+    bash-completion npm python-is-python3 \
+    dotnet6
+
+# Install Rust (installing via devcontainer feature failing for 1.63)
+USER vscode
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain 1.63 -y
+USER root

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,10 @@
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.224.3/containers/ubuntu/.devcontainer/base.Dockerfile
 
 ARG VARIANT="ubuntu-22.04"
+
+# note: keep this in sync with .github/workflows/ci.yml
+ARG RUSTVERSION="1.63"
+
 FROM mcr.microsoft.com/vscode/devcontainers/base:0-${VARIANT}
 
 # Install packages required for build:
@@ -10,7 +14,7 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     bash-completion npm python-is-python3 \
     dotnet6
 
-# Install Rust (installing via devcontainer feature failing for 1.63)
+# Install Rust:
 USER vscode
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain 1.63 -y
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain ${RUSTVERSION} -y
 USER root

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -42,13 +42,6 @@
 	// Note: available features are listed in: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/container-features/src/devcontainer-features.json
 	"features": {
 		"azure-cli": "latest",
-		"python": "os-provided",
-		"dotnet": {
-			"version": "latest"
-		},
-		"rust": {
-			"version": "latest",
-			"profile": "default"
-		}
+		"python": "os-provided"
 	}
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Install specific Rust version
+      # note: keep this in sync with .devcontainer/Dockerfile
       run: |
         rustup default 1.63 
         rustup component add clippy rustfmt


### PR DESCRIPTION
Addresses two things with the devcontainer:

- We want Rust 1.63, since we are pinned to that version now. I couldn't get this version to work with the devcontainer "features" so install it using rustup instead.
- The `dotnet` install was in a broken state due to a mix of Canonical/MS packages (see [here](https://github.com/dotnet/sdk/issues/27129)). The `dotnet6` package is included with Ubuntu now, so install it directly using `apt` instead of via the feature which fetched it from the MS package repository.