### PR TITLE
Allow worker loops to continue after errors

### DIFF
--- a/src/ApiService/ApiService/Functions/TimerWorkers.cs
+++ b/src/ApiService/ApiService/Functions/TimerWorkers.cs
@@ -48,7 +48,7 @@ public class TimerWorkers {
             try {
                 _log.Info($"updating pool: {pool.PoolId:Tag:PoolId} ({pool.Name:Tag:PoolName}) - state: {pool.State:Tag:PoolState}");
                 var newPool = await _poolOps.ProcessStateUpdate(pool);
-                _log.Info($"completed updating pool - now in state {newPool.State:Tag:PoolState}");
+                _log.Info($"completed updating pool: {pool.PoolId:Tag:PoolId} ({pool.Name:Tag:PoolName}) - now in state {newPool.State:Tag:PoolState}");
             } catch (Exception ex) {
                 _log.Exception(ex, $"failed to process pool");
             }
@@ -68,7 +68,7 @@ public class TimerWorkers {
             try {
                 _log.Info($"updating node: {node.MachineId:Tag:MachineId} - state: {node.State:Tag:NodeState}");
                 var newNode = await _nodeOps.ProcessStateUpdate(node);
-                _log.Info($"completed updating node - now in state {newNode.State:Tag:NodeState}");
+                _log.Info($"completed updating node: {node.MachineId:Tag:MachineId} - now in state {newNode.State:Tag:NodeState}");
             } catch (Exception ex) {
                 _log.Exception(ex, $"failed to process node");
             }
@@ -79,7 +79,7 @@ public class TimerWorkers {
             try {
                 _log.Info($"updating scaleset: {scaleset.ScalesetId:Tag:ScalesetId} - state: {scaleset.State:Tag:ScalesetState}");
                 var newScaleset = await ProcessScalesets(scaleset);
-                _log.Info($"completed updating scaleset - now in state {newScaleset.State:Tag:ScalesetState}");
+                _log.Info($"completed updating scaleset: {scaleset.ScalesetId:Tag:ScalesetId} - now in state {newScaleset.State:Tag:ScalesetState}");
             } catch (Exception ex) {
                 _log.Exception(ex, $"failed to process scaleset");
             }

--- a/src/ApiService/ApiService/Functions/TimerWorkers.cs
+++ b/src/ApiService/ApiService/Functions/TimerWorkers.cs
@@ -15,7 +15,7 @@ public class TimerWorkers {
         _nodeOps = context.NodeOperations;
     }
 
-    private async Async.Task ProcessScalesets(Service.Scaleset scaleset) {
+    private async Async.Task<Service.Scaleset> ProcessScalesets(Service.Scaleset scaleset) {
         _log.Verbose($"checking scaleset for updates: {scaleset.ScalesetId:Tag:ScalesetId}");
 
         scaleset = await _scaleSetOps.UpdateConfigs(scaleset);
@@ -28,12 +28,12 @@ public class TimerWorkers {
         var (touched, ss) = await _scaleSetOps.CleanupNodes(scaleset);
         if (touched) {
             _log.Verbose($"scaleset needed cleanup: {scaleset.ScalesetId:Tag:ScalesetId}");
-            return;
+            return ss;
         }
 
         scaleset = ss;
         scaleset = await _scaleSetOps.SyncScalesetSize(scaleset);
-        _ = await _scaleSetOps.ProcessStateUpdate(scaleset);
+        return await _scaleSetOps.ProcessStateUpdate(scaleset);
     }
 
 
@@ -43,11 +43,14 @@ public class TimerWorkers {
         // (such as shutdown or resize) happen during this iteration `timer_worker`
         // rather than the following iteration.
 
-        var pools = _poolOps.SearchAll();
+        var pools = _poolOps.SearchStates(states: PoolStateHelper.NeedsWork);
         await foreach (var pool in pools) {
-            if (PoolStateHelper.NeedsWork.Contains(pool.State)) {
-                _log.Info($"update pool: {pool.PoolId:Tag:PoolId} - {pool.Name:Tag:PoolName}");
-                _ = await _poolOps.ProcessStateUpdate(pool);
+            try {
+                _log.Info($"updating pool: {pool.PoolId:Tag:PoolId} ({pool.Name:Tag:PoolName}) - state: {pool.State:Tag:PoolState}");
+                var newPool = await _poolOps.ProcessStateUpdate(pool);
+                _log.Info($"completed updating pool - now in state {newPool.State:Tag:PoolState}");
+            } catch (Exception ex) {
+                _log.Exception(ex, $"failed to process pool");
             }
         }
 
@@ -62,13 +65,24 @@ public class TimerWorkers {
 
         var nodes = _nodeOps.SearchStates(states: NodeStateHelper.NeedsWorkStates);
         await foreach (var node in nodes) {
-            _log.Info($"update node: {node.MachineId:Tag:MachineId}");
-            _ = await _nodeOps.ProcessStateUpdate(node);
+            try {
+                _log.Info($"updating node: {node.MachineId:Tag:MachineId} - state: {node.State:Tag:NodeState}");
+                var newNode = await _nodeOps.ProcessStateUpdate(node);
+                _log.Info($"completed updating node - now in state {newNode.State:Tag:NodeState}");
+            } catch (Exception ex) {
+                _log.Exception(ex, $"failed to process node");
+            }
         }
 
         var scalesets = _scaleSetOps.SearchAll();
         await foreach (var scaleset in scalesets) {
-            await ProcessScalesets(scaleset);
+            try {
+                _log.Info($"updating scaleset: {scaleset.ScalesetId:Tag:ScalesetId} - state: {scaleset.State:Tag:ScalesetState}");
+                var newScaleset = await ProcessScalesets(scaleset);
+                _log.Info($"completed updating scaleset - now in state {newScaleset.State:Tag:ScalesetState}");
+            } catch (Exception ex) {
+                _log.Exception(ex, $"failed to process scaleset");
+            }
         }
     }
 }


### PR DESCRIPTION
During `TimerWorkers` if updating one entity fails and throws an exception we will abandon the whole update. Instead log the error and continue to attempt to process the remaining entities. This will allow us to make progress even if one entity is stuck.
