### PR TITLE
Fix NullReferenceException in CreateQueue

### DIFF
--- a/src/ApiService/ApiService/onefuzzlib/Queue.cs
+++ b/src/ApiService/ApiService/onefuzzlib/Queue.cs
@@ -84,7 +84,7 @@ public class Queue : IQueue {
         var client = await GetQueueClient(name, storageType);
         var resp = await client.CreateIfNotExistsAsync();
 
-        if (resp.IsError) {
+        if (resp is not null && resp.IsError) {
             _log.Error($"failed to create queue {name} due to {resp.ReasonPhrase}");
         }
     }


### PR DESCRIPTION
`CreateIfNotExistsAsync` is documented as returning `null` if the queue already exists:

```csharp
        // Returns:
        //     If the queue does not already exist, a Azure.Response describing the newly created
        //     queue. If the queue already exists, null.
 ```

To be investigated: why did we not hit this earlier? Why did null reference checking not trigger here?