### PR TITLE
Change the verbosity of the azcopy logs

### DIFF
--- a/src/agent/onefuzz/src/az_copy.rs
+++ b/src/agent/onefuzz/src/az_copy.rs
@@ -81,8 +81,6 @@ async fn az_impl(mode: Mode, src: &OsStr, dst: &OsStr, args: &[&str]) -> Result<
         .arg(mode.to_string())
         .arg(&src)
         .arg(&dst)
-        .arg("--log-level")
-        .arg("ERROR")
         .args(args);
 
     let output = cmd


### PR DESCRIPTION
Changing the log level to INFO [(the default value)](https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azcopy-configure#change-the-default-log-level) To get more information about the azcopy failure