### PR TITLE
Produce an error if coverage recording failed due to timeout

### DIFF
--- a/src/agent/coverage/src/block/linux.rs
+++ b/src/agent/coverage/src/block/linux.rs
@@ -46,7 +46,7 @@ impl<'c> Recorder<'c> {
         let timer_flag = timed_out.clone();
         let timer = Timer::new(timeout, move || {
             if child.kill().is_ok() {
-                timer_flag.as_ref().store(true, Ordering::Relaxed);
+                timer_flag.store(true, Ordering::Relaxed);
             }
         });
 


### PR DESCRIPTION
Closes #2520.

After investigation the underlying cause here is that the process is getting killed due to timeout, but we don't report the timeout or produce an error. Modify the coverage code so that it fails if timeout is hit.

## Open questions

Do we want to be able to support a partial coverage instead?