### PR TITLE
Use the vitual env folder to store the config if it exists

### DIFF
--- a/src/cli/onefuzz/backend.py
+++ b/src/cli/onefuzz/backend.py
@@ -45,7 +45,7 @@ HOME_PATH = os.environ.get("VIRTUAL_ENV") if os.environ.get("VIRTUAL_ENV") else 
 ONEFUZZ_CACHE = os.path.join(".onefuzz", "cache")
 ONEFUZZ_BASE_PATH = os.path.join(HOME_PATH, ONEFUZZ_CACHE)
 DEFAULT_CONFIG_PATH = os.path.join(ONEFUZZ_BASE_PATH, "config.json")
-DEFAULT_TOKEN_PATH = os.path.join(os.path.join("~", ONEFUZZ_CACHE), "access_token.json")
+DEFAULT_TOKEN_PATH = os.path.join("~", ONEFUZZ_CACHE, "access_token.json")
 REQUEST_CONNECT_TIMEOUT = 30.0
 REQUEST_READ_TIMEOUT = 120.0
 

--- a/src/cli/onefuzz/backend.py
+++ b/src/cli/onefuzz/backend.py
@@ -41,7 +41,7 @@ from .azcopy import azcopy_copy, azcopy_sync
 
 _ACCESSTOKENCACHE_UMASK = 0o077
 
-HOME_PATH = os.environ.get("VIRTUAL_ENV") if os.environ.get("VIRTUAL_ENV") else "~"
+HOME_PATH: str = os.environ.get("VIRTUAL_ENV") if os.environ.get("VIRTUAL_ENV") else "~"
 ONEFUZZ_CACHE = os.path.join(".onefuzz", "cache")
 ONEFUZZ_BASE_PATH = os.path.join(HOME_PATH, ONEFUZZ_CACHE)
 DEFAULT_CONFIG_PATH = os.path.join(ONEFUZZ_BASE_PATH, "config.json")

--- a/src/cli/onefuzz/backend.py
+++ b/src/cli/onefuzz/backend.py
@@ -41,7 +41,8 @@ from .azcopy import azcopy_copy, azcopy_sync
 
 _ACCESSTOKENCACHE_UMASK = 0o077
 
-HOME_PATH: str = os.environ.get("VIRTUAL_ENV") if os.environ.get("VIRTUAL_ENV") else "~"
+VIRTUAL_ENV = os.environ.get("VIRTUAL_ENV")
+HOME_PATH = VIRTUAL_ENV if VIRTUAL_ENV else "~"
 ONEFUZZ_CACHE = os.path.join(".onefuzz", "cache")
 ONEFUZZ_BASE_PATH = os.path.join(HOME_PATH, ONEFUZZ_CACHE)
 DEFAULT_CONFIG_PATH = os.path.join(ONEFUZZ_BASE_PATH, "config.json")

--- a/src/cli/onefuzz/backend.py
+++ b/src/cli/onefuzz/backend.py
@@ -41,7 +41,8 @@ from .azcopy import azcopy_copy, azcopy_sync
 
 _ACCESSTOKENCACHE_UMASK = 0o077
 
-ONEFUZZ_BASE_PATH = os.path.join("~", ".cache", "onefuzz")
+HOME_PATH = os.environ.get("VIRTUAL_ENV") if os.environ.get("VIRTUAL_ENV") else "~"
+ONEFUZZ_BASE_PATH = os.path.join(HOME_PATH, ".cache", "onefuzz")
 DEFAULT_CONFIG_PATH = os.path.join(ONEFUZZ_BASE_PATH, "config.json")
 DEFAULT_TOKEN_PATH = os.path.join(ONEFUZZ_BASE_PATH, "access_token.json")
 REQUEST_CONNECT_TIMEOUT = 30.0

--- a/src/cli/onefuzz/backend.py
+++ b/src/cli/onefuzz/backend.py
@@ -42,9 +42,10 @@ from .azcopy import azcopy_copy, azcopy_sync
 _ACCESSTOKENCACHE_UMASK = 0o077
 
 HOME_PATH = os.environ.get("VIRTUAL_ENV") if os.environ.get("VIRTUAL_ENV") else "~"
-ONEFUZZ_BASE_PATH = os.path.join(HOME_PATH, ".cache", "onefuzz")
+ONEFUZZ_CACHE = os.path.join(".onefuzz", "cache")
+ONEFUZZ_BASE_PATH = os.path.join(HOME_PATH, ONEFUZZ_CACHE)
 DEFAULT_CONFIG_PATH = os.path.join(ONEFUZZ_BASE_PATH, "config.json")
-DEFAULT_TOKEN_PATH = os.path.join(ONEFUZZ_BASE_PATH, "access_token.json")
+DEFAULT_TOKEN_PATH = os.path.join(os.path.join("~", ONEFUZZ_CACHE), "access_token.json")
 REQUEST_CONNECT_TIMEOUT = 30.0
 REQUEST_READ_TIMEOUT = 120.0
 


### PR DESCRIPTION
## Summary of the Pull Request

Save the onefuzz config in the virtual environment folder. This simplifies the scenarios of connecting to multiple environments.