### PR TITLE
Fix Scaleset response Auth inclusion

### DIFF
--- a/src/ApiService/ApiService/Functions/Scaleset.cs
+++ b/src/ApiService/ApiService/Functions/Scaleset.cs
@@ -148,8 +148,10 @@ public class Scaleset {
 
             await _context.AutoScaleOperations.Insert(autoScale);
         }
-
-        return await RequestHandling.Ok(req, ScalesetResponse.ForScaleset(scaleset));
+        
+        // auth not included on create results, only GET with include_auth set
+        var response = ScalesetResponse.ForScaleset(scaleset, includeAuth: false);
+        return await RequestHandling.Ok(req, response);
     }
 
     private async Task<HttpResponseData> Patch(HttpRequestData req) {
@@ -181,9 +183,9 @@ public class Scaleset {
         if (request.OkV.Size is long size) {
             scaleset = await _context.ScalesetOperations.SetSize(scaleset, size);
         }
-
-        scaleset = scaleset with { Auth = null };
-        return await RequestHandling.Ok(req, ScalesetResponse.ForScaleset(scaleset));
+    
+        var response = ScalesetResponse.ForScaleset(scaleset, includeAuth: false);
+        return await RequestHandling.Ok(req, response);
     }
 
     private async Task<HttpResponseData> Get(HttpRequestData req) {
@@ -201,19 +203,15 @@ public class Scaleset {
 
             var scaleset = scalesetResult.OkV;
 
-            var response = ScalesetResponse.ForScaleset(scaleset);
+            var response = ScalesetResponse.ForScaleset(scaleset, includeAuth: search.IncludeAuth);
             response = response with { Nodes = await _context.ScalesetOperations.GetNodes(scaleset) };
-            if (!search.IncludeAuth) {
-                response = response with { Auth = null };
-            }
-
             return await RequestHandling.Ok(req, response);
         }
 
         var states = search.State ?? Enumerable.Empty<ScalesetState>();
         var scalesets = await _context.ScalesetOperations.SearchStates(states).ToListAsync();
         // don't return auths during list actions, only 'get'
-        var result = scalesets.Select(ss => ScalesetResponse.ForScaleset(ss with { Auth = null }));
+        var result = scalesets.Select(ss => ScalesetResponse.ForScaleset(ss, includeAuth: false));
         return await RequestHandling.Ok(req, result);
     }
 }

--- a/src/ApiService/ApiService/Functions/Scaleset.cs
+++ b/src/ApiService/ApiService/Functions/Scaleset.cs
@@ -148,7 +148,7 @@ public class Scaleset {
 
             await _context.AutoScaleOperations.Insert(autoScale);
         }
-        
+
         // auth not included on create results, only GET with include_auth set
         var response = ScalesetResponse.ForScaleset(scaleset, includeAuth: false);
         return await RequestHandling.Ok(req, response);
@@ -183,7 +183,7 @@ public class Scaleset {
         if (request.OkV.Size is long size) {
             scaleset = await _context.ScalesetOperations.SetSize(scaleset, size);
         }
-    
+
         var response = ScalesetResponse.ForScaleset(scaleset, includeAuth: false);
         return await RequestHandling.Ok(req, response);
     }

--- a/src/ApiService/ApiService/OneFuzzTypes/Responses.cs
+++ b/src/ApiService/ApiService/OneFuzzTypes/Responses.cs
@@ -138,12 +138,12 @@ public record ScalesetResponse(
     Dictionary<string, string> Tags,
     List<ScalesetNodeState>? Nodes
 ) : BaseResponse() {
-    public static ScalesetResponse ForScaleset(Scaleset s)
+    public static ScalesetResponse ForScaleset(Scaleset s, bool includeAuth)
         => new(
             PoolName: s.PoolName,
             ScalesetId: s.ScalesetId,
             State: s.State,
-            Auth: s.Auth,
+            Auth: includeAuth ? s.Auth : null,
             VmSku: s.VmSku,
             Image: s.Image,
             Region: s.Region,

--- a/src/ApiService/IntegrationTests/Fakes/TestContext.cs
+++ b/src/ApiService/IntegrationTests/Fakes/TestContext.cs
@@ -18,6 +18,10 @@ public sealed class TestContext : IOnefuzzContext {
         ServiceConfiguration = new TestServiceConfiguration(storagePrefix);
         Storage = storage;
         Creds = creds;
+
+        // this one is faked entirely; we can’t perform these operations at test time
+        VmssOperations = new TestVmssOperations();
+
         Containers = new Containers(logTracer, Storage, ServiceConfiguration);
         Queue = new Queue(Storage, logTracer);
         RequestHandling = new RequestHandling(logTracer);
@@ -71,6 +75,7 @@ public sealed class TestContext : IOnefuzzContext {
     public IConfigOperations ConfigOperations { get; }
     public IPoolOperations PoolOperations { get; }
     public IScalesetOperations ScalesetOperations { get; }
+    public IVmssOperations VmssOperations { get; }
     public EntityConverter EntityConverter { get; }
 
     // -- Remainder not implemented --
@@ -102,8 +107,6 @@ public sealed class TestContext : IOnefuzzContext {
     public ISecretsOperations SecretsOperations => throw new System.NotImplementedException();
 
     public IVmOperations VmOperations => throw new System.NotImplementedException();
-
-    public IVmssOperations VmssOperations => throw new System.NotImplementedException();
 
     public IWebhookMessageLogOperations WebhookMessageLogOperations => throw new System.NotImplementedException();
 

--- a/src/ApiService/IntegrationTests/Fakes/TestVmssOperations.cs
+++ b/src/ApiService/IntegrationTests/Fakes/TestVmssOperations.cs
@@ -1,0 +1,70 @@
+﻿
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Azure.ResourceManager.Compute;
+using Microsoft.OneFuzz.Service;
+
+using Async = System.Threading.Tasks;
+
+namespace IntegrationTests.Fakes;
+
+
+sealed class TestVmssOperations : IVmssOperations {
+    public Task<IReadOnlyList<string>> ListAvailableSkus(Region region)
+        => Async.Task.FromResult(TestSkus);
+
+    public static IReadOnlyList<string> TestSkus = new[] { TestSku };
+    public const string TestSku = "Test_Sku";
+
+    /* below not implemented */
+
+    public Task<OneFuzzResultVoid> CreateVmss(Region location, Guid name, string vmSku, long vmCount, string image, string networkId, bool? spotInstance, bool ephemeralOsDisks, IList<VirtualMachineScaleSetExtensionData>? extensions, string password, string sshPublicKey, IDictionary<string, string> tags) {
+        throw new NotImplementedException();
+    }
+
+    public System.Threading.Tasks.Task DeleteNodes(Guid scalesetId, IReadOnlySet<Guid> machineIds) {
+        throw new NotImplementedException();
+    }
+
+    public Task<bool> DeleteVmss(Guid name, bool? forceDeletion = null) {
+        throw new NotImplementedException();
+    }
+
+    public Task<OneFuzzResult<string>> GetInstanceId(Guid name, Guid vmId) {
+        throw new NotImplementedException();
+    }
+
+    public Task<VirtualMachineScaleSetData?> GetVmss(Guid name) {
+        throw new NotImplementedException();
+    }
+
+    public Task<long?> GetVmssSize(Guid name) {
+        throw new NotImplementedException();
+    }
+
+
+    public Task<IDictionary<Guid, string>> ListInstanceIds(Guid name) {
+        throw new NotImplementedException();
+    }
+
+    public Task<List<string>?> ListVmss(Guid name, Func<VirtualMachineScaleSetVmResource, bool>? filter) {
+        throw new NotImplementedException();
+    }
+
+    public Task<OneFuzzResultVoid> ReimageNodes(Guid scalesetId, IReadOnlySet<Guid> machineIds) {
+        throw new NotImplementedException();
+    }
+
+    public Task<OneFuzzResultVoid> ResizeVmss(Guid name, long capacity) {
+        throw new NotImplementedException();
+    }
+
+    public Task<OneFuzzResultVoid> UpdateExtensions(Guid name, IList<VirtualMachineScaleSetExtensionData> extensions) {
+        throw new NotImplementedException();
+    }
+
+    public Task<OneFuzzResultVoid> UpdateScaleInProtection(Guid name, Guid vmId, bool protectFromScaleIn) {
+        throw new NotImplementedException();
+    }
+}


### PR DESCRIPTION
The `Auth` property is not meant to be returned upon Create/`POST`. Fix this, and make it easier to specify when `Auth` should be included or not. 