### PR TITLE
Remove some response-only properties from the Task model

### DIFF
--- a/src/ApiService/ApiService/Functions/Tasks.cs
+++ b/src/ApiService/ApiService/Functions/Tasks.cs
@@ -32,8 +32,8 @@ public class Tasks {
             return await _context.RequestHandling.NotOk(req, request.ErrorV, "task get");
         }
 
-        if (request.OkV.TaskId != null) {
-            var task = await _context.TaskOperations.GetByTaskId(request.OkV.TaskId.Value);
+        if (request.OkV.TaskId is Guid taskId) {
+            var task = await _context.TaskOperations.GetByTaskId(taskId);
             if (task == null) {
                 return await _context.RequestHandling.NotOk(
                     req,
@@ -44,8 +44,8 @@ public class Tasks {
             }
 
             var (nodes, events) = await (
-                _context.NodeTasksOperations.GetNodeAssignments(request.OkV.TaskId.Value).ToListAsync().AsTask(),
-                _context.TaskEventOperations.GetSummary(request.OkV.TaskId.Value).ToListAsync().AsTask());
+                _context.NodeTasksOperations.GetNodeAssignments(taskId).ToListAsync().AsTask(),
+                _context.TaskEventOperations.GetSummary(taskId).ToListAsync().AsTask());
 
             var result = new TaskSearchResult(
                 JobId: task.JobId,

--- a/src/ApiService/ApiService/OneFuzzTypes/Model.cs
+++ b/src/ApiService/ApiService/OneFuzzTypes/Model.cs
@@ -256,8 +256,6 @@ public record Task(
     DateTimeOffset? Heartbeat = null,
     DateTimeOffset? EndTime = null,
     UserInfo? UserInfo = null) : StatefulEntityBase<TaskState>(State) {
-    public List<TaskEventSummary> Events { get; set; } = new List<TaskEventSummary>();
-    public List<NodeAssignment> Nodes { get; set; } = new List<NodeAssignment>();
 }
 
 public record TaskEvent(

--- a/src/ApiService/ApiService/OneFuzzTypes/Responses.cs
+++ b/src/ApiService/ApiService/OneFuzzTypes/Responses.cs
@@ -35,6 +35,21 @@ public record NodeSearchResult(
     bool DebugKeepNode
 ) : BaseResponse();
 
+public record TaskSearchResult(
+     Guid JobId,
+     Guid TaskId,
+    TaskState State,
+    Os Os,
+    TaskConfig Config,
+    Error? Error,
+    Authentication? Auth,
+    DateTimeOffset? Heartbeat,
+    DateTimeOffset? EndTime,
+    UserInfo? UserInfo,
+    List<TaskEventSummary> Events,
+    List<NodeAssignment> Nodes
+) : BaseResponse();
+
 public record BoolResult(
     bool Result
 ) : BaseResponse();


### PR DESCRIPTION
`Nodes` and `Events` are not really part of the `Task` model but only used in responses to search requests. Remove them and make a separate response type.