### PR TITLE
Fix custom type interpolation in queries

### DIFF
--- a/src/ApiService/ApiService/onefuzzlib/NodeOperations.cs
+++ b/src/ApiService/ApiService/onefuzzlib/NodeOperations.cs
@@ -235,15 +235,15 @@ public class NodeOperations : StatefulOrm<Node, NodeState, NodeOperations>, INod
         List<string> queryParts = new();
 
         if (poolId is not null) {
-            queryParts.Add($"(pool_id eq '{poolId}')");
+            queryParts.Add(TableClient.CreateQueryFilter($"(pool_id eq {poolId})"));
         }
 
         if (poolName is not null) {
-            queryParts.Add($"(pool_name eq '{poolName}')");
+            queryParts.Add(TableClient.CreateQueryFilter($"(pool_name eq {poolName.String})"));
         }
 
         if (scalesetId is not null) {
-            queryParts.Add($"(scaleset_id eq '{scalesetId}')");
+            queryParts.Add(TableClient.CreateQueryFilter($"(scaleset_id eq {scalesetId})"));
         }
 
         if (states is not null) {
@@ -469,7 +469,7 @@ public class NodeOperations : StatefulOrm<Node, NodeState, NodeOperations>, INod
         }
 
         if (poolName is not null) {
-            queryParts.Add($"(PartitionKey eq '{poolName}')");
+            queryParts.Add($"(PartitionKey eq '{poolName.String}')");
         }
 
         if (scaleSetId is not null) {
@@ -513,7 +513,7 @@ public class NodeOperations : StatefulOrm<Node, NodeState, NodeOperations>, INod
     }
 
     public IAsyncEnumerable<Node> SearchByPoolName(PoolName poolName) {
-        return QueryAsync($"(pool_name eq '{poolName}')");
+        return QueryAsync(TableClient.CreateQueryFilter($"(pool_name eq {poolName.String})"));
     }
 
 

--- a/src/ApiService/ApiService/onefuzzlib/NotificationOperations.cs
+++ b/src/ApiService/ApiService/onefuzzlib/NotificationOperations.cs
@@ -1,5 +1,6 @@
 ﻿using System.Text.Json;
 using ApiService.OneFuzzLib.Orm;
+using Azure.Data.Tables;
 using Azure.Storage.Sas;
 
 namespace Microsoft.OneFuzz.Service;
@@ -77,7 +78,7 @@ public class NotificationOperations : Orm<Notification>, INotificationOperations
     }
 
     public IAsyncEnumerable<Notification> GetNotifications(Container container) {
-        return QueryAsync(filter: $"container eq '{container}'");
+        return QueryAsync(filter: TableClient.CreateQueryFilter($"container eq {container.String}"));
     }
 
     public IAsyncEnumerable<(Task, IEnumerable<Container>)> GetQueueTasks() {

--- a/src/ApiService/ApiService/onefuzzlib/ProxyForwardOperations.cs
+++ b/src/ApiService/ApiService/onefuzzlib/ProxyForwardOperations.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using ApiService.OneFuzzLib.Orm;
+using Azure.Data.Tables;
 
 namespace Microsoft.OneFuzz.Service;
 
@@ -24,11 +25,11 @@ public class ProxyForwardOperations : Orm<ProxyForward>, IProxyForwardOperations
 
         var conditions =
             new[] {
-                scalesetId != null ? $"scaleset_id eq '{scalesetId}'" : null,
-                region != null ? $"PartitionKey eq '{region}'" : null ,
-                machineId != null ? $"machine_id eq '{machineId}'" : null ,
-                proxyId != null ? $"proxy_id eq '{proxyId}'" : null ,
-                dstPort != null ? $"dst_port eq {dstPort}" : null ,
+                scalesetId is not null ? TableClient.CreateQueryFilter($"scaleset_id eq {scalesetId}") : null,
+                region is not null ? TableClient.CreateQueryFilter($"PartitionKey eq {region.String}") : null ,
+                machineId is not null ? TableClient.CreateQueryFilter($"machine_id eq {machineId}") : null ,
+                proxyId is not null ? TableClient.CreateQueryFilter($"proxy_id eq {proxyId}") : null ,
+                dstPort is not null ? TableClient.CreateQueryFilter($"dst_port eq {dstPort}") : null ,
             }.Where(x => x != null);
 
         var filter = Query.And(conditions!);

--- a/src/ApiService/ApiService/onefuzzlib/ProxyOperations.cs
+++ b/src/ApiService/ApiService/onefuzzlib/ProxyOperations.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using ApiService.OneFuzzLib.Orm;
+using Azure.Data.Tables;
 using Azure.ResourceManager.Compute;
 using Azure.ResourceManager.Compute.Models;
 using Azure.Storage.Sas;
@@ -42,7 +43,7 @@ public class ProxyOperations : StatefulOrm<Proxy, VmState, ProxyOperations>, IPr
     }
 
     public async Async.Task<Proxy?> GetOrCreate(Region region) {
-        var proxyList = QueryAsync(filter: $"region eq '{region}' and outdated eq false");
+        var proxyList = QueryAsync(filter: TableClient.CreateQueryFilter($"region eq {region.String} and outdated eq false"));
 
         await foreach (var proxy in proxyList) {
             if (IsOutdated(proxy)) {

--- a/src/ApiService/ApiService/onefuzzlib/VmssOperations.cs
+++ b/src/ApiService/ApiService/onefuzzlib/VmssOperations.cs
@@ -399,7 +399,7 @@ public class VmssOperations : IVmssOperations {
             entry.SetAbsoluteExpiration(TimeSpan.FromMinutes(10));
 
             var sub = _creds.GetSubscriptionResource();
-            var skus = sub.GetResourceSkusAsync(filter: TableClient.CreateQueryFilter($"location eq '{region}'"));
+            var skus = sub.GetResourceSkusAsync(filter: TableClient.CreateQueryFilter($"location eq {region.String}"));
 
             var skuNames = new List<string>();
             await foreach (var sku in skus) {


### PR DESCRIPTION
Fixes a problem introduced by #2357, since [only specific types are permitted in `TableClient.CreateQueryFilter`](https://github.com/Azure/azure-sdk-for-net/blob/da47271b8faabc1b61d419b9d0741061154c0482/sdk/tables/Azure.Data.Tables/src/TableOdataFilter.cs#L29-L82).