### PR TITLE
Improve scaling protection logging

### DIFF
--- a/src/ApiService/ApiService/onefuzzlib/NodeOperations.cs
+++ b/src/ApiService/ApiService/onefuzzlib/NodeOperations.cs
@@ -86,7 +86,11 @@ public class NodeOperations : StatefulOrm<Node, NodeState, NodeOperations>, INod
         if (node.ScalesetId is Guid scalesetId && await TryGetNodeInfo(node) is NodeInfo nodeInfo) {
 
             _logTracer.Info($"Setting scale-in protection on node {node.MachineId:Tag:MachineId}");
-            return await _context.VmssOperations.UpdateScaleInProtection(nodeInfo.Scaleset, node.MachineId, protectFromScaleIn: true);
+            var r = await _context.VmssOperations.UpdateScaleInProtection(nodeInfo.Scaleset, node.MachineId, protectFromScaleIn: true);
+            if (!r.IsOk) {
+                _logTracer.Error(r.ErrorV);
+            }
+            return r;
         }
 
         return OneFuzzResultVoid.Ok;
@@ -97,7 +101,11 @@ public class NodeOperations : StatefulOrm<Node, NodeState, NodeOperations>, INod
             node.ScalesetId is Guid scalesetId &&
             await TryGetNodeInfo(node) is NodeInfo nodeInfo) {
             _logTracer.Info($"Removing scale-in protection on node {node.MachineId:Tag:MachineId}");
-            return await _context.VmssOperations.UpdateScaleInProtection(nodeInfo.Scaleset, node.MachineId, protectFromScaleIn: false);
+            var r = await _context.VmssOperations.UpdateScaleInProtection(nodeInfo.Scaleset, node.MachineId, protectFromScaleIn: false);
+            if (!r.IsOk) {
+                _logTracer.Error(r.ErrorV);
+            }
+            return r;
         }
 
         return OneFuzzResultVoid.Ok;

--- a/src/ApiService/ApiService/onefuzzlib/VmssOperations.cs
+++ b/src/ApiService/ApiService/onefuzzlib/VmssOperations.cs
@@ -252,8 +252,7 @@ public class VmssOperations : IVmssOperations {
         var instanceId = instanceIdResult.OkV;
         var data = new VirtualMachineScaleSetVmData(scaleset.Region) {
             ProtectionPolicy = new VirtualMachineScaleSetVmProtectionPolicy {
-                ProtectFromScaleIn = true,
-                ProtectFromScaleSetActions = true
+                ProtectFromScaleIn = protectFromScaleIn,
             }
         };
         var vmCollection = GetVmssResource(scaleset.ScalesetId).GetVirtualMachineScaleSetVms();

--- a/src/ApiService/ApiService/onefuzzlib/VmssOperations.cs
+++ b/src/ApiService/ApiService/onefuzzlib/VmssOperations.cs
@@ -253,6 +253,7 @@ public class VmssOperations : IVmssOperations {
         var data = new VirtualMachineScaleSetVmData(scaleset.Region) {
             ProtectionPolicy = new VirtualMachineScaleSetVmProtectionPolicy {
                 ProtectFromScaleIn = protectFromScaleIn,
+                ProtectFromScaleSetActions = false,
             }
         };
         var vmCollection = GetVmssResource(scaleset.ScalesetId).GetVirtualMachineScaleSetVms();


### PR DESCRIPTION
Even if the caller doesn't care about the result of the scaling protection change, log when we fail to make the update to make it easier to trace in prod.