### PR TITLE
Disable PoolName validation

### DIFF
--- a/src/ApiService/ApiService/OneFuzzTypes/Validated.cs
+++ b/src/ApiService/ApiService/OneFuzzTypes/Validated.cs
@@ -54,7 +54,10 @@ public abstract class ValidatedStringConverter<T> : JsonConverter<T> where T : V
 
 [JsonConverter(typeof(Converter))]
 public sealed record PoolName : ValidatedString {
-    private static bool IsValid(string input) => Check.IsNameLike(input);
+    // NOTE: PoolName is currently _not_ validated, since this 
+    // can break existing users. When CSHARP-RELEASE happens, we can
+    // try to synchronize other breaking changes with that.
+    private static bool IsValid(string input) => true;
 
     private PoolName(string value) : base(value) {
         Debug.Assert(IsValid(value));

--- a/src/ApiService/Tests/ValidatedStringTests.cs
+++ b/src/ApiService/Tests/ValidatedStringTests.cs
@@ -34,7 +34,7 @@ public class ValidatedStringTests {
         Assert.Equal(valid, Container.TryParse(name, out var _));
     }
 
-    [Theory]
+    [Theory(Skip = "Validation is disabled for now")]
     [InlineData("xyz", true)]
     [InlineData("", false)]
     [InlineData("Default-Ubuntu20.04-Standard_D2", true)]


### PR DESCRIPTION
We are going to want _some_ restrictions on pool names in future, but for now we are disabling validation to prevent breaking any existing users with non-conforming pool names.