### PR TITLE
Add deleteAll to the orm

### DIFF
--- a/src/ApiService/ApiService/onefuzzlib/NodeMessageOperations.cs
+++ b/src/ApiService/ApiService/onefuzzlib/NodeMessageOperations.cs
@@ -31,11 +31,10 @@ public class NodeMessageOperations : Orm<NodeMessage>, INodeMessageOperations {
     public async Async.Task ClearMessages(Guid machineId) {
         _logTracer.Info($"clearing messages for node {machineId:Tag:MachineId}");
 
-        await foreach (var message in GetMessage(machineId)) {
-            var r = await Delete(message);
-            if (!r.IsOk) {
-                _logTracer.WithHttpStatus(r.ErrorV).Error($"failed to delete message for node {machineId:Tag:MachineId}");
-            }
+        var result = await DeleteAll(new (string?, string?)[] { (machineId.ToString(), null) });
+
+        if (result.FailureCount > 0) {
+            _logTracer.Error($"failed to delete {result.FailureCount:Tag:FailedDeleteMessageCount} messages for node {machineId:Tag:MachineId}");
         }
     }
 

--- a/src/ApiService/ApiService/onefuzzlib/Utils.cs
+++ b/src/ApiService/ApiService/onefuzzlib/Utils.cs
@@ -15,3 +15,22 @@ public static class ObjectExtention {
     public static Async.Task IgnoreResult<T>(this Async.Task<T> task)
         => task;
 }
+
+public static class IAsyncEnumerableExtension {
+    public static async IAsyncEnumerable<List<TSource>> Chunk<TSource>(this IAsyncEnumerable<TSource> source, int size) {
+
+        var enumerator = source.GetAsyncEnumerator();
+        List<TSource> result = new List<TSource>(size);
+        while (await enumerator.MoveNextAsync()) {
+            if (result.Count == size) {
+                yield return result;
+                result = new List<TSource>(size);
+            }
+            result.Add(enumerator.Current);
+        }
+
+        if (result.Count > 0) {
+            yield return result;
+        }
+    }
+}

--- a/src/ApiService/ApiService/onefuzzlib/Utils.cs
+++ b/src/ApiService/ApiService/onefuzzlib/Utils.cs
@@ -19,14 +19,19 @@ public static class ObjectExtention {
 public static class IAsyncEnumerableExtension {
     public static async IAsyncEnumerable<List<TSource>> Chunk<TSource>(this IAsyncEnumerable<TSource> source, int size) {
 
+        if (size <= 0) {
+            throw new ArgumentException("size must be greater than 0");
+        }
+
         var enumerator = source.GetAsyncEnumerator();
         List<TSource> result = new List<TSource>(size);
         while (await enumerator.MoveNextAsync()) {
+            result.Add(enumerator.Current);
+
             if (result.Count == size) {
                 yield return result;
                 result = new List<TSource>(size);
             }
-            result.Add(enumerator.Current);
         }
 
         if (result.Count > 0) {

--- a/src/ApiService/ApiService/onefuzzlib/orm/Orm.cs
+++ b/src/ApiService/ApiService/onefuzzlib/orm/Orm.cs
@@ -172,12 +172,11 @@ namespace ApiService.OneFuzzLib.Orm {
 
             var requests = await pages
                 .Chunk(MAX_TRANSACTION_SIZE)
-                .Where(chunk => chunk.Count > 0)
-                .Select(chunk =>
-                    chunk.Select(e => new TableTransactionAction(TableTransactionActionType.Delete, e))
-                )
-                .Select(t => tableClient.SubmitTransactionAsync(t))
-                .ToArrayAsync();
+                .Select(chunk => {
+                    var transactions = chunk.Select(e => new TableTransactionAction(TableTransactionActionType.Delete, e));
+                    return tableClient.SubmitTransactionAsync(transactions);
+                })
+                .ToListAsync();
 
             var responses = await System.Threading.Tasks.Task.WhenAll(requests);
             var (successes, failures) = responses


### PR DESCRIPTION
## Summary of the Pull Request

Introduce a DeleteAll operation to speedup the deletion of multiple entities.

The new method is able to delete 13404 Nodemessges in 4s