### PR TITLE
Only save the job once when creating it

### DIFF
--- a/src/ApiService/ApiService/Functions/Jobs.cs
+++ b/src/ApiService/ApiService/Functions/Jobs.cs
@@ -40,9 +40,7 @@ public class Jobs {
             UserInfo = userInfo.OkV,
         };
 
-        await _context.JobOperations.Insert(job);
-
-        // create the job logs container 
+        // create the job logs container
         var metadata = new Dictionary<string, string>{
             { "container_type", "logs" }, // TODO: use ContainerType.Logs enum somehow; needs snake case name
         };

--- a/src/ApiService/ApiService/Functions/Jobs.cs
+++ b/src/ApiService/ApiService/Functions/Jobs.cs
@@ -58,7 +58,7 @@ public class Jobs {
         // log container must not have the SAS included
         var logContainerUri = new UriBuilder(containerSas) { Query = "" }.Uri;
         job = job with { Config = job.Config with { Logs = logContainerUri.ToString() } };
-        await _context.JobOperations.Update(job);
+        await _context.JobOperations.Insert(job);
         return await RequestHandling.Ok(req, JobResponse.ForJob(job));
     }
 

--- a/src/ApiService/ApiService/OneFuzzTypes/Model.cs
+++ b/src/ApiService/ApiService/OneFuzzTypes/Model.cs
@@ -847,7 +847,7 @@ public record TaskUnitConfig(
     Guid InstanceId,
     Guid JobId,
     Guid TaskId,
-    Uri? logs,
+    Uri logs,
     TaskType TaskType,
     string? InstanceTelemetryKey,
     string? MicrosoftTelemetryKey,

--- a/src/ApiService/ApiService/OneFuzzTypes/Model.cs
+++ b/src/ApiService/ApiService/OneFuzzTypes/Model.cs
@@ -847,7 +847,7 @@ public record TaskUnitConfig(
     Guid InstanceId,
     Guid JobId,
     Guid TaskId,
-    Uri logs,
+    Uri? logs,
     TaskType TaskType,
     string? InstanceTelemetryKey,
     string? MicrosoftTelemetryKey,

--- a/src/ApiService/ApiService/onefuzzlib/Config.cs
+++ b/src/ApiService/ApiService/onefuzzlib/Config.cs
@@ -56,16 +56,17 @@ public class Config : IConfig {
         }
 
         if (job.Config.Logs == null) {
-            throw new Exception($"Missing log container:  job_id {job.JobId}, task_id {task.TaskId}");
+            _logTracer.Warning($"Missing log container:  job_id {job.JobId}, task_id {task.TaskId}");
         }
 
         var definition = Defs.TASK_DEFINITIONS[task.Config.Task.Type];
+        var configLogs = job.Config.Logs == null ? null : await _containers.AddContainerSasUrl(new Uri(job.Config.Logs));
 
         var config = new TaskUnitConfig(
             InstanceId: await _containers.GetInstanceId(),
             JobId: job.JobId,
             TaskId: task.TaskId,
-            logs: await _containers.AddContainerSasUrl(new Uri(job.Config.Logs)),
+            logs: configLogs,
             TaskType: task.Config.Task.Type,
             InstanceTelemetryKey: _serviceConfig.ApplicationInsightsInstrumentationKey,
             MicrosoftTelemetryKey: _serviceConfig.OneFuzzTelemetry,

--- a/src/ApiService/ApiService/onefuzzlib/Scheduler.cs
+++ b/src/ApiService/ApiService/onefuzzlib/Scheduler.cs
@@ -136,6 +136,10 @@ public class Scheduler : IScheduler {
         }
 
         var taskConfig = await _config.BuildTaskConfig(job, task);
+        if (taskConfig == null) {
+            _logTracer.Info($"unable to build task config for task: {task.TaskId}");
+            return null;
+        }
         var setupContainer = task.Config.Containers?.FirstOrDefault(c => c.Type == ContainerType.Setup) ?? throw new Exception($"task missing setup container: task_type = {task.Config.Task.Type}");
 
         var setupPs1Exist = _containers.BlobExists(setupContainer.Name, "setup.ps1", StorageType.Corpus);
@@ -176,8 +180,6 @@ public class Scheduler : IScheduler {
             setupContainer.Name,
             setupScript,
             pool with { ETag = null });
-
-
 
         return (bucketConfig, workUnit);
     }

--- a/src/api-service/__app__/jobs/__init__.py
+++ b/src/api-service/__app__/jobs/__init__.py
@@ -4,6 +4,7 @@
 # Licensed under the MIT License.
 
 from uuid import uuid4
+
 import azure.functions as func
 from onefuzztypes.enums import ContainerType, ErrorCode, JobState
 from onefuzztypes.models import Error, JobConfig, JobTaskInfo

--- a/src/api-service/__app__/jobs/__init__.py
+++ b/src/api-service/__app__/jobs/__init__.py
@@ -3,6 +3,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+from uuid import uuid4
 import azure.functions as func
 from onefuzztypes.enums import ContainerType, ErrorCode, JobState
 from onefuzztypes.models import Error, JobConfig, JobTaskInfo
@@ -53,9 +54,7 @@ def post(req: func.HttpRequest) -> func.HttpResponse:
     if isinstance(user_info, Error):
         return not_ok(user_info, context="jobs create")
 
-    job = Job(config=request, user_info=user_info)
-    job.save()
-
+    job = Job(job_id=uuid4(), config=request, user_info=user_info)
     # create the job logs container
     log_container_sas = create_container(
         Container(f"logs-{job.job_id}"),
@@ -75,6 +74,7 @@ def post(req: func.HttpRequest) -> func.HttpResponse:
         log_container = log_container_sas[:sep_index]
     else:
         log_container = log_container_sas
+
 
     job.config.logs = log_container
     job.save()

--- a/src/api-service/__app__/jobs/__init__.py
+++ b/src/api-service/__app__/jobs/__init__.py
@@ -75,7 +75,6 @@ def post(req: func.HttpRequest) -> func.HttpResponse:
     else:
         log_container = log_container_sas
 
-
     job.config.logs = log_container
     job.save()
 


### PR DESCRIPTION
- logging a warning in C# instead of an exception just like the [original code ](https://github.com/chkeita/onefuzz/blob/b2399c45710b52160b994e429fe3393a292da8be/src/api-service/__app__/onefuzzlib/tasks/config.py#L289)
- Fix the logic of creation of jobs. Only save once to avoid the job being picked up by the scheduler before it is ready
- [x] check-pr passed