### PR TITLE
fix onefuzz address

### DIFF
--- a/src/deployment/bicep-templates/function-settings.bicep
+++ b/src/deployment/bicep-templates/function-settings.bicep
@@ -70,7 +70,7 @@ resource functionSettings 'Microsoft.Web/sites/config@2021-03-01' = {
       AzureSignalRConnectionString: signal_r_connection_string
       AzureSignalRServiceTransportType: 'Transient'
       ONEFUZZ_INSTANCE_NAME: instance_name
-      ONEFUZZ_INSTANCE: 'https://${name}.azurewebsites.net'
+      ONEFUZZ_INSTANCE: 'https://${instance_name}.azurewebsites.net'
       ONEFUZZ_RESOURCE_GROUP: resourceGroup().id
       ONEFUZZ_DATA_STORAGE: fuzz_storage_resource_id
       ONEFUZZ_FUNC_STORAGE: func_storage_resource_id


### PR DESCRIPTION
fix onefuzz address
This config value is used to generate the `input_url` in the report. The `existing` code was generating a value pointing to the temporary `-net` address.