### PR TITLE
Ignoring the scanning log file when reporting an issue with azcopy

### DIFF
--- a/src/agent/onefuzz/src/az_copy.rs
+++ b/src/agent/onefuzz/src/az_copy.rs
@@ -49,14 +49,20 @@ impl fmt::Display for Mode {
 // caller, rather than the default AZCOPY log location.
 async fn read_azcopy_log_file(path: &Path) -> Result<String> {
     let mut entries = fs::read_dir(path).await?;
-    // there should be only up to one file in azcopy_log dir
-    if let Some(file) = entries.next_entry().await? {
-        fs::read_to_string(file.path())
+    // There should 2 files in azcopy_log dir, one is the log file,
+    // the other is scanning log file (added in 10.9.0)
+    while let Some(file) = entries.next_entry().await? {
+        // There should 2 files in azcopy_log dir, one is the log file, the other is scanning log file (added in 10.9.0)
+        if file.path().to_string_lossy().contains("scanning") {
+            continue;
+        }
+
+        return fs::read_to_string(file.path())
             .await
-            .with_context(|| format!("unable to read file: {}", file.path().display()))
-    } else {
-        bail!("no log file in path: {}", path.display());
+            .with_context(|| format!("unable to read file: {}", file.path().display()));
     }
+
+    bail!("no log file in path: {}", path.display());
 }
 
 // attempt to redact an azcopy argument if it could possibly be a SAS URL

--- a/src/agent/onefuzz/src/az_copy.rs
+++ b/src/agent/onefuzz/src/az_copy.rs
@@ -52,7 +52,6 @@ async fn read_azcopy_log_file(path: &Path) -> Result<String> {
     // There should 2 files in azcopy_log dir, one is the log file,
     // the other is scanning log file (added in 10.9.0)
     while let Some(file) = entries.next_entry().await? {
-        // There should 2 files in azcopy_log dir, one is the log file, the other is scanning log file (added in 10.9.0)
         if file.path().to_string_lossy().contains("scanning") {
             continue;
         }


### PR DESCRIPTION
## Summary of the Pull Request

The current code assumes that only one log file is produced by azcopy. But since [10.9.0](https://github.com/Azure/azure-storage-azcopy/blob/main/ChangeLog.md#version-1090) a scanning log file has been introduced.
This PR ignores the scanning log file.