### PR TITLE
Codecov setup for C# & Rust code

### DIFF
--- a/.devcontainer/install-dependencies.sh
+++ b/.devcontainer/install-dependencies.sh
@@ -5,7 +5,7 @@ set -eux
 # Note that this script runs as user 'vscode' during devcontainer setup.
 
 # Rust global tools, needed to run CI scripts
-"$HOME/.cargo/bin/cargo" install cargo-audit cargo-license@0.4.2 rustfilt
+"$HOME/.cargo/bin/cargo" install cargo-audit cargo-license@0.4.2 cargo-llvm-cov
 "$HOME/.cargo/bin/rustup" component add llvm-tools-preview
 
 # NPM global tools

--- a/.devcontainer/install-dependencies.sh
+++ b/.devcontainer/install-dependencies.sh
@@ -5,7 +5,8 @@ set -eux
 # Note that this script runs as user 'vscode' during devcontainer setup.
 
 # Rust global tools, needed to run CI scripts
-"$HOME/.cargo/bin/cargo" install cargo-audit cargo-license@0.4.2
+"$HOME/.cargo/bin/cargo" install cargo-audit cargo-license@0.4.2 rustfilt
+"$HOME/.cargo/bin/rustup" component add llvm-tools-preview
 
 # NPM global tools
 sudo npm install -g azurite azure-functions-core-tools@4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
       if: runner.os == 'Linux' && steps.cache-agent-artifacts.outputs.cache-hit != 'true'
       uses: codecov/codecov-action@v3
       with:
-        files: src/agent/agent-coverage.txt
+        files: src/agent/lcov.info
     - uses: actions/upload-artifact@v2.2.2
       with:
         name: build-artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,7 +295,7 @@ jobs:
         ../ci/disable-py-cache.sh
         mypy __app__ ./tests
   service-net:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
     - name: Setup .NET Core SDK
@@ -325,6 +325,9 @@ jobs:
         dotnet tool run reportgenerator -reports:*/TestResults/*/coverage.cobertura.xml -targetdir:coverage -reporttypes:MarkdownSummary
         kill %1
         cat coverage/*.md > $GITHUB_STEP_SUMMARY
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v3
 
     - name: Build Service
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,8 +89,10 @@ jobs:
       if: steps.cache-agent-artifacts.outputs.cache-hit != 'true'
       shell: bash
     - name: Upload coverage to Codecov
-      if: steps.cache-agent-artifacts.outputs.cache-hit != 'true'
+      if: runner.os == 'Linux' && steps.cache-agent-artifacts.outputs.cache-hit != 'true'
       uses: codecov/codecov-action@v3
+      with:
+        files: src/agent/agent-coverage.txt
     - uses: actions/upload-artifact@v2.2.2
       with:
         name: build-artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ env:
   CARGO_TERM_COLOR: always
   SCCACHE_DIR: ${{github.workspace}}/sccache/
   SCCACHE_CACHE_SIZE: 1G
-  ACTIONS_CACHE_KEY_DATE: 2022-06-02-01
+  ACTIONS_CACHE_KEY_DATE: 2022-09-15-01
   CI: true
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       # note: keep this in sync with .devcontainer/Dockerfile
       run: |
         rustup default 1.63 
-        rustup component add clippy rustfmt
+        rustup component add clippy rustfmt llvm-tools-preview
     - name: Get Rust version & build version
       shell: bash
       run: |
@@ -88,6 +88,9 @@ jobs:
     - run: src/ci/agent.sh
       if: steps.cache-agent-artifacts.outputs.cache-hit != 'true'
       shell: bash
+    - name: Upload coverage to Codecov
+      if: steps.cache-agent-artifacts.outputs.cache-hit != 'true'
+      uses: codecov/codecov-action@v3
     - uses: actions/upload-artifact@v2.2.2
       with:
         name: build-artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
       with:
         # if nothing has changed inside src/agent, we can reuse the artifacts directory
         path: artifacts
-        key: agent-artifacts|${{ join(matrix.os, ':') }}|${{steps.rust-version.outputs.RUST_VERSION}}|${{ env.ACTIONS_CACHE_KEY_DATE }}|${{ hashFiles('src/agent/**/*') }}
+        key: agent-artifacts|${{ join(matrix.os, ':') }}|${{steps.rust-version.outputs.RUST_VERSION}}|${{ env.ACTIONS_CACHE_KEY_DATE }}|${{ hashFiles('src/agent/**/*') }}|${{hashFiles('src/ci/agent.sh')}}
         # note: also including the ACTIONS_CACHE_KEY_DATE to rebuild if the Prereq Cache is invalidated
     - name: Rust Prereq Cache
       if: steps.cache-agent-artifacts.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ env:
   CARGO_TERM_COLOR: always
   SCCACHE_DIR: ${{github.workspace}}/sccache/
   SCCACHE_CACHE_SIZE: 1G
-  ACTIONS_CACHE_KEY_DATE: 2022-09-15-01
+  ACTIONS_CACHE_KEY_DATE: 2022-09-15-02
   CI: true
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -327,9 +327,7 @@ jobs:
         cd src/ApiService/
         azurite --silent &
         dotnet test --no-restore --collect:"XPlat Code Coverage" --filter 'Category!=Live'
-        dotnet tool run reportgenerator -reports:*/TestResults/*/coverage.cobertura.xml -targetdir:coverage -reporttypes:MarkdownSummary
-        kill %1
-        cat coverage/*.md > $GITHUB_STEP_SUMMARY
+        kill %1 
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
       if: steps.cache-agent-artifacts.outputs.cache-hit != 'true'
       shell: bash
     - name: Upload coverage to Codecov
-      if: runner.os == 'Linux' && steps.cache-agent-artifacts.outputs.cache-hit != 'true'
+      if: steps.cache-agent-artifacts.outputs.cache-hit != 'true'
       uses: codecov/codecov-action@v3
       with:
         files: src/agent/lcov.info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,10 +89,9 @@ jobs:
       if: steps.cache-agent-artifacts.outputs.cache-hit != 'true'
       shell: bash
     - name: Upload coverage to Codecov
-      if: steps.cache-agent-artifacts.outputs.cache-hit != 'true'
       uses: codecov/codecov-action@v3
       with:
-        files: src/agent/lcov.info
+        files: artifacts/lcov.info
     - uses: actions/upload-artifact@v2.2.2
       with:
         name: build-artifacts

--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,10 @@
 **/.envrc
 **/venv
 
-# profiling files
+# profiling/coverage files
 *.profraw
 *.profdata
+lcov.info
 
 # vim
 *.swp

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@
 **/.envrc
 **/venv
 
+# profiling files
+*.profraw
+*.profdata
+
 # vim
 *.swp
 

--- a/src/ci/agent.sh
+++ b/src/ci/agent.sh
@@ -57,7 +57,7 @@ export RUST_BACKTRACE=full
 
 # Run tests and collect coverage 
 # https://github.com/taiki-e/cargo-llvm-cov
-cargo llvm-cov --locked --workspace --lcov --output-path lcov.info
+cargo llvm-cov --locked --workspace --lcov --output-path "../../artifacts/lcov.info"
 
 # TODO: re-enable integration tests.
 # cargo test --release --manifest-path ./onefuzz-task/Cargo.toml --features integration_test -- --nocapture

--- a/src/ci/agent.sh
+++ b/src/ci/agent.sh
@@ -69,12 +69,12 @@ if [ ! -z "$SCCACHE" ]; then
     sccache --show-stats
 fi
 
-cp target/release/onefuzz-task* ../../artifacts/agent-$(uname)
-cp target/release/onefuzz-agent* ../../artifacts/agent-$(uname)
-cp target/release/srcview* ../../artifacts/agent-$(uname)
+cp target/release/onefuzz-task* "../../artifacts/agent-$platform"
+cp target/release/onefuzz-agent* "../../artifacts/agent-$platform"
+cp target/release/srcview* "../../artifacts/agent-$platform"
 
 if exists target/release/*.pdb; then
     for file in target/release/*.pdb; do
-        cp ${file} ../../artifacts/agent-$(uname)
+        cp "$file" "../../artifacts/agent-$platform"
     done
 fi

--- a/src/ci/agent.sh
+++ b/src/ci/agent.sh
@@ -58,7 +58,7 @@ export RUST_BACKTRACE=full
 if [ "$platform" = 'Linux' ]; then
     # Run tests and collect coverage if on Linux
     # https://github.com/taiki-e/cargo-llvm-cov
-    cargo llvm-cov --locked --workspace --lcov lcov.info
+    cargo llvm-cov --locked --workspace --lcov --output-path lcov.info
 else 
     # On Windows, just run tests
     cargo test --locked --workspace

--- a/src/ci/agent.sh
+++ b/src/ci/agent.sh
@@ -28,8 +28,8 @@ else
     fi
 fi
 
-
-mkdir -p artifacts/agent-$(uname)
+platform=$(uname)
+mkdir -p "artifacts/agent-$platform"
 
 cd src/agent
 
@@ -54,7 +54,32 @@ cargo build --release --locked
 cargo clippy --release --locked --all-targets -- -D warnings
 # export RUST_LOG=trace
 export RUST_BACKTRACE=full
-cargo test --release --locked --workspace
+
+if [ "$platform" = 'Linux' ]; then
+    # Run tests and collect coverage if on Linux
+    # https://doc.rust-lang.org/stable/rustc/instrument-coverage.html#test-coverage
+    RUSTFLAGS="-C instrument-coverage" cargo test --locked --workspace
+
+    # merge all coverage files
+    $(rustc --print sysroot)/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-profdata merge -sparse **/default.profraw -o test.profdata
+    # output coverage report (the ugly for loop is to find the right binaries; see link above)
+    $(rustc --print sysroot)/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-cov show --instr-profile=test.profdata \
+        -Xdemangler=rustfilt --show-line-counts-or-regions --show-instantiations \
+        --ignore-filename-regex='/\.cargo/(registry|git)' \
+        $( for file in \
+            $( \
+                RUSTFLAGS="-C instrument-coverage" cargo test --locked --workspace --no-run --message-format=json \
+                | jq -r "select(.profile.test == true) | .filenames[]"  \
+                | grep -v dSYM - \
+                ); \
+            do printf "%s %s " -object $file; \
+            done \
+        ) > agent-coverage.txt
+else 
+    # Else just run tests
+    cargo test --locked --workspace
+fi
+
 
 # TODO: re-enable integration tests.
 # cargo test --release --manifest-path ./onefuzz-task/Cargo.toml --features integration_test -- --nocapture

--- a/src/ci/agent.sh
+++ b/src/ci/agent.sh
@@ -55,15 +55,9 @@ cargo clippy --release --locked --all-targets -- -D warnings
 # export RUST_LOG=trace
 export RUST_BACKTRACE=full
 
-if [ "$platform" = 'Linux' ]; then
-    # Run tests and collect coverage if on Linux
-    # https://github.com/taiki-e/cargo-llvm-cov
-    cargo llvm-cov --locked --workspace --lcov --output-path lcov.info
-else 
-    # On Windows, just run tests
-    cargo test --locked --workspace
-fi
-
+# Run tests and collect coverage 
+# https://github.com/taiki-e/cargo-llvm-cov
+cargo llvm-cov --locked --workspace --lcov --output-path lcov.info
 
 # TODO: re-enable integration tests.
 # cargo test --release --manifest-path ./onefuzz-task/Cargo.toml --features integration_test -- --nocapture

--- a/src/ci/rust-prereqs.sh
+++ b/src/ci/rust-prereqs.sh
@@ -11,7 +11,7 @@ fi
 # sccache --start-server
 # export RUSTC_WRAPPER=$(which sccache)
 
-cargo install cargo-audit
+cargo install cargo-audit rustfilt
 
 if ! cargo license --help; then
     cargo install cargo-license@0.4.2

--- a/src/ci/rust-prereqs.sh
+++ b/src/ci/rust-prereqs.sh
@@ -11,7 +11,7 @@ fi
 # sccache --start-server
 # export RUSTC_WRAPPER=$(which sccache)
 
-cargo install cargo-audit rustfilt
+cargo install cargo-audit cargo-llvm-cov
 
 if ! cargo license --help; then
     cargo install cargo-license@0.4.2


### PR DESCRIPTION
Use Codecov to show coverage reports, so we get highlighted versions of the files where it is easy to see missing coverage.

- Setup Rust coverage using [`cargo-llvm-cov`](https://github.com/taiki-e/cargo-llvm-cov).
- Add the `ci/agent.sh` build script to the agent artifact cache key, since it wasn't there before.
- Don't run Rust tests in `--release` mode (have been meaning to change this so doing it at the same time).

There is some subtlety about putting the coverage result into the cached agent artifact, so that when we reuse the agent artifact we can still upload the coverage information for it to Codecov. Without this it would look like the coverage had dropped.