### PR TITLE
Use self-hosted runner for Rust agent builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,7 @@ jobs:
         os:
         - ubuntu-18.04
         - windows-2019
+        - [ self-hosted, "1ES.Pool=onefuzz-ci" ]
   azcopy:
     runs-on: ubuntu-18.04
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       with:
         # if nothing has changed inside src/agent, we can reuse the artifacts directory
         path: artifacts
-        key: agent-artifacts-${{ matrix.os }}-${{steps.rust-version.outputs.RUST_VERSION}}-${{ env.ACTIONS_CACHE_KEY_DATE }}-${{ hashFiles('src/agent/**/*') }}
+        key: agent-artifacts-${{ join(matrix.os) }}-${{steps.rust-version.outputs.RUST_VERSION}}-${{ env.ACTIONS_CACHE_KEY_DATE }}-${{ hashFiles('src/agent/**/*') }}
         # note: also including the ACTIONS_CACHE_KEY_DATE to rebuild if the Prereq Cache is invalidated
     - name: Rust Prereq Cache
       if: steps.cache-agent-artifacts.outputs.cache-hit != 'true'
@@ -54,7 +54,7 @@ jobs:
           ~/.cargo/registry
           ~/.cargo/git
           ~/.cargo/bin
-        key: rust-${{ matrix.os }}-${{steps.rust-version.outputs.RUST_VERSION}}-${{ env.ACTIONS_CACHE_KEY_DATE }}
+        key: rust-${{ join(matrix.os) }}-${{steps.rust-version.outputs.RUST_VERSION}}-${{ env.ACTIONS_CACHE_KEY_DATE }}
     - name: Install Rust Prereqs
       if: steps.cache-rust-prereqs.outputs.cache-hit != 'true' && steps.cache-agent-artifacts.outputs.cache-hit != 'true'
       shell: bash
@@ -66,9 +66,9 @@ jobs:
         path: |
           sccache
           src/agent/target
-        key: agent-${{ matrix.os }}-${{steps.rust-version.outputs.RUST_VERSION}}-${{ env.ACTIONS_CACHE_KEY_DATE }}-${{ hashFiles('src/agent/Cargo.lock') }}
+        key: agent-${{ join(matrix.os) }}-${{steps.rust-version.outputs.RUST_VERSION}}-${{ env.ACTIONS_CACHE_KEY_DATE }}-${{ hashFiles('src/agent/Cargo.lock') }}
         restore-keys: |
-          agent-${{ matrix.os }}-${{steps.rust-version.outputs.RUST_VERSION}}-${{ env.ACTIONS_CACHE_KEY_DATE }}-
+          agent-${{ join(matrix.os) }}-${{steps.rust-version.outputs.RUST_VERSION}}-${{ env.ACTIONS_CACHE_KEY_DATE }}-
     - name: Linux Prereqs
       if: runner.os == 'Linux' && steps.cache-agent-artifacts.outputs.cache-hit != 'true'
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       with:
         # if nothing has changed inside src/agent, we can reuse the artifacts directory
         path: artifacts
-        key: agent-artifacts-${{ join(matrix.os, ':') }}-${{steps.rust-version.outputs.RUST_VERSION}}-${{ env.ACTIONS_CACHE_KEY_DATE }}-${{ hashFiles('src/agent/**/*') }}
+        key: agent-artifacts|${{ join(matrix.os, ':') }}|${{steps.rust-version.outputs.RUST_VERSION}}|${{ env.ACTIONS_CACHE_KEY_DATE }}|${{ hashFiles('src/agent/**/*') }}
         # note: also including the ACTIONS_CACHE_KEY_DATE to rebuild if the Prereq Cache is invalidated
     - name: Rust Prereq Cache
       if: steps.cache-agent-artifacts.outputs.cache-hit != 'true'
@@ -54,7 +54,7 @@ jobs:
           ~/.cargo/registry
           ~/.cargo/git
           ~/.cargo/bin
-        key: rust-${{ join(matrix.os, ':') }}-${{steps.rust-version.outputs.RUST_VERSION}}-${{ env.ACTIONS_CACHE_KEY_DATE }}
+        key: rust|${{ join(matrix.os, ':') }}|${{steps.rust-version.outputs.RUST_VERSION}}|${{ env.ACTIONS_CACHE_KEY_DATE }}
     - name: Install Rust Prereqs
       if: steps.cache-rust-prereqs.outputs.cache-hit != 'true' && steps.cache-agent-artifacts.outputs.cache-hit != 'true'
       shell: bash
@@ -66,9 +66,9 @@ jobs:
         path: |
           sccache
           src/agent/target
-        key: agent-${{ join(matrix.os, ':') }}-${{steps.rust-version.outputs.RUST_VERSION}}-${{ env.ACTIONS_CACHE_KEY_DATE }}-${{ hashFiles('src/agent/Cargo.lock') }}
+        key: agent|${{ join(matrix.os, ':') }}|${{steps.rust-version.outputs.RUST_VERSION}}|${{ env.ACTIONS_CACHE_KEY_DATE }}|${{ hashFiles('src/agent/Cargo.lock') }}
         restore-keys: |
-          agent-${{ join(matrix.os, ':') }}-${{steps.rust-version.outputs.RUST_VERSION}}-${{ env.ACTIONS_CACHE_KEY_DATE }}-
+          agent|${{ join(matrix.os, ':') }}|${{steps.rust-version.outputs.RUST_VERSION}}|${{ env.ACTIONS_CACHE_KEY_DATE }}|
     - name: Linux Prereqs
       if: runner.os == 'Linux' && steps.cache-agent-artifacts.outputs.cache-hit != 'true'
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       with:
         # if nothing has changed inside src/agent, we can reuse the artifacts directory
         path: artifacts
-        key: agent-artifacts-${{ join(matrix.os) }}-${{steps.rust-version.outputs.RUST_VERSION}}-${{ env.ACTIONS_CACHE_KEY_DATE }}-${{ hashFiles('src/agent/**/*') }}
+        key: agent-artifacts-${{ join(matrix.os, ':') }}-${{steps.rust-version.outputs.RUST_VERSION}}-${{ env.ACTIONS_CACHE_KEY_DATE }}-${{ hashFiles('src/agent/**/*') }}
         # note: also including the ACTIONS_CACHE_KEY_DATE to rebuild if the Prereq Cache is invalidated
     - name: Rust Prereq Cache
       if: steps.cache-agent-artifacts.outputs.cache-hit != 'true'
@@ -54,7 +54,7 @@ jobs:
           ~/.cargo/registry
           ~/.cargo/git
           ~/.cargo/bin
-        key: rust-${{ join(matrix.os) }}-${{steps.rust-version.outputs.RUST_VERSION}}-${{ env.ACTIONS_CACHE_KEY_DATE }}
+        key: rust-${{ join(matrix.os, ':') }}-${{steps.rust-version.outputs.RUST_VERSION}}-${{ env.ACTIONS_CACHE_KEY_DATE }}
     - name: Install Rust Prereqs
       if: steps.cache-rust-prereqs.outputs.cache-hit != 'true' && steps.cache-agent-artifacts.outputs.cache-hit != 'true'
       shell: bash
@@ -66,9 +66,9 @@ jobs:
         path: |
           sccache
           src/agent/target
-        key: agent-${{ join(matrix.os) }}-${{steps.rust-version.outputs.RUST_VERSION}}-${{ env.ACTIONS_CACHE_KEY_DATE }}-${{ hashFiles('src/agent/Cargo.lock') }}
+        key: agent-${{ join(matrix.os, ':') }}-${{steps.rust-version.outputs.RUST_VERSION}}-${{ env.ACTIONS_CACHE_KEY_DATE }}-${{ hashFiles('src/agent/Cargo.lock') }}
         restore-keys: |
-          agent-${{ join(matrix.os) }}-${{steps.rust-version.outputs.RUST_VERSION}}-${{ env.ACTIONS_CACHE_KEY_DATE }}-
+          agent-${{ join(matrix.os, ':') }}-${{steps.rust-version.outputs.RUST_VERSION}}-${{ env.ACTIONS_CACHE_KEY_DATE }}-
     - name: Linux Prereqs
       if: runner.os == 'Linux' && steps.cache-agent-artifacts.outputs.cache-hit != 'true'
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,8 @@ jobs:
     strategy:
       matrix:
         os:
-        - [ self-hosted, "1ES.Pool=onefuzz-ci-windows" ] # this is currently 2019
-        - [ self-hosted, "1ES.Pool=onefuzz-ci" ] # this is currently Ubuntu 18.04
+        - [ self-hosted, "1ES.Pool=onefuzz-ci", "1ES.ImageOverride=github-runner-image-windows-2019" ]
+        - [ self-hosted, "1ES.Pool=onefuzz-ci", "1ES.ImageOverride=github-runner-image-ubuntu-18.04" ] 
     runs-on: "${{ matrix.os }}"
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,8 @@ jobs:
     strategy:
       matrix:
         os:
-        - [ self-hosted, "1ES.Pool=onefuzz-ci", windows ] # this is currently Windows 2019
-        - [ self-hosted, "1ES.Pool=onefuzz-ci", linux ] # this is currently Ubuntu 18.04
+        - [ self-hosted, "1ES.Pool=onefuzz-ci-windows" ] # this is currently 2019
+        - [ self-hosted, "1ES.Pool=onefuzz-ci" ] # this is currently Ubuntu 18.04
     runs-on: "${{ matrix.os }}"
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,11 @@ env:
 
 jobs:
   agent:
+    strategy:
+      matrix:
+        os:
+        - [ self-hosted, "1ES.Pool=onefuzz-ci", windows ] # this is currently Windows 2019
+        - [ self-hosted, "1ES.Pool=onefuzz-ci", linux ] # this is currently Ubuntu 18.04
     runs-on: "${{ matrix.os }}"
     steps:
     - uses: actions/checkout@v2
@@ -81,12 +86,6 @@ jobs:
       with:
         name: build-artifacts
         path: artifacts
-    strategy:
-      matrix:
-        os:
-        - ubuntu-18.04
-        - windows-2019
-        - [ self-hosted, "1ES.Pool=onefuzz-ci" ]
   azcopy:
     runs-on: ubuntu-18.04
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       with:
         # if nothing has changed inside src/agent, we can reuse the artifacts directory
         path: artifacts
-        key: agent-artifacts-${{ runner.os }}-${{steps.rust-version.outputs.RUST_VERSION}}-${{ env.ACTIONS_CACHE_KEY_DATE }}-${{ hashFiles('src/agent/**/*') }}
+        key: agent-artifacts-${{ matrix.os }}-${{steps.rust-version.outputs.RUST_VERSION}}-${{ env.ACTIONS_CACHE_KEY_DATE }}-${{ hashFiles('src/agent/**/*') }}
         # note: also including the ACTIONS_CACHE_KEY_DATE to rebuild if the Prereq Cache is invalidated
     - name: Rust Prereq Cache
       if: steps.cache-agent-artifacts.outputs.cache-hit != 'true'
@@ -54,7 +54,7 @@ jobs:
           ~/.cargo/registry
           ~/.cargo/git
           ~/.cargo/bin
-        key: rust-${{ runner.os }}-${{steps.rust-version.outputs.RUST_VERSION}}-${{ env.ACTIONS_CACHE_KEY_DATE }}
+        key: rust-${{ matrix.os }}-${{steps.rust-version.outputs.RUST_VERSION}}-${{ env.ACTIONS_CACHE_KEY_DATE }}
     - name: Install Rust Prereqs
       if: steps.cache-rust-prereqs.outputs.cache-hit != 'true' && steps.cache-agent-artifacts.outputs.cache-hit != 'true'
       shell: bash
@@ -66,14 +66,14 @@ jobs:
         path: |
           sccache
           src/agent/target
-        key: agent-${{ runner.os }}-${{steps.rust-version.outputs.RUST_VERSION}}-${{ env.ACTIONS_CACHE_KEY_DATE }}-${{ hashFiles('src/agent/Cargo.lock') }}
+        key: agent-${{ matrix.os }}-${{steps.rust-version.outputs.RUST_VERSION}}-${{ env.ACTIONS_CACHE_KEY_DATE }}-${{ hashFiles('src/agent/Cargo.lock') }}
         restore-keys: |
-          agent-${{ runner.os }}-${{steps.rust-version.outputs.RUST_VERSION}}-${{ env.ACTIONS_CACHE_KEY_DATE }}-
+          agent-${{ matrix.os }}-${{steps.rust-version.outputs.RUST_VERSION}}-${{ env.ACTIONS_CACHE_KEY_DATE }}-
     - name: Linux Prereqs
+      if: runner.os == 'Linux' && steps.cache-agent-artifacts.outputs.cache-hit != 'true'
       run: |
         sudo apt-get -y update
         sudo apt-get -y install libssl1.0-dev libunwind-dev
-      if: runner.os == 'Linux' && steps.cache-agent-artifacts.outputs.cache-hit != 'true'
     - run: src/ci/agent.sh
       if: steps.cache-agent-artifacts.outputs.cache-hit != 'true'
       shell: bash

--- a/src/ci/agent.sh
+++ b/src/ci/agent.sh
@@ -38,7 +38,7 @@ cargo --version
 cargo audit --version
 cargo clippy --version
 cargo fmt --version
-cargo-license --version
+cargo license --version
 
 # unless we're doing incremental builds, start clean during CI
 if [ X${CARGO_INCREMENTAL} == X ]; then
@@ -49,7 +49,7 @@ cargo fmt -- --check
 # RUSTSEC-2022-0048: xml-rs is unmaintained
 # RUSTSEC-2021-0139: ansi_term is unmaintained
 cargo audit --deny warnings --deny unmaintained --deny unsound --deny yanked --ignore RUSTSEC-2022-0048 --ignore RUSTSEC-2021-0139
-cargo-license -j > data/licenses.json
+cargo license -j > data/licenses.json
 cargo build --release --locked
 cargo clippy --release --locked --all-targets -- -D warnings
 # export RUST_LOG=trace

--- a/src/ci/proxy.sh
+++ b/src/ci/proxy.sh
@@ -15,7 +15,7 @@ cargo clippy --release --all-targets -- -D warnings
 # RUSTSEC-2022-0048: xml-rs is unmaintained
 # RUSTSEC-2021-0139: ansi_term is unmaintained
 cargo audit --deny warnings --deny unmaintained --deny unsound --deny yanked --ignore RUSTSEC-2022-0048 --ignore RUSTSEC-2021-0139
-cargo-license -j > data/licenses.json
+cargo license -j > data/licenses.json
 cargo build --release --locked
 # export RUST_LOG=trace
 export RUST_BACKTRACE=full

--- a/src/ci/rust-prereqs.sh
+++ b/src/ci/rust-prereqs.sh
@@ -13,6 +13,6 @@ fi
 
 cargo install cargo-audit
 
-if ! cargo-license --help; then
+if ! cargo license --help; then
     cargo install cargo-license@0.4.2
 fi


### PR DESCRIPTION
Use a 1ES hosted pool with more powerful machines to do the build for Rust agents.