### PR TITLE
Enable backtraces for agent errors

### DIFF
--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -46,6 +46,9 @@ name = "anyhow"
 version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b26702f315f53b6071259e15dd9d64528213b44d61de1ec926eca7715d62203"
+dependencies = [
+ "backtrace",
+]
 
 [[package]]
 name = "appinsights"

--- a/src/agent/onefuzz-agent/Cargo.toml
+++ b/src/agent/onefuzz-agent/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 
 [dependencies]
-anyhow = "1.0.51"
+anyhow = { version = "1.0", features = ["backtrace"] }
 async-trait = "0.1"
 downcast-rs = "1.2"
 env_logger = "0.9"

--- a/src/agent/onefuzz-task/Cargo.toml
+++ b/src/agent/onefuzz-task/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 integration_test=[]
 
 [dependencies]
-anyhow = "1.0"
+anyhow = { version = "1.0", features = ["backtrace"] }
 arraydeque = "0.4"
 async-trait = "0.1"
 atexit = { path = "../atexit" }


### PR DESCRIPTION
Enable the `backtrace` feature of `anyhow`, our dynamic catch-all error library. This lets us include backtraces (on `stable` rustc) in our `?`-propagated errors (as long as `RUST_BACKTRACE` is set, which we do in `runtime-tools`).

Example error without the `backtrace` feature:
```
Error: loading path: i-dont-exist.txt

Caused by:
    The system cannot find the file specified. (os error 2)
error: process didn't exit successfully: `target\debug\anyhow-backtrace-example.exe i-dont-exist.txt` (exit code: 1)
```

With:
```
Error: loading path: i-dont-exist.txt

Caused by:
    The system cannot find the file specified. (os error 2)

Stack backtrace:
   0: std::backtrace::Backtrace::create
             at /rustc/a37499ae66ec5fc52a93d71493b78fb141c32f6b/library\std\src\backtrace.rs:333
   1: std::backtrace::Backtrace::capture
             at /rustc/a37499ae66ec5fc52a93d71493b78fb141c32f6b/library\std\src\backtrace.rs:298
   2: anyhow::context::ext::impl$0::ext_context<std::io::error::Error,alloc::string::String>
             at C:\dev\.cargo\registry\src\github.com-1ecc6299db9ec823\anyhow-1.0.65\src\context.rs:27
   3: anyhow::context::impl$0::with_context::closure$0<alloc::vec::Vec<u8,alloc::alloc::Global>,std::io::error::Error,alloc::string::String,anyhow_backtrace_example::load_utf8::closure_env$0<alloc::string::String> >
             at C:\dev\.cargo\registry\src\github.com-1ecc6299db9ec823\anyhow-1.0.65\src\context.rs:58
   4: enum2$<core::result::Result<alloc::vec::Vec<u8,alloc::alloc::Global>,std::io::error::Error> >::map_err<alloc::vec::Vec<u8,alloc::alloc::Global>,std::io::error::Error,anyhow::Error,anyhow::context::impl$0::with_context::closure_env$0<alloc::vec::Vec<u8,all
             at /rustc/a37499ae66ec5fc52a93d71493b78fb141c32f6b\library\core\src\result.rs:855
   5: anyhow::context::impl$0::with_context<alloc::vec::Vec<u8,alloc::alloc::Global>,std::io::error::Error,alloc::string::String,anyhow_backtrace_example::load_utf8::closure_env$0<alloc::string::String> >
             at C:\dev\.cargo\registry\src\github.com-1ecc6299db9ec823\anyhow-1.0.65\src\context.rs:58
   6: anyhow_backtrace_example::load_utf8<alloc::string::String>
             at .\src\main.rs:17
   7: anyhow_backtrace_example::main
             at .\src\main.rs:8
   8: core::ops::function::FnOnce::call_once<enum2$<core::result::Result<tuple$<>,anyhow::Error> > (*)(),tuple$<> >
             at /rustc/a37499ae66ec5fc52a93d71493b78fb141c32f6b\library\core\src\ops\function.rs:248
   9: std::sys_common::backtrace::__rust_begin_short_backtrace<enum2$<core::result::Result<tuple$<>,anyhow::Error> > (*)(),enum2$<core::result::Result<tuple$<>,anyhow::Error> > >
             at /rustc/a37499ae66ec5fc52a93d71493b78fb141c32f6b\library\std\src\sys_common\backtrace.rs:122
  10: std::rt::lang_start::closure$0<enum2$<core::result::Result<tuple$<>,anyhow::Error> > >
             at /rustc/a37499ae66ec5fc52a93d71493b78fb141c32f6b\library\std\src\rt.rs:166
  11: core::ops::function::impls::impl$2::call_once
             at /rustc/a37499ae66ec5fc52a93d71493b78fb141c32f6b/library\core\src\ops\function.rs:283
  12: std::panicking::try::do_call
             at /rustc/a37499ae66ec5fc52a93d71493b78fb141c32f6b/library\std\src\panicking.rs:492
  13: std::panicking::try
             at /rustc/a37499ae66ec5fc52a93d71493b78fb141c32f6b/library\std\src\panicking.rs:456
  14: std::panic::catch_unwind
             at /rustc/a37499ae66ec5fc52a93d71493b78fb141c32f6b/library\std\src\panic.rs:137
  15: std::rt::lang_start_internal::closure$2
             at /rustc/a37499ae66ec5fc52a93d71493b78fb141c32f6b/library\std\src\rt.rs:148
  16: std::panicking::try::do_call
             at /rustc/a37499ae66ec5fc52a93d71493b78fb141c32f6b/library\std\src\panicking.rs:492
  17: std::panicking::try
             at /rustc/a37499ae66ec5fc52a93d71493b78fb141c32f6b/library\std\src\panicking.rs:456
  18: std::panic::catch_unwind
             at /rustc/a37499ae66ec5fc52a93d71493b78fb141c32f6b/library\std\src\panic.rs:137
  19: std::rt::lang_start_internal
             at /rustc/a37499ae66ec5fc52a93d71493b78fb141c32f6b/library\std\src\rt.rs:148
  20: std::rt::lang_start<enum2$<core::result::Result<tuple$<>,anyhow::Error> > >
             at /rustc/a37499ae66ec5fc52a93d71493b78fb141c32f6b\library\std\src\rt.rs:165
  21: main
  22: invoke_main
             at D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:78
  23: __scrt_common_main_seh
             at D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288
  24: BaseThreadInitThunk
  25: RtlUserThreadStart
error: process didn't exit successfully: `target\debug\anyhow-backtrace-example.exe i-dont-exist.txt` (exit code: 1)
```
There's a lot of stuff in the backtrace, but note how it includes the failure sites in the code in these frames:
```
   6: anyhow_backtrace_example::load_utf8<alloc::string::String>
             at .\src\main.rs:17
   7: anyhow_backtrace_example::main
             at .\src\main.rs:8
```