### PR TITLE
Fix: Node state getting reset to `init`

### DIFF
--- a/src/ApiService/ApiService/onefuzzlib/NodeOperations.cs
+++ b/src/ApiService/ApiService/onefuzzlib/NodeOperations.cs
@@ -338,10 +338,11 @@ public class NodeOperations : StatefulOrm<Node, NodeState, NodeOperations>, INod
 
         ResultVoid<(int, string)> r;
         if (isNew) {
-            r = await Replace(node);
+            r = await Insert(node);
         } else {
-            r = await Update(node);
+            r = await Replace(node);
         }
+
         if (!r.IsOk) {
             _logTracer.WithHttpStatus(r.ErrorV).Error($"failed to save NodeRecord for node {node.MachineId:Tag:MachineId} isNew: {isNew:Tag:IsNew}");
         } else {
@@ -350,8 +351,7 @@ public class NodeOperations : StatefulOrm<Node, NodeState, NodeOperations>, INod
                     node.MachineId,
                     node.ScalesetId,
                     node.PoolName
-                    )
-                );
+                    ));
         }
 
         return node;

--- a/src/ApiService/ApiService/onefuzzlib/NodeOperations.cs
+++ b/src/ApiService/ApiService/onefuzzlib/NodeOperations.cs
@@ -1,5 +1,7 @@
-﻿using System.Threading.Tasks;
+﻿using System.Net;
+using System.Threading.Tasks;
 using ApiService.OneFuzzLib.Orm;
+using Azure;
 using Azure.Data.Tables;
 
 namespace Microsoft.OneFuzz.Service;
@@ -31,7 +33,7 @@ public interface INodeOperations : IStatefulOrm<Node, NodeState> {
 
     Async.Task ReimageLongLivedNodes(Guid scaleSetId);
 
-    Async.Task<Node> Create(
+    Async.Task<Node?> Create(
         Guid poolId,
         PoolName poolName,
         Guid machineId,
@@ -326,7 +328,7 @@ public class NodeOperations : StatefulOrm<Node, NodeState, NodeOperations>, INod
     }
 
 
-    public async Async.Task<Node> Create(
+    public async Async.Task<Node?> Create(
         Guid poolId,
         PoolName poolName,
         Guid machineId,
@@ -338,21 +340,27 @@ public class NodeOperations : StatefulOrm<Node, NodeState, NodeOperations>, INod
 
         ResultVoid<(int, string)> r;
         if (isNew) {
-            r = await Insert(node);
+            try {
+                r = await Insert(node);
+            } catch (RequestFailedException ex) when (
+                ex.Status == (int)HttpStatusCode.Conflict ||
+                ex.ErrorCode == "EntityAlreadyExists") {
+                return null;
+            }
         } else {
             r = await Replace(node);
         }
 
         if (!r.IsOk) {
             _logTracer.WithHttpStatus(r.ErrorV).Error($"failed to save NodeRecord for node {node.MachineId:Tag:MachineId} isNew: {isNew:Tag:IsNew}");
-        } else {
-            await _context.Events.SendEvent(
-                new EventNodeCreated(
-                    node.MachineId,
-                    node.ScalesetId,
-                    node.PoolName
-                    ));
+            return null;
         }
+
+        await _context.Events.SendEvent(
+            new EventNodeCreated(
+                node.MachineId,
+                node.ScalesetId,
+                node.PoolName));
 
         return node;
     }

--- a/src/ApiService/ApiService/onefuzzlib/ScalesetOperations.cs
+++ b/src/ApiService/ApiService/onefuzzlib/ScalesetOperations.cs
@@ -527,18 +527,23 @@ public class ScalesetOperations : StatefulOrm<Scaleset, ScalesetState, ScalesetO
 
         foreach (var azureNode in azureNodes) {
             var machineId = azureNode.Key;
-
             if (nodeMachineIds.Contains(machineId)) {
                 continue;
             }
+
             _log.Info($"adding missing azure node {machineId:Tag:MachineId} to scaleset {scaleSet.ScalesetId:Tag:ScalesetId}");
 
-            //# Note, using `new=True` makes it such that if a node already has
-            //# checked in, this won't overwrite it.
+            // Note, using isNew:True makes it such that if a node already has
+            // checked in, this won't overwrite it.
 
-            //Python code does use created node
-            //pool.IsOk was handled above, OkV must be not null at this point
-            _ = await _context.NodeOperations.Create(pool.OkV!.PoolId, scaleSet.PoolName, machineId, scaleSet.ScalesetId, _context.ServiceConfiguration.OneFuzzVersion, true);
+            // don't use result, if there is one
+            _ = await _context.NodeOperations.Create(
+                pool.OkV.PoolId,
+                scaleSet.PoolName,
+                machineId,
+                scaleSet.ScalesetId,
+                _context.ServiceConfiguration.OneFuzzVersion,
+                isNew: true);
         }
 
         var existingNodes =
@@ -550,7 +555,6 @@ public class ScalesetOperations : StatefulOrm<Scaleset, ScalesetState, ScalesetO
                 from x in existingNodes
                 where x.State.ReadyForReset()
                 select x;
-
 
         Dictionary<Guid, Node> toDelete = new();
         Dictionary<Guid, Node> toReimage = new();


### PR DESCRIPTION
When `isNew` was passed, then the creation should fail if there is a `Node` that already exists. Instead, the existing `Node` was being overwritten.