### PR TITLE
Enable AppInsights dependency tracking

### DIFF
--- a/src/ApiService/ApiService/ApiService.csproj
+++ b/src/ApiService/ApiService/ApiService.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.ResourceManager.Monitor" Version="1.0.0-beta.2" />
     <PackageReference Include="Faithlife.Utility" Version="0.12.2" />
+    <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.21.0" />
     <PackageReference Include="Semver" Version="2.1.0" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.3.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Storage" Version="5.0.0" />
@@ -19,7 +20,7 @@
     <PackageReference Include="Microsoft.Azure.Management.OperationalInsights" Version="0.24.0-preview" />
     <PackageReference Include="Microsoft.Azure.Management.Monitor" Version="0.28.0-preview" />
 
-    <PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.20.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.21.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.3.0" OutputItemType="Analyzer" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.6.0" />
     <PackageReference Include="Azure.Data.Tables" Version="12.5.0" />

--- a/src/ApiService/ApiService/Program.cs
+++ b/src/ApiService/ApiService/Program.cs
@@ -108,7 +108,9 @@ public class Program {
 
                 .AddSingleton<TelemetryConfiguration>(provider => {
                     var config = provider.GetRequiredService<IServiceConfig>();
-                    return new(config.ApplicationInsightsInstrumentationKey);
+                    return new() { 
+                        ConnectionString = $"InstrumentationKey={config.ApplicationInsightsInstrumentationKey}",
+                    };
                 })
                 .AddSingleton<DependencyTrackingTelemetryModule>()
                 .AddSingleton<ICreds, Creds>()

--- a/src/ApiService/ApiService/Program.cs
+++ b/src/ApiService/ApiService/Program.cs
@@ -9,6 +9,8 @@ using Async = System.Threading.Tasks;
 using System.Text.Json;
 using ApiService.OneFuzzLib.Orm;
 using Azure.Core.Serialization;
+using Microsoft.ApplicationInsights.DependencyCollector;
+using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Middleware;
 using Microsoft.Extensions.DependencyInjection;
@@ -39,80 +41,94 @@ public class Program {
 
     //Move out expensive resources into separate class, and add those as Singleton
     // ArmClient, Table Client(s), Queue Client(s), HttpClient, etc.
-    public async static Async.Task Main() {
-        var host = new HostBuilder()
-        .ConfigureFunctionsWorkerDefaults(
-            builder => {
-                builder.UseMiddleware<LoggingMiddleware>();
-            }
-        )
-        .ConfigureServices((context, services) => {
-            services.Configure<JsonSerializerOptions>(options => {
-                options = EntityConverter.GetJsonSerializerOptions();
-            });
+    public static async Async.Task Main() {
+        using var host =
+            new HostBuilder()
+            .ConfigureFunctionsWorkerDefaults(
+                builder => {
+                    builder.UseMiddleware<LoggingMiddleware>();
+                }
+            )
+            .ConfigureServices((context, services) => {
+                services.Configure<JsonSerializerOptions>(options => {
+                    options = EntityConverter.GetJsonSerializerOptions();
+                });
 
-            services.Configure<WorkerOptions>(options => {
-                options.Serializer = new JsonObjectSerializer(EntityConverter.GetJsonSerializerOptions());
-            });
+                services.Configure<WorkerOptions>(options => {
+                    options.Serializer = new JsonObjectSerializer(EntityConverter.GetJsonSerializerOptions());
+                });
 
-            services
-            .AddScoped<ILogTracer>(s => {
-                var logSinks = s.GetRequiredService<ILogSinks>();
-                var cfg = s.GetRequiredService<IServiceConfig>();
-                return new LogTracerFactory(logSinks.GetLogSinks())
-                    .CreateLogTracer(
-                        Guid.Empty,
-                        severityLevel: cfg.LogSeverityLevel);
+                services
+                .AddScoped<ILogTracer>(s => {
+                    var logSinks = s.GetRequiredService<ILogSinks>();
+                    var cfg = s.GetRequiredService<IServiceConfig>();
+                    return new LogTracerFactory(logSinks.GetLogSinks())
+                        .CreateLogTracer(
+                            Guid.Empty,
+                            severityLevel: cfg.LogSeverityLevel);
+                })
+                .AddScoped<IAutoScaleOperations, AutoScaleOperations>()
+                .AddScoped<INodeOperations, NodeOperations>()
+                .AddScoped<IEvents, Events>()
+                .AddScoped<IWebhookOperations, WebhookOperations>()
+                .AddScoped<IWebhookMessageLogOperations, WebhookMessageLogOperations>()
+                .AddScoped<ITaskOperations, TaskOperations>()
+                .AddScoped<ITaskEventOperations, TaskEventOperations>()
+                .AddScoped<IQueue, Queue>()
+                .AddScoped<IProxyOperations, ProxyOperations>()
+                .AddScoped<IProxyForwardOperations, ProxyForwardOperations>()
+                .AddScoped<IConfigOperations, ConfigOperations>()
+                .AddScoped<IScalesetOperations, ScalesetOperations>()
+                .AddScoped<IContainers, Containers>()
+                .AddScoped<IReports, Reports>()
+                .AddScoped<INotificationOperations, NotificationOperations>()
+                .AddScoped<IUserCredentials, UserCredentials>()
+                .AddScoped<IReproOperations, ReproOperations>()
+                .AddScoped<IPoolOperations, PoolOperations>()
+                .AddScoped<IIpOperations, IpOperations>()
+                .AddScoped<IDiskOperations, DiskOperations>()
+                .AddScoped<IVmOperations, VmOperations>()
+                .AddScoped<ISecretsOperations, SecretsOperations>()
+                .AddScoped<IJobOperations, JobOperations>()
+                .AddScoped<INsgOperations, NsgOperations>()
+                .AddScoped<IScheduler, Scheduler>()
+                .AddScoped<IConfig, Config>()
+                .AddScoped<ILogAnalytics, LogAnalytics>()
+                .AddScoped<IExtensions, Extensions>()
+                .AddScoped<IVmssOperations, VmssOperations>()
+                .AddScoped<INodeTasksOperations, NodeTasksOperations>()
+                .AddScoped<INodeMessageOperations, NodeMessageOperations>()
+                .AddScoped<IRequestHandling, RequestHandling>()
+                .AddScoped<IImageOperations, ImageOperations>()
+                .AddScoped<IOnefuzzContext, OnefuzzContext>()
+                .AddScoped<IEndpointAuthorization, EndpointAuthorization>()
+                .AddScoped<INodeMessageOperations, NodeMessageOperations>()
+                .AddScoped<ISubnet, Subnet>()
+                .AddScoped<IAutoScaleOperations, AutoScaleOperations>()
+
+                .AddSingleton<TelemetryConfiguration>(provider => {
+                    var config = provider.GetRequiredService<IServiceConfig>();
+                    return new(config.ApplicationInsightsInstrumentationKey);
+                })
+                .AddSingleton<DependencyTrackingTelemetryModule>()
+                .AddSingleton<ICreds, Creds>()
+                .AddSingleton<EntityConverter>()
+                .AddSingleton<IServiceConfig, ServiceConfiguration>()
+                .AddSingleton<IStorage, Storage>()
+                .AddSingleton<ILogSinks, LogSinks>()
+                .AddHttpClient()
+                .AddMemoryCache();
             })
-            .AddScoped<IAutoScaleOperations, AutoScaleOperations>()
-            .AddScoped<INodeOperations, NodeOperations>()
-            .AddScoped<IEvents, Events>()
-            .AddScoped<IWebhookOperations, WebhookOperations>()
-            .AddScoped<IWebhookMessageLogOperations, WebhookMessageLogOperations>()
-            .AddScoped<ITaskOperations, TaskOperations>()
-            .AddScoped<ITaskEventOperations, TaskEventOperations>()
-            .AddScoped<IQueue, Queue>()
-            .AddScoped<IProxyOperations, ProxyOperations>()
-            .AddScoped<IProxyForwardOperations, ProxyForwardOperations>()
-            .AddScoped<IConfigOperations, ConfigOperations>()
-            .AddScoped<IScalesetOperations, ScalesetOperations>()
-            .AddScoped<IContainers, Containers>()
-            .AddScoped<IReports, Reports>()
-            .AddScoped<INotificationOperations, NotificationOperations>()
-            .AddScoped<IUserCredentials, UserCredentials>()
-            .AddScoped<IReproOperations, ReproOperations>()
-            .AddScoped<IPoolOperations, PoolOperations>()
-            .AddScoped<IIpOperations, IpOperations>()
-            .AddScoped<IDiskOperations, DiskOperations>()
-            .AddScoped<IVmOperations, VmOperations>()
-            .AddScoped<ISecretsOperations, SecretsOperations>()
-            .AddScoped<IJobOperations, JobOperations>()
-            .AddScoped<INsgOperations, NsgOperations>()
-            .AddScoped<IScheduler, Scheduler>()
-            .AddScoped<IConfig, Config>()
-            .AddScoped<ILogAnalytics, LogAnalytics>()
-            .AddScoped<IExtensions, Extensions>()
-            .AddScoped<IVmssOperations, VmssOperations>()
-            .AddScoped<INodeTasksOperations, NodeTasksOperations>()
-            .AddScoped<INodeMessageOperations, NodeMessageOperations>()
-            .AddScoped<IRequestHandling, RequestHandling>()
-            .AddScoped<IImageOperations, ImageOperations>()
-            .AddScoped<IOnefuzzContext, OnefuzzContext>()
-            .AddScoped<IEndpointAuthorization, EndpointAuthorization>()
-            .AddScoped<INodeMessageOperations, NodeMessageOperations>()
-            .AddScoped<ISubnet, Subnet>()
-            .AddScoped<IAutoScaleOperations, AutoScaleOperations>()
+            .Build();
 
-            .AddSingleton<ICreds, Creds>()
-            .AddSingleton<EntityConverter>()
-            .AddSingleton<IServiceConfig, ServiceConfiguration>()
-            .AddSingleton<IStorage, Storage>()
-            .AddSingleton<ILogSinks, LogSinks>()
-            .AddHttpClient()
-            .AddMemoryCache();
-        })
-        .Build();
+        // Set up Application Insights dependency tracking:
+        {
+            var telemetryConfig = host.Services.GetRequiredService<TelemetryConfiguration>();
+            var module = host.Services.GetRequiredService<DependencyTrackingTelemetryModule>();
+            module.Initialize(telemetryConfig);
+        }
 
+        // Initialize expected Storage tables:
         await SetupStorage(
             host.Services.GetRequiredService<IStorage>(),
             host.Services.GetRequiredService<IServiceConfig>());

--- a/src/ApiService/ApiService/Program.cs
+++ b/src/ApiService/ApiService/Program.cs
@@ -108,7 +108,7 @@ public class Program {
 
                 .AddSingleton<TelemetryConfiguration>(provider => {
                     var config = provider.GetRequiredService<IServiceConfig>();
-                    return new() { 
+                    return new() {
                         ConnectionString = $"InstrumentationKey={config.ApplicationInsightsInstrumentationKey}",
                     };
                 })

--- a/src/ApiService/ApiService/packages.lock.json
+++ b/src/ApiService/ApiService/packages.lock.json
@@ -157,6 +157,16 @@
         "resolved": "0.12.2",
         "contentHash": "JgMAGj8ekeAzKkagubXqf1UqgfHq89GyA1UQYWbkAe441uRr2Rh2rktkx5Z0LPwmD/aOqu9cxjekD2GZjP8rbw=="
       },
+      "Microsoft.ApplicationInsights.DependencyCollector": {
+        "type": "Direct",
+        "requested": "[2.21.0, )",
+        "resolved": "2.21.0",
+        "contentHash": "XArm5tBEUdWs05eDKxnsUUQBduJ45DEQOMnpL7wNWxBpgxn+dbl8nObA2jzExbQhbw6P74lc/1f+RdV4iPaOgg==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.21.0",
+          "System.Diagnostics.DiagnosticSource": "5.0.0"
+        }
+      },
       "Microsoft.Azure.Functions.Worker": {
         "type": "Direct",
         "requested": "[1.6.0, )",
@@ -253,11 +263,11 @@
       },
       "Microsoft.Extensions.Logging.ApplicationInsights": {
         "type": "Direct",
-        "requested": "[2.20.0, )",
-        "resolved": "2.20.0",
-        "contentHash": "phuNUDeTlffkJi6zAsMQNOpijNOQ4Olda1WL2L+F33u4fqXmY+EGQnPg81rHW6dOXIYCQvrQUr2gVN5NNMvwKA==",
+        "requested": "[2.21.0, )",
+        "resolved": "2.21.0",
+        "contentHash": "tjzErt5oaLs1caaThu6AbtJuHH0oIGDG/rYCXDruHVGig3m8MyCDuwDsGQwzimY7g4aFyLOKfHc3unBN2G96gw==",
         "dependencies": {
-          "Microsoft.ApplicationInsights": "2.20.0",
+          "Microsoft.ApplicationInsights": "2.21.0",
           "Microsoft.Extensions.Logging": "2.1.1"
         }
       },
@@ -374,8 +384,8 @@
       },
       "Microsoft.ApplicationInsights": {
         "type": "Transitive",
-        "resolved": "2.20.0",
-        "contentHash": "mb+EC5j06Msn5HhKrhrsMAst6JxvYUnphQMGY2cixCabgGAO3q79Y8o/p1Zce1Azgd1IVkRKAMzAV4vDCbXOqA==",
+        "resolved": "2.21.0",
+        "contentHash": "btZEDWAFNo9CoYliMCriSMTX3ruRGZTtYw4mo2XyyfLlowFicYVM2Xszi5evDG95QRYV7MbbH3D2RqVwfZlJHw==",
         "dependencies": {
           "System.Diagnostics.DiagnosticSource": "5.0.0"
         }

--- a/src/ApiService/IntegrationTests/packages.lock.json
+++ b/src/ApiService/IntegrationTests/packages.lock.json
@@ -257,9 +257,18 @@
       },
       "Microsoft.ApplicationInsights": {
         "type": "Transitive",
-        "resolved": "2.20.0",
-        "contentHash": "mb+EC5j06Msn5HhKrhrsMAst6JxvYUnphQMGY2cixCabgGAO3q79Y8o/p1Zce1Azgd1IVkRKAMzAV4vDCbXOqA==",
+        "resolved": "2.21.0",
+        "contentHash": "btZEDWAFNo9CoYliMCriSMTX3ruRGZTtYw4mo2XyyfLlowFicYVM2Xszi5evDG95QRYV7MbbH3D2RqVwfZlJHw==",
         "dependencies": {
+          "System.Diagnostics.DiagnosticSource": "5.0.0"
+        }
+      },
+      "Microsoft.ApplicationInsights.DependencyCollector": {
+        "type": "Transitive",
+        "resolved": "2.21.0",
+        "contentHash": "XArm5tBEUdWs05eDKxnsUUQBduJ45DEQOMnpL7wNWxBpgxn+dbl8nObA2jzExbQhbw6P74lc/1f+RdV4iPaOgg==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.21.0",
           "System.Diagnostics.DiagnosticSource": "5.0.0"
         }
       },
@@ -637,10 +646,10 @@
       },
       "Microsoft.Extensions.Logging.ApplicationInsights": {
         "type": "Transitive",
-        "resolved": "2.20.0",
-        "contentHash": "phuNUDeTlffkJi6zAsMQNOpijNOQ4Olda1WL2L+F33u4fqXmY+EGQnPg81rHW6dOXIYCQvrQUr2gVN5NNMvwKA==",
+        "resolved": "2.21.0",
+        "contentHash": "tjzErt5oaLs1caaThu6AbtJuHH0oIGDG/rYCXDruHVGig3m8MyCDuwDsGQwzimY7g4aFyLOKfHc3unBN2G96gw==",
         "dependencies": {
-          "Microsoft.ApplicationInsights": "2.20.0",
+          "Microsoft.ApplicationInsights": "2.21.0",
           "Microsoft.Extensions.Logging": "2.1.1"
         }
       },
@@ -2134,37 +2143,38 @@
       "apiservice": {
         "type": "Project",
         "dependencies": {
-          "Azure.Core": "[1.25.0, )",
-          "Azure.Data.Tables": "[12.5.0, )",
-          "Azure.Identity": "[1.6.0, )",
-          "Azure.Messaging.EventGrid": "[4.10.0, )",
-          "Azure.ResourceManager": "[1.2.1, )",
-          "Azure.ResourceManager.Compute": "[1.0.0-beta.8, )",
-          "Azure.ResourceManager.Monitor": "[1.0.0-beta.2, )",
-          "Azure.ResourceManager.Network": "[1.0.0, )",
-          "Azure.ResourceManager.Resources": "[1.0.0, )",
-          "Azure.ResourceManager.Storage": "[1.0.0-beta.11, )",
-          "Azure.Security.KeyVault.Secrets": "[4.3.0, )",
-          "Azure.Storage.Blobs": "[12.13.0, )",
-          "Azure.Storage.Queues": "[12.11.0, )",
-          "Faithlife.Utility": "[0.12.2, )",
-          "Microsoft.Azure.Functions.Worker": "[1.6.0, )",
-          "Microsoft.Azure.Functions.Worker.Extensions.EventGrid": "[2.1.0, )",
-          "Microsoft.Azure.Functions.Worker.Extensions.Http": "[3.0.13, )",
-          "Microsoft.Azure.Functions.Worker.Extensions.SignalRService": "[1.7.0, )",
-          "Microsoft.Azure.Functions.Worker.Extensions.Storage": "[5.0.0, )",
-          "Microsoft.Azure.Functions.Worker.Extensions.Timer": "[4.1.0, )",
-          "Microsoft.Azure.Functions.Worker.Sdk": "[1.3.0, )",
-          "Microsoft.Azure.Management.Monitor": "[0.28.0-preview, )",
-          "Microsoft.Azure.Management.OperationalInsights": "[0.24.0-preview, )",
-          "Microsoft.Extensions.Logging.ApplicationInsights": "[2.20.0, )",
-          "Microsoft.Graph": "[4.24.0, )",
-          "Microsoft.Identity.Client": "[4.43.0, )",
-          "Microsoft.Identity.Web.TokenCache": "[1.23.1, )",
-          "Semver": "[2.1.0, )",
-          "System.IdentityModel.Tokens.Jwt": "[6.17.0, )",
-          "System.Linq.Async": "[6.0.1, )",
-          "TaskTupleAwaiter": "[2.0.0, )"
+          "Azure.Core": "1.25.0",
+          "Azure.Data.Tables": "12.5.0",
+          "Azure.Identity": "1.6.0",
+          "Azure.Messaging.EventGrid": "4.10.0",
+          "Azure.ResourceManager": "1.2.1",
+          "Azure.ResourceManager.Compute": "1.0.0-beta.8",
+          "Azure.ResourceManager.Monitor": "1.0.0-beta.2",
+          "Azure.ResourceManager.Network": "1.0.0",
+          "Azure.ResourceManager.Resources": "1.0.0",
+          "Azure.ResourceManager.Storage": "1.0.0-beta.11",
+          "Azure.Security.KeyVault.Secrets": "4.3.0",
+          "Azure.Storage.Blobs": "12.13.0",
+          "Azure.Storage.Queues": "12.11.0",
+          "Faithlife.Utility": "0.12.2",
+          "Microsoft.ApplicationInsights.DependencyCollector": "2.21.0",
+          "Microsoft.Azure.Functions.Worker": "1.6.0",
+          "Microsoft.Azure.Functions.Worker.Extensions.EventGrid": "2.1.0",
+          "Microsoft.Azure.Functions.Worker.Extensions.Http": "3.0.13",
+          "Microsoft.Azure.Functions.Worker.Extensions.SignalRService": "1.7.0",
+          "Microsoft.Azure.Functions.Worker.Extensions.Storage": "5.0.0",
+          "Microsoft.Azure.Functions.Worker.Extensions.Timer": "4.1.0",
+          "Microsoft.Azure.Functions.Worker.Sdk": "1.3.0",
+          "Microsoft.Azure.Management.Monitor": "0.28.0-preview",
+          "Microsoft.Azure.Management.OperationalInsights": "0.24.0-preview",
+          "Microsoft.Extensions.Logging.ApplicationInsights": "2.21.0",
+          "Microsoft.Graph": "4.24.0",
+          "Microsoft.Identity.Client": "4.43.0",
+          "Microsoft.Identity.Web.TokenCache": "1.23.1",
+          "Semver": "2.1.0",
+          "System.IdentityModel.Tokens.Jwt": "6.17.0",
+          "System.Linq.Async": "6.0.1",
+          "TaskTupleAwaiter": "2.0.0"
         }
       }
     }

--- a/src/ApiService/Tests/packages.lock.json
+++ b/src/ApiService/Tests/packages.lock.json
@@ -306,9 +306,18 @@
       },
       "Microsoft.ApplicationInsights": {
         "type": "Transitive",
-        "resolved": "2.20.0",
-        "contentHash": "mb+EC5j06Msn5HhKrhrsMAst6JxvYUnphQMGY2cixCabgGAO3q79Y8o/p1Zce1Azgd1IVkRKAMzAV4vDCbXOqA==",
+        "resolved": "2.21.0",
+        "contentHash": "btZEDWAFNo9CoYliMCriSMTX3ruRGZTtYw4mo2XyyfLlowFicYVM2Xszi5evDG95QRYV7MbbH3D2RqVwfZlJHw==",
         "dependencies": {
+          "System.Diagnostics.DiagnosticSource": "5.0.0"
+        }
+      },
+      "Microsoft.ApplicationInsights.DependencyCollector": {
+        "type": "Transitive",
+        "resolved": "2.21.0",
+        "contentHash": "XArm5tBEUdWs05eDKxnsUUQBduJ45DEQOMnpL7wNWxBpgxn+dbl8nObA2jzExbQhbw6P74lc/1f+RdV4iPaOgg==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.21.0",
           "System.Diagnostics.DiagnosticSource": "5.0.0"
         }
       },
@@ -686,10 +695,10 @@
       },
       "Microsoft.Extensions.Logging.ApplicationInsights": {
         "type": "Transitive",
-        "resolved": "2.20.0",
-        "contentHash": "phuNUDeTlffkJi6zAsMQNOpijNOQ4Olda1WL2L+F33u4fqXmY+EGQnPg81rHW6dOXIYCQvrQUr2gVN5NNMvwKA==",
+        "resolved": "2.21.0",
+        "contentHash": "tjzErt5oaLs1caaThu6AbtJuHH0oIGDG/rYCXDruHVGig3m8MyCDuwDsGQwzimY7g4aFyLOKfHc3unBN2G96gw==",
         "dependencies": {
-          "Microsoft.ApplicationInsights": "2.20.0",
+          "Microsoft.ApplicationInsights": "2.21.0",
           "Microsoft.Extensions.Logging": "2.1.1"
         }
       },
@@ -2261,37 +2270,38 @@
       "apiservice": {
         "type": "Project",
         "dependencies": {
-          "Azure.Core": "[1.25.0, )",
-          "Azure.Data.Tables": "[12.5.0, )",
-          "Azure.Identity": "[1.6.0, )",
-          "Azure.Messaging.EventGrid": "[4.10.0, )",
-          "Azure.ResourceManager": "[1.2.1, )",
-          "Azure.ResourceManager.Compute": "[1.0.0-beta.8, )",
-          "Azure.ResourceManager.Monitor": "[1.0.0-beta.2, )",
-          "Azure.ResourceManager.Network": "[1.0.0, )",
-          "Azure.ResourceManager.Resources": "[1.0.0, )",
-          "Azure.ResourceManager.Storage": "[1.0.0-beta.11, )",
-          "Azure.Security.KeyVault.Secrets": "[4.3.0, )",
-          "Azure.Storage.Blobs": "[12.13.0, )",
-          "Azure.Storage.Queues": "[12.11.0, )",
-          "Faithlife.Utility": "[0.12.2, )",
-          "Microsoft.Azure.Functions.Worker": "[1.6.0, )",
-          "Microsoft.Azure.Functions.Worker.Extensions.EventGrid": "[2.1.0, )",
-          "Microsoft.Azure.Functions.Worker.Extensions.Http": "[3.0.13, )",
-          "Microsoft.Azure.Functions.Worker.Extensions.SignalRService": "[1.7.0, )",
-          "Microsoft.Azure.Functions.Worker.Extensions.Storage": "[5.0.0, )",
-          "Microsoft.Azure.Functions.Worker.Extensions.Timer": "[4.1.0, )",
-          "Microsoft.Azure.Functions.Worker.Sdk": "[1.3.0, )",
-          "Microsoft.Azure.Management.Monitor": "[0.28.0-preview, )",
-          "Microsoft.Azure.Management.OperationalInsights": "[0.24.0-preview, )",
-          "Microsoft.Extensions.Logging.ApplicationInsights": "[2.20.0, )",
-          "Microsoft.Graph": "[4.24.0, )",
-          "Microsoft.Identity.Client": "[4.43.0, )",
-          "Microsoft.Identity.Web.TokenCache": "[1.23.1, )",
-          "Semver": "[2.1.0, )",
-          "System.IdentityModel.Tokens.Jwt": "[6.17.0, )",
-          "System.Linq.Async": "[6.0.1, )",
-          "TaskTupleAwaiter": "[2.0.0, )"
+          "Azure.Core": "1.25.0",
+          "Azure.Data.Tables": "12.5.0",
+          "Azure.Identity": "1.6.0",
+          "Azure.Messaging.EventGrid": "4.10.0",
+          "Azure.ResourceManager": "1.2.1",
+          "Azure.ResourceManager.Compute": "1.0.0-beta.8",
+          "Azure.ResourceManager.Monitor": "1.0.0-beta.2",
+          "Azure.ResourceManager.Network": "1.0.0",
+          "Azure.ResourceManager.Resources": "1.0.0",
+          "Azure.ResourceManager.Storage": "1.0.0-beta.11",
+          "Azure.Security.KeyVault.Secrets": "4.3.0",
+          "Azure.Storage.Blobs": "12.13.0",
+          "Azure.Storage.Queues": "12.11.0",
+          "Faithlife.Utility": "0.12.2",
+          "Microsoft.ApplicationInsights.DependencyCollector": "2.21.0",
+          "Microsoft.Azure.Functions.Worker": "1.6.0",
+          "Microsoft.Azure.Functions.Worker.Extensions.EventGrid": "2.1.0",
+          "Microsoft.Azure.Functions.Worker.Extensions.Http": "3.0.13",
+          "Microsoft.Azure.Functions.Worker.Extensions.SignalRService": "1.7.0",
+          "Microsoft.Azure.Functions.Worker.Extensions.Storage": "5.0.0",
+          "Microsoft.Azure.Functions.Worker.Extensions.Timer": "4.1.0",
+          "Microsoft.Azure.Functions.Worker.Sdk": "1.3.0",
+          "Microsoft.Azure.Management.Monitor": "0.28.0-preview",
+          "Microsoft.Azure.Management.OperationalInsights": "0.24.0-preview",
+          "Microsoft.Extensions.Logging.ApplicationInsights": "2.21.0",
+          "Microsoft.Graph": "4.24.0",
+          "Microsoft.Identity.Client": "4.43.0",
+          "Microsoft.Identity.Web.TokenCache": "1.23.1",
+          "Semver": "2.1.0",
+          "System.IdentityModel.Tokens.Jwt": "6.17.0",
+          "System.Linq.Async": "6.0.1",
+          "TaskTupleAwaiter": "2.0.0"
         }
       }
     }


### PR DESCRIPTION
At the moment we do not have this enabled, but it will be useful to diagnose issues with our use of Azure Storage.