### PR TITLE
Don't log an error if we delete a Repro and it is already missing

### DIFF
--- a/src/ApiService/ApiService/Functions/ReproVmss.cs
+++ b/src/ApiService/ApiService/Functions/ReproVmss.cs
@@ -114,7 +114,7 @@ public class ReproVmss {
         var updatedRepro = vm with { State = VmState.Stopping };
         var r = await _context.ReproOperations.Replace(updatedRepro);
         if (!r.IsOk) {
-            _log.WithHttpStatus(r.ErrorV!).Error($"Failed to replace repro {updatedRepro.VmId:Tag:VmId}");
+            _log.WithHttpStatus(r.ErrorV).Error($"Failed to replace repro {updatedRepro.VmId:Tag:VmId}");
         }
 
         var response = req.CreateResponse(HttpStatusCode.OK);

--- a/src/ApiService/ApiService/Log.cs
+++ b/src/ApiService/ApiService/Log.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.Net;
 using System.Runtime.CompilerServices;
 using System.Text;
 using Microsoft.ApplicationInsights;
@@ -188,7 +189,7 @@ public interface ILogTracer {
 
     ILogTracer WithTag(string k, string v);
     ILogTracer WithTags(IEnumerable<(string, string)>? tags);
-    ILogTracer WithHttpStatus((int, string) status);
+    ILogTracer WithHttpStatus((HttpStatusCode Status, string Reason) result);
 }
 
 internal interface ILogTracerInternal : ILogTracer {
@@ -252,8 +253,12 @@ public class LogTracer : ILogTracerInternal {
         return WithTags(new[] { (k, v) });
     }
 
-    public ILogTracer WithHttpStatus((int, string) status) {
-        (string, string)[] tags = { ("StatusCode", status.Item1.ToString()), ("ReasonPhrase", status.Item2) };
+    public ILogTracer WithHttpStatus((HttpStatusCode Status, string Reason) result) {
+        (string, string)[] tags = {
+            ("StatusCode", ((int)result.Status).ToString()),
+            ("ReasonPhrase", result.Reason),
+        };
+
         return WithTags(tags);
     }
 

--- a/src/ApiService/ApiService/onefuzzlib/AutoScale.cs
+++ b/src/ApiService/ApiService/onefuzzlib/AutoScale.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json;
+﻿using System.Net;
+using System.Text.Json;
 using System.Threading.Tasks;
 using ApiService.OneFuzzLib.Orm;
 using Azure;
@@ -10,7 +11,7 @@ namespace Microsoft.OneFuzz.Service;
 
 public interface IAutoScaleOperations {
 
-    public Async.Task<ResultVoid<(int, string)>> Insert(AutoScale autoScale);
+    public Async.Task<ResultVoid<(HttpStatusCode Status, string Reason)>> Insert(AutoScale autoScale);
 
     public Async.Task<AutoScale?> GetSettingsForScaleset(Guid scalesetId);
 

--- a/src/ApiService/ApiService/onefuzzlib/ConfigOperations.cs
+++ b/src/ApiService/ApiService/onefuzzlib/ConfigOperations.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Net;
+using System.Threading.Tasks;
 using ApiService.OneFuzzLib.Orm;
 using Microsoft.Extensions.Caching.Memory;
 
@@ -32,7 +33,7 @@ public class ConfigOperations : Orm<InstanceConfig>, IConfigOperations {
 
     public async Async.Task Save(InstanceConfig config, bool isNew = false, bool requireEtag = false) {
         var newConfig = config with { InstanceName = _context.ServiceConfiguration.OneFuzzInstanceName ?? throw new Exception("Environment variable ONEFUZZ_INSTANCE_NAME is not set") };
-        ResultVoid<(int, string)> r;
+        ResultVoid<(HttpStatusCode Status, string Reason)> r;
         if (isNew) {
             r = await Insert(newConfig);
             if (!r.IsOk) {

--- a/src/ApiService/ApiService/onefuzzlib/NodeOperations.cs
+++ b/src/ApiService/ApiService/onefuzzlib/NodeOperations.cs
@@ -385,7 +385,7 @@ public class NodeOperations : StatefulOrm<Node, NodeState, NodeOperations>, INod
 
         var node = new Node(poolName, machineId, poolId, version, ScalesetId: scaleSetId);
 
-        ResultVoid<(int, string)> r;
+        ResultVoid<(HttpStatusCode Status, string Reason)> r;
         if (isNew) {
             try {
                 r = await Insert(node);

--- a/src/ApiService/ApiService/onefuzzlib/ReproOperations.cs
+++ b/src/ApiService/ApiService/onefuzzlib/ReproOperations.cs
@@ -1,4 +1,5 @@
 ﻿using System.Globalization;
+using System.Net;
 using System.Threading.Tasks;
 using ApiService.OneFuzzLib.Orm;
 using Azure.ResourceManager.Compute.Models;
@@ -111,9 +112,10 @@ public class ReproOperations : StatefulOrm<Repro, VmState, ReproOperations>, IRe
         // BUG?: why are we updating repro and then deleting it and returning a new value
         repro = repro with { State = VmState.Stopped };
         var r = await Delete(repro);
-        if (!r.IsOk) {
+        if (!r.IsOk && r.ErrorV.Status != HttpStatusCode.NotFound) {
             _logTracer.WithHttpStatus(r.ErrorV).Error($"failed to delete repro {repro.VmId:Tag:VmId} marked as stopped");
         }
+
         return repro;
     }
 

--- a/src/ApiService/ApiService/onefuzzlib/VmssOperations.cs
+++ b/src/ApiService/ApiService/onefuzzlib/VmssOperations.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Net;
+using System.Threading.Tasks;
 using Azure;
 using Azure.Core;
 using Azure.Data.Tables;
@@ -69,7 +70,7 @@ public class VmssOperations : IVmssOperations {
         var result = await r.DeleteAsync(WaitUntil.Started, forceDeletion: forceDeletion);
         var raw = result.GetRawResponse();
         if (raw.IsError) {
-            _log.WithHttpStatus((raw.Status, raw.ReasonPhrase)).Error($"Failed to delete vmss: {name:Tag:VmssName}");
+            _log.WithHttpStatus(((HttpStatusCode)raw.Status, raw.ReasonPhrase)).Error($"Failed to delete vmss: {name:Tag:VmssName}");
             return false;
         } else {
             return true;

--- a/src/ApiService/IntegrationTests/TestLogTracer.cs
+++ b/src/ApiService/IntegrationTests/TestLogTracer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Net;
 using Microsoft.OneFuzz.Service;
 using Xunit.Abstractions;
 
@@ -48,7 +49,7 @@ sealed class TestLogTracer : ILogTracer {
         _output.WriteLine($"[Warning] {message.ToString()}");
     }
 
-    public ILogTracer WithHttpStatus((int, string) status) {
+    public ILogTracer WithHttpStatus((HttpStatusCode Status, string Reason) result) {
         return this; // TODO?
     }
 


### PR DESCRIPTION
If we delete a Repro and it is already missing, this shouldn't be considered an error.

Also update the Insert/Update/Delete/Replace methods to return an `HttpStatusCode` instead of a raw `int`.