### PR TITLE
Attempt to fix `integration-tests-linux` failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -649,6 +649,20 @@ jobs:
     needs:
       - build-integration-tests-linux
       - dotnet-fuzzing-tools-linux
+      # even though this job doesn't use the artifacts for these other jobs,
+      # we must include them or we get spurious failures when the download-artifact
+      # step tries to download the named artifact which includes files from
+      # all of these jobs
+      - agent
+      - azcopy
+      - cli
+      - onefuzztypes
+      - proxy
+      - service
+      - afl
+      - aflpp
+      - radamsa-linux
+      - radamsa-win64
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v3


### PR DESCRIPTION
Attempting to fix the failure we see occasionally, like [here](https://github.com/microsoft/onefuzz/actions/runs/3184845545/jobs/5193798358).

The problem seems to be that we have multiple jobs uploading into the same named artifact; if we only wait for one of those jobs to finish then the artifact is not fully complete and we get 404s for different parts of the artifact occasionally when trying to download it. Potentially there is some kind of race where the artifact is marked as containing a file but doesn't actually have the file data yet. 