### PR TITLE
Fix: Coverage task should have access to `readonly_inputs` containers

### DIFF
--- a/src/cli/onefuzz/templates/libfuzzer.py
+++ b/src/cli/onefuzz/templates/libfuzzer.py
@@ -159,6 +159,15 @@ class Libfuzzer(Command):
             (ContainerType.coverage, containers[ContainerType.coverage]),
             (ContainerType.readonly_inputs, containers[ContainerType.inputs]),
         ]
+
+        if ContainerType.readonly_inputs in containers:
+            coverage_containers.append(
+                (
+                    ContainerType.readonly_inputs,
+                    containers[ContainerType.readonly_inputs],
+                )
+            )
+
         self.logger.info("creating coverage task")
 
         # The `coverage` task is not libFuzzer-aware, so invocations of the target fuzzer


### PR DESCRIPTION
Fixes #2348.

Code duplicated & modified from line 112.

Both the generic and dotnet coverage tasks [iterate over all `readonly_inputs` that they are supplied](https://github.com/microsoft/onefuzz/blob/bd4dfdc592391e0d02eea8ae2b300252baade3ab/src/agent/onefuzz-task/src/tasks/coverage/generic.rs#L98-L115), so this should be sufficient.