### PR TITLE
Add SrcView::try_insert function

### DIFF
--- a/src/agent/srcview/src/srcview.rs
+++ b/src/agent/srcview/src/srcview.rs
@@ -52,30 +52,30 @@ impl SrcView {
     /// Insert a new pdb into the SrcView only if the `pdb` path is not in the SrcView already,
     /// returning a  [Result] indicating the success of the insert, if any was necessary.
     /// If the [Result] is [Ok], the contained bool indicates whether a value was inserted.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `module` - Module name to store the PDB info as
     /// * `pdb` - Path to PDB
-    /// 
+    ///
     /// # Errors
-    /// 
+    ///
     /// If the PDB at the provided path has not been inserted already **and**
     /// cannot be parsed or contains otherwise unexpected data.
-    /// 
+    ///
     /// # Example
-    /// 
+    ///
     /// ```no_run
     /// use srcview::SrcView;
-    /// 
+    ///
     /// let mut sv = SrcView::new();
     /// let modoffs = get_coverage();
-    /// 
+    ///
     /// // Map each modoff to a PDB name/path and make sure it's in the SrcView
     /// for modoff in modoffs {
     ///     let module_name =  mod_name_from_modoff(modoff);
     ///     let res = sv.try_insert(module_name, format!("~/pdbs/{module_name}.pdb"));
-    /// 
+    ///
     ///     if let Ok(inserted) = res {
     ///         println!("PDB was inserted: {inserted}");
     ///     }

--- a/src/agent/srcview/src/srcview.rs
+++ b/src/agent/srcview/src/srcview.rs
@@ -30,7 +30,7 @@ impl SrcView {
     ///
     /// # Errors
     ///
-    ///  If the provided PDB cannot be parsed or contains otherwise unexpected data.
+    ///  If the PDB at the provided path cannot be parsed or contains otherwise unexpected data.
     ///
     /// # Example
     ///
@@ -47,6 +47,42 @@ impl SrcView {
     pub fn insert<P: AsRef<Path>>(&mut self, module: &str, pdb: P) -> Result<Option<PdbCache>> {
         let cache = PdbCache::new(pdb)?;
         Ok(self.0.insert(module.to_owned(), cache))
+    }
+
+    /// Insert a new pdb into the SrcView only if the `pdb` path is not in the SrcView already,
+    /// returning a  [Result] indicating the success of the insert, if any was necessary.
+    /// If an insert was not necessary, returns [Ok].
+    /// 
+    /// # Arguments
+    /// 
+    /// * `module` - Module name to store the PDB info as
+    /// * `pdb` - Path to PDB
+    /// 
+    /// # Errors
+    /// 
+    /// If the PDB at the provided path has not been inserted already **and**
+    /// cannot be parsed or contains otherwise unexpected data.
+    /// 
+    /// # Example
+    /// 
+    /// ```no_run
+    /// use srcview::SrcView;
+    /// 
+    /// let mut sv = SrcView::new();
+    /// let modoffs = get_coverage();
+    /// 
+    /// // Map each modoff to a PDB name/path and make sure it's in the SrcView
+    /// for modoff in modoffs {
+    ///     let module_name =  mod_name_from_modoff(modoff);
+    ///     sv.try_insert(module_name, format!("~/pdbs/{module_name}.pdb"));
+    /// }
+    /// ```
+    pub fn try_insert<P: AsRef<Path>>(&mut self, module: &str, pdb: P) -> Result<()> {
+        if self.0.contains_key(&module.to_owned()) {
+            Ok(())
+        } else {
+            self.insert(module, pdb).map(|_| ())
+        }
     }
 
     /// Resolve a modoff to SrcLine, if one exists

--- a/src/agent/srcview/src/srcview.rs
+++ b/src/agent/srcview/src/srcview.rs
@@ -51,7 +51,7 @@ impl SrcView {
 
     /// Insert a new pdb into the SrcView only if the `pdb` path is not in the SrcView already,
     /// returning a  [Result] indicating the success of the insert, if any was necessary.
-    /// If an insert was not necessary, returns [Ok].
+    /// If the [Result] is [Ok], the contained bool indicates whether a value was inserted.
     /// 
     /// # Arguments
     /// 
@@ -74,14 +74,18 @@ impl SrcView {
     /// // Map each modoff to a PDB name/path and make sure it's in the SrcView
     /// for modoff in modoffs {
     ///     let module_name =  mod_name_from_modoff(modoff);
-    ///     sv.try_insert(module_name, format!("~/pdbs/{module_name}.pdb"));
+    ///     let res = sv.try_insert(module_name, format!("~/pdbs/{module_name}.pdb"));
+    /// 
+    ///     if let Ok(inserted) = res {
+    ///         println!("PDB was inserted: {inserted}");
+    ///     }
     /// }
     /// ```
-    pub fn try_insert<P: AsRef<Path>>(&mut self, module: &str, pdb: P) -> Result<()> {
+    pub fn try_insert<P: AsRef<Path>>(&mut self, module: &str, pdb: P) -> Result<bool> {
         if self.0.contains_key(&module.to_owned()) {
-            Ok(())
+            Ok(false)
         } else {
-            self.insert(module, pdb).map(|_| ())
+            self.insert(module, pdb).map(|_| true)
         }
     }
 

--- a/src/agent/srcview/src/srcview.rs
+++ b/src/agent/srcview/src/srcview.rs
@@ -65,7 +65,7 @@ impl SrcView {
     ///
     /// # Example
     ///
-    /// ```no_run
+    /// ```ignore
     /// use srcview::SrcView;
     ///
     /// let mut sv = SrcView::new();


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_

## PR Checklist
* [x] Applies to work item: #2350 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/onefuzz) and sign the CLI.
* [x] Tests added/passed
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: chat
* [x] Requires documentation to be updated: doc comments

## Info on Pull Request

Adds `try_insert` function to the `SrcView` struct of the `srcview` crate so that a user can ensure a PDB associated with the given module name has been parsed without re-parsing the PDB.

## Validation Steps Performed

TODO: currently working on integrating with the existing tests
