### PR TITLE
Fix TaskOperations.SearchStates

### DIFF
--- a/src/ApiService/ApiService/onefuzzlib/TaskOperations.cs
+++ b/src/ApiService/ApiService/onefuzzlib/TaskOperations.cs
@@ -64,12 +64,16 @@ public class TaskOperations : StatefulOrm<Task, TaskState, TaskOperations>, ITas
         return await data.FirstOrDefaultAsync();
     }
     public IAsyncEnumerable<Task> SearchStates(Guid? jobId = null, IEnumerable<TaskState>? states = null) {
+        if (states is not null && !states.Any()) {
+            states = null;
+        }
+
         var queryString =
             (jobId, states) switch {
                 (null, null) => "",
-                (Guid id, null) => Query.PartitionKey($"{id}"),
+                (Guid id, null) => Query.PartitionKey(id.ToString()),
                 (null, IEnumerable<TaskState> s) => Query.EqualAnyEnum("state", s),
-                (Guid id, IEnumerable<TaskState> s) => Query.And(Query.PartitionKey($"{id}"), Query.EqualAnyEnum("state", s)),
+                (Guid id, IEnumerable<TaskState> s) => Query.And(Query.PartitionKey(id.ToString()), Query.EqualAnyEnum("state", s)),
             };
 
         return QueryAsync(filter: queryString);

--- a/src/ApiService/IntegrationTests/TasksTests.cs
+++ b/src/ApiService/IntegrationTests/TasksTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Text.Json;
 using System.Text.Json.Nodes;
@@ -67,5 +68,19 @@ public abstract class TasksTestBase : FunctionTestBase {
         Assert.Equal(HttpStatusCode.BadRequest, result.StatusCode);
         var err = BodyAs<Error>(result);
         Assert.Equal(new[] { "The Pool field is required." }, err.Errors);
+    }
+
+    [Fact]
+    public async Async.Task CanSearchWithJobIdAndEmptyListOfStates() {
+        var auth = new TestEndpointAuthorization(RequestType.User, Logger, Context);
+
+        var req = new TaskSearch(
+            JobId: Guid.NewGuid(),
+            TaskId: null,
+            State: new List<TaskState>());
+
+        var func = new Tasks(Logger, auth, Context);
+        var result = await func.Run(TestHttpRequestData.FromJson("GET", req));
+        Assert.Equal(HttpStatusCode.OK, result.StatusCode);
     }
 }


### PR DESCRIPTION
If passed a Job ID and an empty list of states, this would attempt to perform a query like `'(PartitionKey eq '7092e29e-e254-4103-b5fd-4a5dade02365') and ()'`, which is invalid. 

Fix by treating empty lists and null lists of states the same.