### PR TITLE
Only fetch VM InstanceView data when required

### DIFF
--- a/src/ApiService/ApiService/onefuzzlib/ProxyOperations.cs
+++ b/src/ApiService/ApiService/onefuzzlib/ProxyOperations.cs
@@ -1,7 +1,6 @@
 ﻿using System.Threading.Tasks;
 using ApiService.OneFuzzLib.Orm;
 using Azure.Data.Tables;
-using Azure.ResourceManager.Compute;
 using Azure.ResourceManager.Compute.Models;
 using Azure.Storage.Sas;
 using Microsoft.OneFuzz.Service.OneFuzzLib.Orm;
@@ -175,7 +174,13 @@ public class ProxyOperations : StatefulOrm<Proxy, VmState, ProxyOperations>, IPr
 
         if (vmData != null) {
             if (vmData.ProvisioningState == "Failed") {
-                return await SetProvisionFailed(proxy, vmData);
+                var failedVmData = await _context.VmOperations.GetVmWithInstanceView(vm.Name);
+                if (failedVmData is null) {
+                    // this should exist since we just loaded the VM above
+                    throw new InvalidOperationException("Unable to load instance-view data for VM");
+                }
+
+                return await SetProvisionFailed(proxy, failedVmData.InstanceView);
             } else {
                 await SaveProxyConfig(proxy);
                 return await SetState(proxy, VmState.ExtensionsLaunch);
@@ -207,8 +212,8 @@ public class ProxyOperations : StatefulOrm<Proxy, VmState, ProxyOperations>, IPr
         }
     }
 
-    private async System.Threading.Tasks.Task<Proxy> SetProvisionFailed(Proxy proxy, VirtualMachineData vmData) {
-        var errors = GetErrors(proxy, vmData).ToArray();
+    private async System.Threading.Tasks.Task<Proxy> SetProvisionFailed(Proxy proxy, VirtualMachineInstanceView? instanceView) {
+        var errors = GetErrors(proxy, instanceView).ToArray();
         return await SetFailed(proxy, new Error(ErrorCode.PROXY_FAILED, errors));
     }
 
@@ -223,8 +228,7 @@ public class ProxyOperations : StatefulOrm<Proxy, VmState, ProxyOperations>, IPr
     }
 
 
-    private static IEnumerable<string> GetErrors(Proxy proxy, VirtualMachineData vmData) {
-        var instanceView = vmData.InstanceView;
+    private static IEnumerable<string> GetErrors(Proxy proxy, VirtualMachineInstanceView? instanceView) {
         yield return "provisioning failed";
         if (instanceView is null) {
             yield break;
@@ -262,13 +266,18 @@ public class ProxyOperations : StatefulOrm<Proxy, VmState, ProxyOperations>, IPr
         var config = await _context.ConfigOperations.Fetch();
         var vm = GetVm(proxy, config);
         var vmData = await _context.VmOperations.GetVm(vm.Name);
-
         if (vmData is null) {
             return await SetFailed(proxy, new Error(ErrorCode.PROXY_FAILED, new[] { "azure not able to find vm" }));
         }
 
         if (vmData.ProvisioningState == "Failed") {
-            return await SetProvisionFailed(proxy, vmData);
+            var failedVmData = await _context.VmOperations.GetVm(vm.Name);
+            if (failedVmData is null) {
+                // this should exist since we just loaded the VM above
+                throw new InvalidOperationException("Unable to load instance-view data for VM");
+            }
+
+            return await SetProvisionFailed(proxy, failedVmData.InstanceView);
         }
 
         var ip = await _context.IpOperations.GetPublicIp(vmData.NetworkProfile.NetworkInterfaces[0].Id);

--- a/src/ApiService/ApiService/onefuzzlib/ProxyOperations.cs
+++ b/src/ApiService/ApiService/onefuzzlib/ProxyOperations.cs
@@ -271,7 +271,7 @@ public class ProxyOperations : StatefulOrm<Proxy, VmState, ProxyOperations>, IPr
         }
 
         if (vmData.ProvisioningState == "Failed") {
-            var failedVmData = await _context.VmOperations.GetVm(vm.Name);
+            var failedVmData = await _context.VmOperations.GetVmWithInstanceView(vm.Name);
             if (failedVmData is null) {
                 // this should exist since we just loaded the VM above
                 throw new InvalidOperationException("Unable to load instance-view data for VM");

--- a/src/ApiService/ApiService/onefuzzlib/VmOperations.cs
+++ b/src/ApiService/ApiService/onefuzzlib/VmOperations.cs
@@ -12,6 +12,7 @@ public interface IVmOperations {
     Async.Task<bool> HasComponents(string name);
 
     Task<VirtualMachineData?> GetVm(string name);
+
     Task<VirtualMachineData?> GetVmWithInstanceView(string name);
 
     Async.Task<bool> Delete(Vm vm);

--- a/src/ApiService/ApiService/onefuzzlib/VmOperations.cs
+++ b/src/ApiService/ApiService/onefuzzlib/VmOperations.cs
@@ -12,6 +12,7 @@ public interface IVmOperations {
     Async.Task<bool> HasComponents(string name);
 
     Task<VirtualMachineData?> GetVm(string name);
+    Task<VirtualMachineData?> GetVmWithInstanceView(string name);
 
     Async.Task<bool> Delete(Vm vm);
 
@@ -65,22 +66,31 @@ public class VmOperations : IVmOperations {
     }
 
     public async Task<VirtualMachineData?> GetVm(string name) {
-        // _logTracer.Debug($"getting vm: {name}");
         try {
-            var result = await _context.Creds.GetResourceGroupResource().GetVirtualMachineAsync(name, InstanceViewTypes.InstanceView);
-            if (result == null) {
+            var result = await _context.Creds.GetResourceGroupResource().GetVirtualMachineAsync(name);
+            if (result is null || !result.Value.HasData) {
                 return null;
             }
-            if (result.Value.HasData) {
-                return result.Value.Data;
-            }
 
+            return result.Value.Data;
         } catch (RequestFailedException) {
-            // _logTracer.Debug($"vm does not exist {ex});
+            // TODO: we shouldn't hide this error, only if it doesn't exist
             return null;
         }
+    }
 
-        return null;
+    public async Task<VirtualMachineData?> GetVmWithInstanceView(string name) {
+        try {
+            var result = await _context.Creds.GetResourceGroupResource().GetVirtualMachineAsync(name, InstanceViewTypes.InstanceView);
+            if (result is null || !result.Value.HasData) {
+                return null;
+            }
+
+            return result.Value.Data;
+        } catch (RequestFailedException) {
+            // TODO: we shouldn't hide this error, only if it doesn't exist
+            return null;
+        }
     }
 
     public async Async.Task<bool> Delete(Vm vm) {


### PR DESCRIPTION
Fetching the `InstanceView` data for a VM is considered a “high-cost” operation by VMSS and contributes to throttling. In most cases we do not need this data, so split the `GetVm` method into two versions, one that fetches the `InstanceView` data and one that doesn’t.

We only need `InstanceView` data during VM provisioning failures, to see what went wrong.
