### PR TITLE
Fix ServiceConfiguration.OneFuzzVersion

### DIFF
--- a/src/ApiService/ApiService/Functions/Info.cs
+++ b/src/ApiService/ApiService/Functions/Info.cs
@@ -31,13 +31,13 @@ public class Info {
             var asm = Assembly.GetExecutingAssembly();
             var gitVersion = ReadResource(asm, "ApiService.onefuzzlib.git.version");
             var buildId = ReadResource(asm, "ApiService.onefuzzlib.build.id");
-            var versionString = asm.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+            var versionString = context.ServiceConfiguration.OneFuzzVersion;
 
             return new InfoResponse(
                 ResourceGroup: resourceGroup,
                 Subscription: subscription,
                 Region: region,
-                Versions: new Dictionary<string, InfoVersion> { { "onefuzz", new(gitVersion, buildId, versionString ?? "") } },
+                Versions: new Dictionary<string, InfoVersion> { { "onefuzz", new(gitVersion, buildId, versionString) } },
                 InstanceId: await _context.Containers.GetInstanceId(),
                 InsightsAppid: config.ApplicationInsightsAppId,
                 InsightsInstrumentationKey: config.ApplicationInsightsInstrumentationKey);

--- a/src/ApiService/ApiService/ServiceConfiguration.cs
+++ b/src/ApiService/ApiService/ServiceConfiguration.cs
@@ -99,7 +99,7 @@ public class ServiceConfiguration : IServiceConfig {
             // version can be overridden by config:
             return Environment.GetEnvironmentVariable("ONEFUZZ_VERSION")
                 ?? _oneFuzzVersion
-                ?? "0.0.0";
+                ?? throw new InvalidOperationException("Unable to read OneFuzz version from assembly");
         }
     }
 

--- a/src/ApiService/ApiService/ServiceConfiguration.cs
+++ b/src/ApiService/ApiService/ServiceConfiguration.cs
@@ -1,4 +1,6 @@
-﻿namespace Microsoft.OneFuzz.Service;
+﻿using System.Reflection;
+
+namespace Microsoft.OneFuzz.Service;
 
 public enum LogDestination {
     Console,
@@ -49,6 +51,11 @@ public interface IServiceConfig {
 
 public class ServiceConfiguration : IServiceConfig {
 
+    // Version is baked into the assembly by the build process:
+    private static readonly string? _oneFuzzVersion = 
+        Assembly.GetExecutingAssembly()
+        .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+
     public ServiceConfiguration() {
 #if DEBUG
         LogDestinations = new LogDestination[] { LogDestination.AppInsights, LogDestination.Console };
@@ -86,7 +93,16 @@ public class ServiceConfiguration : IServiceConfig {
     public string? OneFuzzOwner { get => Environment.GetEnvironmentVariable("ONEFUZZ_OWNER"); }
     public string? OneFuzzResourceGroup { get => Environment.GetEnvironmentVariable("ONEFUZZ_RESOURCE_GROUP"); }
     public string? OneFuzzTelemetry { get => Environment.GetEnvironmentVariable("ONEFUZZ_TELEMETRY"); }
-    public string OneFuzzVersion { get => Environment.GetEnvironmentVariable("ONEFUZZ_VERSION") ?? "0.0.0"; }
+
+    public string OneFuzzVersion {
+        get {
+            // version can be overridden by config:
+            return Environment.GetEnvironmentVariable("ONEFUZZ_VERSION")
+                ?? _oneFuzzVersion
+                ?? "0.0.0";
+        }
+    }
+
     public string? OneFuzzAllowOutdatedAgent => Environment.GetEnvironmentVariable("ONEFUZZ_ALLOW_OUTDATED_AGENT");
 
     public string OneFuzzNodeDisposalStrategy { get => Environment.GetEnvironmentVariable("ONEFUZZ_NODE_DISPOSAL_STRATEGY") ?? "scale_in"; }

--- a/src/ApiService/ApiService/ServiceConfiguration.cs
+++ b/src/ApiService/ApiService/ServiceConfiguration.cs
@@ -52,7 +52,7 @@ public interface IServiceConfig {
 public class ServiceConfiguration : IServiceConfig {
 
     // Version is baked into the assembly by the build process:
-    private static readonly string? _oneFuzzVersion = 
+    private static readonly string? _oneFuzzVersion =
         Assembly.GetExecutingAssembly()
         .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
 

--- a/src/ApiService/ApiService/onefuzzlib/ReproOperations.cs
+++ b/src/ApiService/ApiService/onefuzzlib/ReproOperations.cs
@@ -31,8 +31,8 @@ public interface IReproOperations : IStatefulOrm<Repro, VmState> {
 public class ReproOperations : StatefulOrm<Repro, VmState, ReproOperations>, IReproOperations {
     private static readonly Dictionary<Os, string> DEFAULT_OS = new()
     {
-        {Os.Linux, "Canonical:UbuntuServer:18.04-LTS:latest"},
-        {Os.Windows, "MicrosoftWindowsDesktop:Windows-10:20h2-pro:latest"}
+        { Os.Linux, "Canonical:UbuntuServer:18.04-LTS:latest" },
+        { Os.Windows, "MicrosoftWindowsDesktop:Windows-10:20h2-pro:latest" }
     };
 
     const string DEFAULT_SKU = "Standard_DS1_v2";


### PR DESCRIPTION
.NET code was not getting the correct version from `ServiceConfiguration.OneFuzzVersion` as that expected to read it from the config. It should be read from the assembly attributes instead, but I still allow it to be overridden here.