### PR TITLE
Github Actions: Adjust concurrency spec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 # limit to one concurrent run per PR/branch,
 # and cancel any previous runs still going
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
This should be per-workflow, and it is not by default.