### PR TITLE
Add `--use_dotnet_agent_functions` to `deploy.py` and Python service

### DIFF
--- a/src/api-service/__app__/onefuzzlib/azure/creds.py
+++ b/src/api-service/__app__/onefuzzlib/azure/creds.py
@@ -82,16 +82,13 @@ def get_instance_url() -> str:
 
 
 @cached
-def python_agent_functions_are_disabled() -> bool:
-    # note that we only check one function here;
-    # these should be enabled or disabled as a group
-    return os.environ["AzureWebJobs_agent_can_schedule_Disabled"] == "1"
-    # periods become underscores here
+def use_dotnet_agent_functions() -> bool:
+    return os.environ.get("USE_DOTNET_AGENT_FUNCTIONS") == "1"
 
 
 @cached
 def get_agent_instance_url() -> str:
-    if python_agent_functions_are_disabled():
+    if use_dotnet_agent_functions():
         return "https://%s-net.azurewebsites.net" % get_instance_name()
     else:
         return get_instance_url()

--- a/src/api-service/__app__/onefuzzlib/azure/creds.py
+++ b/src/api-service/__app__/onefuzzlib/azure/creds.py
@@ -83,7 +83,7 @@ def get_instance_url() -> str:
 
 @cached
 def use_dotnet_agent_functions() -> bool:
-    return os.environ.get("USE_DOTNET_AGENT_FUNCTIONS") == "1"
+    return os.environ.get("ONEFUZZ_USE_DOTNET_AGENT_FUNCTIONS") == "1"
 
 
 @cached

--- a/src/deployment/azuredeploy.bicep
+++ b/src/deployment/azuredeploy.bicep
@@ -24,6 +24,8 @@ param workbookData object
 ])
 param diagnosticsLogLevel string = 'Verbose'
 
+param use_dotnet_agent_functions bool
+
 var log_retention = 30
 var tenantId = subscription().tenantId
 
@@ -270,6 +272,7 @@ module pythonFunctionSettings 'bicep-templates/function-settings.bicep' = {
     monitor_account_name: operationalInsights.outputs.monitorAccountName
     multi_tenant_domain: multi_tenant_domain
     functions_disabled: python_functions_disabled
+    use_dotnet_agent_functions: use_dotnet_agent_functions
     all_function_names: [
       'agent_can_schedule'    //0
       'agent_commands'        //1
@@ -334,6 +337,7 @@ module netFunctionSettings 'bicep-templates/function-settings.bicep' = {
     monitor_account_name: operationalInsights.outputs.monitorAccountName
     multi_tenant_domain: multi_tenant_domain
     functions_disabled: dotnet_functions_disabled
+    use_dotnet_agent_functions: false // this doesn’t do anything on the .NET service
     all_function_names: [
       'AgentCanSchedule'      //0
       'AgentCommands'         //1

--- a/src/deployment/bicep-templates/function-settings.bicep
+++ b/src/deployment/bicep-templates/function-settings.bicep
@@ -71,6 +71,6 @@ resource functionSettings 'Microsoft.Web/sites/config@2021-03-01' = {
       ONEFUZZ_KEYVAULT: keyvault_name
       ONEFUZZ_OWNER: owner
       ONEFUZZ_CLIENT_SECRET: client_secret
-      ONEFUZZ_USE_DOTNET_AGENT_FUNCTIONS: use_dotnet_agent_functions
+      ONEFUZZ_USE_DOTNET_AGENT_FUNCTIONS: use_dotnet_agent_functions ? '1' : '0'
   }, disabledFunctions.outputs.appSettings)
 }

--- a/src/deployment/bicep-templates/function-settings.bicep
+++ b/src/deployment/bicep-templates/function-settings.bicep
@@ -71,6 +71,6 @@ resource functionSettings 'Microsoft.Web/sites/config@2021-03-01' = {
       ONEFUZZ_KEYVAULT: keyvault_name
       ONEFUZZ_OWNER: owner
       ONEFUZZ_CLIENT_SECRET: client_secret
-      USE_DOTNET_AGENT_FUNCTIONS: use_dotnet_agent_functions
+      ONEFUZZ_USE_DOTNET_AGENT_FUNCTIONS: use_dotnet_agent_functions
   }, disabledFunctions.outputs.appSettings)
 }

--- a/src/deployment/bicep-templates/function-settings.bicep
+++ b/src/deployment/bicep-templates/function-settings.bicep
@@ -27,6 +27,7 @@ param functions_worker_runtime string
 param functions_extension_version string
 
 param functions_disabled string
+param use_dotnet_agent_functions bool
 
 param all_function_names array
 
@@ -50,26 +51,26 @@ resource functionSettings 'Microsoft.Web/sites/config@2021-03-01' = {
   parent: function
   name: 'appsettings'
   properties: union({
-      'FUNCTIONS_EXTENSION_VERSION': functions_extension_version
-      'FUNCTIONS_WORKER_RUNTIME': functions_worker_runtime
-      'FUNCTIONS_WORKER_PROCESS_COUNT': '1'
-      'APPINSIGHTS_INSTRUMENTATIONKEY': app_insights_key
-      'APPINSIGHTS_APPID': app_insights_app_id
-      'ONEFUZZ_TELEMETRY': telemetry
-      'AzureWebJobsStorage': func_sas_url
-      'MULTI_TENANT_DOMAIN': multi_tenant_domain
-      'AzureWebJobsDisableHomepage': 'true'
-      'AzureSignalRConnectionString': signal_r_connection_string
-      'AzureSignalRServiceTransportType': 'Transient'
-      'ONEFUZZ_INSTANCE_NAME': instance_name
-      'ONEFUZZ_INSTANCE': 'https://${name}.azurewebsites.net'
-      'ONEFUZZ_RESOURCE_GROUP': resourceGroup().id
-      'ONEFUZZ_DATA_STORAGE': fuzz_storage_resource_id
-      'ONEFUZZ_FUNC_STORAGE': func_storage_resource_id
-      'ONEFUZZ_MONITOR': monitor_account_name
-      'ONEFUZZ_KEYVAULT': keyvault_name
-      'ONEFUZZ_OWNER': owner
-      'ONEFUZZ_CLIENT_SECRET': client_secret
+      FUNCTIONS_EXTENSION_VERSION: functions_extension_version
+      FUNCTIONS_WORKER_RUNTIME: functions_worker_runtime
+      FUNCTIONS_WORKER_PROCESS_COUNT: '1'
+      APPINSIGHTS_INSTRUMENTATIONKEY: app_insights_key
+      APPINSIGHTS_APPID: app_insights_app_id
+      ONEFUZZ_TELEMETRY: telemetry
+      AzureWebJobsStorage: func_sas_url
+      MULTI_TENANT_DOMAIN: multi_tenant_domain
+      AzureWebJobsDisableHomepage: 'true'
+      AzureSignalRConnectionString: signal_r_connection_string
+      AzureSignalRServiceTransportType: 'Transient'
+      ONEFUZZ_INSTANCE_NAME: instance_name
+      ONEFUZZ_INSTANCE: 'https://${name}.azurewebsites.net'
+      ONEFUZZ_RESOURCE_GROUP: resourceGroup().id
+      ONEFUZZ_DATA_STORAGE: fuzz_storage_resource_id
+      ONEFUZZ_FUNC_STORAGE: func_storage_resource_id
+      ONEFUZZ_MONITOR: monitor_account_name
+      ONEFUZZ_KEYVAULT: keyvault_name
+      ONEFUZZ_OWNER: owner
+      ONEFUZZ_CLIENT_SECRET: client_secret
+      USE_DOTNET_AGENT_FUNCTIONS: use_dotnet_agent_functions
   }, disabledFunctions.outputs.appSettings)
 }
-

--- a/src/deployment/deploy.py
+++ b/src/deployment/deploy.py
@@ -156,6 +156,7 @@ class Client:
         admins: List[UUID],
         allowed_aad_tenants: List[UUID],
         enable_dotnet: List[str],
+        use_dotnet_agent_functions: bool,
     ):
         self.subscription_id = subscription_id
         self.resource_group = resource_group
@@ -191,6 +192,7 @@ class Client:
         self.arm_template = bicep_to_arm(bicep_template)
 
         self.enable_dotnet = enable_dotnet
+        self.use_dotnet_agent_functions = use_dotnet_agent_functions
 
         machine = platform.machine()
         system = platform.system()
@@ -618,6 +620,7 @@ class Client:
             "signedExpiry": {"value": expiry},
             "multi_tenant_domain": multi_tenant_domain,
             "workbookData": {"value": self.workbook_data},
+            "use_dotnet_agent_functions": {"value":self.use_dotnet_agent_functions}
         }
         deployment = Deployment(
             properties=DeploymentProperties(
@@ -1363,6 +1366,11 @@ def main() -> None:
         "their functions and enable corresponding dotnet functions in the Azure "
         "Function App deployment",
     )
+    parser.add_argument(
+        "--use-dotnet-agent-functions",
+        action="store_true",
+        help="Tell the OneFuzz agent to use the dotnet endpoint",
+    )
     args = parser.parse_args()
 
     if shutil.which("func") is None:
@@ -1393,6 +1401,7 @@ def main() -> None:
         admins=args.set_admins,
         allowed_aad_tenants=args.allowed_aad_tenants or [],
         enable_dotnet=args.enable_dotnet,
+        use_dotnet_agent_functions=args.use_dotnet_agent_functions
     )
     if args.verbose:
         level = logging.DEBUG

--- a/src/deployment/deploy.py
+++ b/src/deployment/deploy.py
@@ -1367,7 +1367,7 @@ def main() -> None:
         "Function App deployment",
     )
     parser.add_argument(
-        "--use-dotnet-agent-functions",
+        "--use_dotnet_agent_functions",
         action="store_true",
         help="Tell the OneFuzz agent to use the dotnet endpoint",
     )


### PR DESCRIPTION
Add an explicit `USE_DOTNET_AGENT_FUNCTIONS` setting to Python service, instead of relying on whether or not functions are enabled/disabled.

We now run the Python & C# functions side-by-side so this wasn’t taking effect.