### PR TITLE
Use 64-bit worker for function

### DIFF
--- a/src/deployment/bicep-templates/function.bicep
+++ b/src/deployment/bicep-templates/function.bicep
@@ -37,6 +37,7 @@ var commonSiteConfig = {
   detailedErrorLoggingEnabled: true
   http20Enabled: true
   ftpsState: 'Disabled'
+  use32BitWorkerProcess: false
 }
 
 var extraProperties = (use_windows && enable_remote_debugging) ? {


### PR DESCRIPTION
We want the .NET code running as 64-bit. This shouldn't affect the Python code.