### PR TITLE
Fix MarkDependantsFailed

### DIFF
--- a/src/ApiService/ApiService/onefuzzlib/TaskOperations.cs
+++ b/src/ApiService/ApiService/onefuzzlib/TaskOperations.cs
@@ -133,7 +133,7 @@ public class TaskOperations : StatefulOrm<Task, TaskState, TaskOperations>, ITas
 
         foreach (var t in taskInJob) {
             if (t.Config.PrereqTasks != null) {
-                if (t.Config.PrereqTasks.Contains(t.TaskId)) {
+                if (t.Config.PrereqTasks.Contains(task.TaskId)) {
                     await MarkFailed(t, new Error(ErrorCode.TASK_FAILED, new[] { $"prerequisite task failed.  task_id:{t.TaskId}" }), taskInJob);
                 }
             }


### PR DESCRIPTION
This was checking if the task depends on itself, and not the given task.