### PR TITLE
Enable MSVC security features

### DIFF
--- a/src/agent/.cargo/config
+++ b/src/agent/.cargo/config
@@ -1,2 +1,0 @@
-[target.x86_64-pc-windows-msvc]
-rustflags = ["-C", "target-feature=+crt-static"]

--- a/src/agent/.cargo/config.toml
+++ b/src/agent/.cargo/config.toml
@@ -1,0 +1,11 @@
+[target.x86_64-pc-windows-msvc]
+rustflags = [
+    "-C",
+    "target-feature=+crt-static",
+    "-C",
+    "control-flow-guard",
+    "-C",
+    "link-arg=/DYNAMICBASE",
+    "-C",
+    "link-arg=/CETCOMPAT",
+]


### PR DESCRIPTION
Enabling some native code features which are SDL requirements. (Specifically, the requirement "Executable binary files must be hardened to leverage available platform security mitigations".)

I attempted to use BinSkim to enforce the requirements but it has trouble with Rust binaries at present.
