### PR TITLE
Return error when we fail to match libfuzzer output

### DIFF
--- a/src/agent/onefuzz/src/libfuzzer.rs
+++ b/src/agent/onefuzz/src/libfuzzer.rs
@@ -378,10 +378,8 @@ impl LibFuzzerLine {
     }
 
     pub fn parse(line: &str) -> Result<Option<Self>> {
-        let caps = match LIBFUZZERLINEREGEX.captures(line) {
-            Some(caps) => caps,
-            None => return Ok(None),
-        };
+        let caps = LIBFUZZERLINEREGEX.captures(line)
+            .context(format!("Failed to capture libfuzzer line regex in: {:?}", line))?;
 
         let iters = caps[1].parse()?;
         let execs_sec = caps[2].parse()?;


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_

We return `Ok(None)` when we fail to match libfuzzer output, so we're silently ignoring reporting failures.

The relevant call stack:

https://github.com/microsoft/onefuzz/blob/c3c9e0d94261612038997593bd72cc4c156e8a4d/src/agent/onefuzz-task/src/tasks/fuzz/libfuzzer/common.rs#L264-L266

https://github.com/microsoft/onefuzz/blob/c3c9e0d94261612038997593bd72cc4c156e8a4d/src/agent/onefuzz-task/src/tasks/fuzz/libfuzzer/common.rs#L335-L351

https://github.com/microsoft/onefuzz/blob/c3c9e0d94261612038997593bd72cc4c156e8a4d/src/agent/onefuzz/src/libfuzzer.rs#L380-L384

This change will return an `Error` if we fail to match the regex in the libfuzzer output. The `Error` will now propagate up to be reported by https://github.com/microsoft/onefuzz/blob/c3c9e0d94261612038997593bd72cc4c156e8a4d/src/agent/onefuzz-task/src/tasks/fuzz/libfuzzer/common.rs#L265