### PR TITLE
Cache VMSS VM InstanceID lookups

### DIFF
--- a/src/ApiService/ApiService/Functions/AgentCanSchedule.cs
+++ b/src/ApiService/ApiService/Functions/AgentCanSchedule.cs
@@ -30,7 +30,6 @@ public class AgentCanSchedule {
         var canScheduleRequest = request.OkV;
 
         var node = await _context.NodeOperations.GetByMachineId(canScheduleRequest.MachineId);
-
         if (node == null) {
             _log.Warning($"Unable to find {canScheduleRequest.MachineId:Tag:MachineId}");
             return await _context.RequestHandling.NotOk(
@@ -44,14 +43,12 @@ public class AgentCanSchedule {
         }
 
         var allowed = true;
-
         if (!await _context.NodeOperations.CanProcessNewWork(node)) {
             allowed = false;
         }
 
         var task = await _context.TaskOperations.GetByTaskId(canScheduleRequest.TaskId);
         var workStopped = task == null || task.State.ShuttingDown();
-
         if (workStopped) {
             _log.Info($"Work stopped for: {canScheduleRequest.MachineId:Tag:MachineId} and {canScheduleRequest.TaskId:Tag:TaskId}");
             allowed = false;

--- a/src/ApiService/ApiService/onefuzzlib/NodeOperations.cs
+++ b/src/ApiService/ApiService/onefuzzlib/NodeOperations.cs
@@ -103,17 +103,17 @@ public class NodeOperations : StatefulOrm<Node, NodeState, NodeOperations>, INod
     }
 
     public async Async.Task<bool> ScalesetNodeExists(Node node) {
-        if (node.ScalesetId == null) {
+        var scalesetId = node.ScalesetId;
+        if (scalesetId is null) {
             return false;
         }
 
-        var scalesetResult = await _context.ScalesetOperations.GetById((Guid)(node.ScalesetId!));
+        var scalesetResult = await _context.ScalesetOperations.GetById(scalesetId.Value);
         if (!scalesetResult.IsOk || scalesetResult.OkV == null) {
             return false;
         }
-        var scaleset = scalesetResult.OkV;
 
-        var instanceId = await _context.VmssOperations.GetInstanceId(scaleset.ScalesetId, node.MachineId);
+        var instanceId = await _context.VmssOperations.GetInstanceId(scalesetResult.OkV.ScalesetId, node.MachineId);
         return instanceId.IsOk;
     }
 

--- a/src/ApiService/ApiService/onefuzzlib/VmssOperations.cs
+++ b/src/ApiService/ApiService/onefuzzlib/VmssOperations.cs
@@ -192,7 +192,8 @@ public class VmssOperations : IVmssOperations {
 
     private record InstanceIdKey(Guid Scaleset, Guid VmId);
     private Task<string> GetInstanceIdForVmId(Guid scaleset, Guid vmId)
-        => _cache.GetOrCreateAsync(new InstanceIdKey(scaleset, vmId), async _ => {
+        => _cache.GetOrCreateAsync(new InstanceIdKey(scaleset, vmId), async entry => {
+            entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(1);
             var scalesetResource = GetVmssResource(scaleset);
             var vmIdString = vmId.ToString();
             await foreach (var vm in scalesetResource.GetVirtualMachineScaleSetVms().AsAsyncEnumerable()) {

--- a/src/ApiService/ApiService/onefuzzlib/VmssOperations.cs
+++ b/src/ApiService/ApiService/onefuzzlib/VmssOperations.cs
@@ -193,7 +193,7 @@ public class VmssOperations : IVmssOperations {
     private record InstanceIdKey(Guid Scaleset, Guid VmId);
     private Task<string> GetInstanceIdForVmId(Guid scaleset, Guid vmId)
         => _cache.GetOrCreateAsync(new InstanceIdKey(scaleset, vmId), async entry => {
-            entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(1);
+            entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(10);
             var scalesetResource = GetVmssResource(scaleset);
             var vmIdString = vmId.ToString();
             await foreach (var vm in scalesetResource.GetVirtualMachineScaleSetVms().AsAsyncEnumerable()) {


### PR DESCRIPTION
This is a potentially expensive operation as we need to fetch every VM in the Scaleset to find the VMID we are looking for.

This should be safe to cache "forever" since the mapping will not change.

It seems like we should be storing the `InstanceID` instead of (as well as?) the VMID, but that is hard to change at the moment. Perhaps after C# port is completed.