### PR TITLE
Add Cobertura XML output to `src-cov` example binary

### DIFF
--- a/src/agent/coverage/examples/src-cov.rs
+++ b/src/agent/coverage/examples/src-cov.rs
@@ -24,6 +24,9 @@ struct Opt {
 
     #[structopt(short, long, long_help = "Timeout in ms", default_value = "5000")]
     timeout: u64,
+
+    #[structopt(short = "x", long)]
+    cobertura_xml: bool,
 }
 
 fn main() -> Result<()> {
@@ -59,12 +62,17 @@ fn main() -> Result<()> {
     let mut debug_info = coverage::debuginfo::DebugInfo::default();
     let src_coverage = total.source_coverage(&mut debug_info)?;
 
-    for file_coverage in src_coverage.files {
-        for location in &file_coverage.locations {
-            println!(
-                "{} {}:{}",
-                location.count, file_coverage.file, location.line
-            );
+    if opt.cobertura_xml {
+        let cobertura = coverage::cobertura::cobertura(src_coverage)?;
+        println!("{}", cobertura);
+    } else {
+        for file_coverage in src_coverage.files {
+            for location in &file_coverage.locations {
+                println!(
+                    "{} {}:{}",
+                    location.count, file_coverage.file, location.line
+                );
+            }
         }
     }
 

--- a/src/agent/coverage/examples/src-cov.rs
+++ b/src/agent/coverage/examples/src-cov.rs
@@ -38,7 +38,7 @@ fn main() -> Result<()> {
         for entry in std::fs::read_dir(dir)? {
             let input = entry?.path();
 
-            println!("testing input: {}", input.display());
+            eprintln!("testing input: {}", input.display());
 
             let cmd = input_command(&opt.cmd, &input);
             let coverage = record(&mut cache, filter.clone(), cmd, timeout)?;
@@ -48,7 +48,7 @@ fn main() -> Result<()> {
     }
 
     for input in &opt.inputs {
-        println!("testing input: {}", input.display());
+        eprintln!("testing input: {}", input.display());
 
         let cmd = input_command(&opt.cmd, input);
         let coverage = record(&mut cache, filter.clone(), cmd, timeout)?;


### PR DESCRIPTION
Enable convenient local generation of Cobertura XML reports using the `src-cov` example binary from the `coverage` crate.

Progress logging is now written to stdout. Adding the `-x`/`--cobertura-xml` flag will result in emitting an Cobertura XML report to stdout. Otherwise, simple hit/miss line coverage is reported.

Note that this currently only reports src coverage associated with basic block entrypoints, and not every source line that is implicitly executed when a block is entered.