### PR TITLE
Reduce number of ARM calls in ListVmss

### DIFF
--- a/src/ApiService/ApiService/onefuzzlib/ScalesetOperations.cs
+++ b/src/ApiService/ApiService/onefuzzlib/ScalesetOperations.cs
@@ -871,7 +871,7 @@ public class ScalesetOperations : StatefulOrm<Scaleset, ScalesetState, ScalesetO
                     scaleset.ScalesetId,
                     (vmResource) => vmResource?.Data?.ProtectionPolicy?.ProtectFromScaleIn != null
                         && vmResource.Data.ProtectionPolicy.ProtectFromScaleIn.Value
-                ).ToListAsync();
+                );
 
                 _logTracer.Info($"{JsonSerializer.Serialize(vmsWithProtection):Tag:VMsWithProtection}");
                 if (vmsWithProtection != null) {

--- a/src/ApiService/ApiService/onefuzzlib/ScalesetOperations.cs
+++ b/src/ApiService/ApiService/onefuzzlib/ScalesetOperations.cs
@@ -871,7 +871,7 @@ public class ScalesetOperations : StatefulOrm<Scaleset, ScalesetState, ScalesetO
                     scaleset.ScalesetId,
                     (vmResource) => vmResource?.Data?.ProtectionPolicy?.ProtectFromScaleIn != null
                         && vmResource.Data.ProtectionPolicy.ProtectFromScaleIn.Value
-                );
+                ).ToListAsync();
 
                 _logTracer.Info($"{JsonSerializer.Serialize(vmsWithProtection):Tag:VMsWithProtection}");
                 if (vmsWithProtection != null) {

--- a/src/ApiService/ApiService/onefuzzlib/VmssOperations.cs
+++ b/src/ApiService/ApiService/onefuzzlib/VmssOperations.cs
@@ -417,7 +417,10 @@ public class VmssOperations : IVmssOperations {
             IAsyncEnumerable<VirtualMachineScaleSetVmResource> vms =
                 GetVmssResource(name).GetVirtualMachineScaleSetVms();
 
-            return await vms.Where(vm => filter == null || filter(vm)).Select(vm => vm.Data.InstanceId).ToListAsync();
+            return await vms
+                .SelectAwait(async vm => vm.HasData ? vm : await vm.GetAsync())
+                .Where(vm => filter == null || filter(vm))
+                .Select(vm => vm.Data.InstanceId).ToListAsync();
         } catch (RequestFailedException ex) {
             _log.Exception(ex, $"cloud error listing vmss: {name:Tag:VmssName}");
             return null;

--- a/src/ApiService/ApiService/onefuzzlib/VmssOperations.cs
+++ b/src/ApiService/ApiService/onefuzzlib/VmssOperations.cs
@@ -420,7 +420,8 @@ public class VmssOperations : IVmssOperations {
             return await vms
                 .SelectAwait(async vm => vm.HasData ? vm : await vm.GetAsync())
                 .Where(vm => filter == null || filter(vm))
-                .Select(vm => vm.Data.InstanceId).ToListAsync();
+                .Select(vm => vm.Data.InstanceId)
+                .ToListAsync();
         } catch (RequestFailedException ex) {
             _log.Exception(ex, $"cloud error listing vmss: {name:Tag:VmssName}");
             return null;

--- a/src/ApiService/ApiService/onefuzzlib/VmssOperations.cs
+++ b/src/ApiService/ApiService/onefuzzlib/VmssOperations.cs
@@ -413,16 +413,9 @@ public class VmssOperations : IVmssOperations {
 
     public IAsyncEnumerable<string> ListVmss(Guid name, Func<VirtualMachineScaleSetVmResource, bool>? filter) {
         try {
-            var vmssId =
-                VirtualMachineScaleSetResource.CreateResourceIdentifier(
-                    _creds.GetSubscription(),
-                    _creds.GetBaseResourceGroup(),
-                    name.ToString());
-
             // have to assign to a typed variable so that the Where call can be disambiguated
             IAsyncEnumerable<VirtualMachineScaleSetVmResource> vms =
-                _creds.ArmClient.GetVirtualMachineScaleSetResource(vmssId)
-                .GetVirtualMachineScaleSetVms();
+                GetVmssResource(name).GetVirtualMachineScaleSetVms();
 
             return vms
                 .Where(vm => filter == null || filter(vm))

--- a/src/ApiService/IntegrationTests/Fakes/TestVmssOperations.cs
+++ b/src/ApiService/IntegrationTests/Fakes/TestVmssOperations.cs
@@ -48,7 +48,7 @@ sealed class TestVmssOperations : IVmssOperations {
         throw new NotImplementedException();
     }
 
-    public IAsyncEnumerable<string> ListVmss(Guid name, Func<VirtualMachineScaleSetVmResource, bool>? filter) {
+    public Task<List<string>?> ListVmss(Guid name, Func<VirtualMachineScaleSetVmResource, bool>? filter) {
         throw new NotImplementedException();
     }
 

--- a/src/ApiService/IntegrationTests/Fakes/TestVmssOperations.cs
+++ b/src/ApiService/IntegrationTests/Fakes/TestVmssOperations.cs
@@ -48,7 +48,7 @@ sealed class TestVmssOperations : IVmssOperations {
         throw new NotImplementedException();
     }
 
-    public Task<List<string>?> ListVmss(Guid name, Func<VirtualMachineScaleSetVmResource, bool>? filter) {
+    public IAsyncEnumerable<VirtualMachineScaleSetVmResource> ListVmss(Guid name) {
         throw new NotImplementedException();
     }
 

--- a/src/ApiService/IntegrationTests/Fakes/TestVmssOperations.cs
+++ b/src/ApiService/IntegrationTests/Fakes/TestVmssOperations.cs
@@ -48,7 +48,7 @@ sealed class TestVmssOperations : IVmssOperations {
         throw new NotImplementedException();
     }
 
-    public Task<List<string>?> ListVmss(Guid name, Func<VirtualMachineScaleSetVmResource, bool>? filter) {
+    public IAsyncEnumerable<string> ListVmss(Guid name, Func<VirtualMachineScaleSetVmResource, bool>? filter) {
         throw new NotImplementedException();
     }
 


### PR DESCRIPTION
1. `ListVmss` was invoking `GetVirtualMachineScaleSetAsync` and then `GetVirtualMachineScaleSetVms`; instead we can get the VMSS resource directly and invoke `GetVirtualMachineScaleSetVms` on it.

2. I also removed some unneeded invocations of `AsAsyncEnumerable` which might be turning async enumerables into sync enumerables.

3. Do the same `HasData` check in the instance ID lookup that we were already doing in `ListVmss`.

After this change (#3) we no longer do any `GET`s against individual VMSS VMs during the `check-pr` run: 
![image](https://user-images.githubusercontent.com/12575/198410236-250ed8d7-f7a1-4c2d-8bf4-2ebd1c1a0f7a.png)
