### PR TITLE
Update CodeQL workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -17,6 +17,9 @@ jobs:
       matrix:
         language: ["csharp", "python"]
 
+    permissions:
+      security-events: write
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2


### PR DESCRIPTION
Since `GITHUB_TOKEN` has been changed to only allow read access by default, CodeQL needs write access to `security-events` granted explicitly. 