### PR TITLE
Extend default coverage timeout to 120s

### DIFF
--- a/src/agent/coverage/examples/src-cov.rs
+++ b/src/agent/coverage/examples/src-cov.rs
@@ -22,7 +22,7 @@ struct Opt {
     #[structopt(min_values = 2)]
     cmd: Vec<String>,
 
-    #[structopt(short, long, long_help = "Timeout in ms", default_value = "5000")]
+    #[structopt(short, long, long_help = "Timeout in ms", default_value = "120000")]
     timeout: u64,
 
     #[structopt(short = "x", long)]

--- a/src/agent/onefuzz-task/src/tasks/coverage/dotnet.rs
+++ b/src/agent/onefuzz-task/src/tasks/coverage/dotnet.rs
@@ -30,7 +30,7 @@ use crate::tasks::{
 };
 
 const MAX_COVERAGE_RECORDING_ATTEMPTS: usize = 2;
-const DEFAULT_TARGET_TIMEOUT: Duration = Duration::from_secs(600);
+const DEFAULT_TARGET_TIMEOUT: Duration = Duration::from_secs(120);
 
 #[derive(Debug, Deserialize)]
 pub struct Config {

--- a/src/agent/onefuzz-task/src/tasks/coverage/dotnet.rs
+++ b/src/agent/onefuzz-task/src/tasks/coverage/dotnet.rs
@@ -30,7 +30,7 @@ use crate::tasks::{
 };
 
 const MAX_COVERAGE_RECORDING_ATTEMPTS: usize = 2;
-const DEFAULT_TARGET_TIMEOUT: Duration = Duration::from_secs(120);
+const DEFAULT_TARGET_TIMEOUT: Duration = Duration::from_secs(600);
 
 #[derive(Debug, Deserialize)]
 pub struct Config {

--- a/src/agent/onefuzz-task/src/tasks/coverage/dotnet.rs
+++ b/src/agent/onefuzz-task/src/tasks/coverage/dotnet.rs
@@ -30,7 +30,7 @@ use crate::tasks::{
 };
 
 const MAX_COVERAGE_RECORDING_ATTEMPTS: usize = 2;
-const DEFAULT_TARGET_TIMEOUT: Duration = Duration::from_secs(5);
+const DEFAULT_TARGET_TIMEOUT: Duration = Duration::from_secs(120);
 
 #[derive(Debug, Deserialize)]
 pub struct Config {

--- a/src/agent/onefuzz-task/src/tasks/coverage/generic.rs
+++ b/src/agent/onefuzz-task/src/tasks/coverage/generic.rs
@@ -36,7 +36,7 @@ const COVERAGE_FILE: &str = "coverage.json";
 const SOURCE_COVERAGE_FILE: &str = "source-coverage.json";
 const MODULE_CACHE_FILE: &str = "module-cache.json";
 
-const DEFAULT_TARGET_TIMEOUT: Duration = Duration::from_secs(5);
+const DEFAULT_TARGET_TIMEOUT: Duration = Duration::from_secs(120);
 
 #[derive(Debug, Deserialize)]
 pub struct Config {

--- a/src/agent/onefuzz-task/src/tasks/coverage/generic.rs
+++ b/src/agent/onefuzz-task/src/tasks/coverage/generic.rs
@@ -36,7 +36,7 @@ const COVERAGE_FILE: &str = "coverage.json";
 const SOURCE_COVERAGE_FILE: &str = "source-coverage.json";
 const MODULE_CACHE_FILE: &str = "module-cache.json";
 
-const DEFAULT_TARGET_TIMEOUT: Duration = Duration::from_secs(600);
+const DEFAULT_TARGET_TIMEOUT: Duration = Duration::from_secs(120);
 
 #[derive(Debug, Deserialize)]
 pub struct Config {

--- a/src/agent/onefuzz-task/src/tasks/coverage/generic.rs
+++ b/src/agent/onefuzz-task/src/tasks/coverage/generic.rs
@@ -36,7 +36,7 @@ const COVERAGE_FILE: &str = "coverage.json";
 const SOURCE_COVERAGE_FILE: &str = "source-coverage.json";
 const MODULE_CACHE_FILE: &str = "module-cache.json";
 
-const DEFAULT_TARGET_TIMEOUT: Duration = Duration::from_secs(120);
+const DEFAULT_TARGET_TIMEOUT: Duration = Duration::from_secs(600);
 
 #[derive(Debug, Deserialize)]
 pub struct Config {


### PR DESCRIPTION
As of #2529 we now fail if the coverage recording times out. The default timeout (5s) does not appear to be long enough for even simple tasks to run, so extend it to 120s.

