### PR TITLE
Devcontainer: ensure venv is installed

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends \
     libunwind-dev clang build-essential libssl-dev pkg-config lldb \
     bash-completion npm dotnet6 \
-    python-is-python3 direnv uuid-runtime python3-distutils python3-pip
+    python-is-python3 direnv uuid-runtime python3-distutils python3-pip python3-venv
 
 # Install Rust:
 USER vscode
@@ -21,6 +21,9 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --defau
 # Install other dependencies:
 COPY install-dependencies.sh .
 RUN ./install-dependencies.sh 
+
+# Setup direnv for Python stuff:
+RUN echo 'eval "$(direnv hook bash)"' >> ~/.bashrc
 
 USER root
 RUN rm install-dependencies.sh

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -35,7 +35,8 @@
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "chmod u+x .devcontainer/post-create-script.sh; ./.devcontainer/post-create-script.sh",
+	// Run as interactive bash shell to pick up .bashrc so that direnv is set up:
+	"postCreateCommand": "bash -i .devcontainer/post-create-script.sh",
 	// - ensure all nuget packages are present
 	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode",


### PR DESCRIPTION
`venv` needed to be installed for Python. Also ensure `direnv` is installed to the `vscode` user's profile.