### PR TITLE
CLI: Retry on connection reset

### DIFF
--- a/src/cli/onefuzz/backend.py
+++ b/src/cli/onefuzz/backend.py
@@ -323,6 +323,10 @@ class Backend:
                 check_application_error(response)
 
                 LOGGER.info("request bad status code: %s", response.status_code)
+            except ConnectionResetError as err:
+                # in our case this means some kind of lower-level timeout was hit;
+                # treat it as a retryable error
+                LOGGER.info("connection reset error: %s", err)
             except requests.exceptions.ConnectionError as err:
                 LOGGER.info("request connection error: %s", err)
             except requests.exceptions.ReadTimeout as err:

--- a/src/cli/onefuzz/cli.py
+++ b/src/cli/onefuzz/cli.py
@@ -543,6 +543,7 @@ def log_exception(args: argparse.Namespace, err: Exception) -> None:
             LOGGER.error("traceback: %s", x)
     LOGGER.error("command failed: %s", " ".join([str(x) for x in err.args]))
 
+
 def set_tcp_keepalive() -> None:
     value = (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
     # monkey-patch the default socket options to enable TCP keep-alive
@@ -552,6 +553,7 @@ def set_tcp_keepalive() -> None:
     # https://urllib3.readthedocs.io/en/stable/reference/urllib3.connection.html?highlight=keep-alive#:~:text=For%20example%2C%20if,socket.SO_KEEPALIVE%2C%201)%2C%0A%5D
     if not value in urllib3.connection.HTTPConnection.default_socket_options:
         urllib3.connection.HTTPConnection.default_socket_options.extend((value,))
+
 
 def execute_api(api: Any, api_types: List[Any], version: str) -> int:
     set_tcp_keepalive()

--- a/src/cli/onefuzz/cli.py
+++ b/src/cli/onefuzz/cli.py
@@ -16,7 +16,6 @@ import os
 import socket
 import sys
 import traceback
-import urllib3.connection
 from enum import Enum
 from typing import (
     Any,
@@ -33,6 +32,7 @@ from typing import (
 from uuid import UUID
 
 import jmespath
+import urllib3.connection
 from docstring_parser import parse as parse_docstring
 from msrest.serialization import Model
 from onefuzztypes.models import SecretData

--- a/src/cli/onefuzz/cli.py
+++ b/src/cli/onefuzz/cli.py
@@ -551,7 +551,7 @@ def set_tcp_keepalive() -> None:
     # Azure Load Balancer default timeout (4 minutes)
     #
     # https://urllib3.readthedocs.io/en/stable/reference/urllib3.connection.html?highlight=keep-alive#:~:text=For%20example%2C%20if,socket.SO_KEEPALIVE%2C%201)%2C%0A%5D
-    if not value in urllib3.connection.HTTPConnection.default_socket_options:
+    if value not in urllib3.connection.HTTPConnection.default_socket_options:
         urllib3.connection.HTTPConnection.default_socket_options.extend((value,))
 
 


### PR DESCRIPTION
In our integration test run we are seeing some connection-reset errors which causes the CLI operation to fail.

To fix this:
1. Set TCP-KeepAlive to keep Azure load balancer connections alive longer than the default timeout (4 minutes).
2. Treat ConnectionResetError as retryable.
