### PR TITLE
Fix Github actions warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,11 +34,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Install specific Rust version
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@55c7845fad90d0ae8b2e83715cb900e5e861e8cb # pinned latest master as of 2022-10-08
       # note: keep this in sync with .devcontainer/Dockerfile
       with:
         toolchain: 1.64
-        default: true
         components: clippy, rustfmt, llvm-tools-preview
     - name: Get Rust version & build version
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
         sudo apt-get -y install libssl-dev libunwind-dev build-essential pkg-config
     - name: Rust Prereq Cache
       if: steps.cache-agent-artifacts.outputs.cache-hit != 'true'
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       id: cache-rust-prereqs
       with:
         path: |
@@ -80,7 +80,7 @@ jobs:
       run: src/ci/rust-prereqs.sh
     - name: Rust Compile Cache
       if: steps.cache-agent-artifacts.outputs.cache-hit != 'true'
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           sccache
@@ -226,7 +226,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Rust Prereq Cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       id: cache-rust-prereqs
       with:
         path: |
@@ -239,7 +239,7 @@ jobs:
       shell: bash
       run: src/ci/rust-prereqs.sh
     - name: Rust Compile Cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           sccache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
       uses: codecov/codecov-action@v3
       with:
         directory: artifacts
-    - uses: actions/upload-artifact@v2.2.2
+    - uses: actions/upload-artifact@v3
       with:
         name: build-artifacts
         path: artifacts
@@ -105,7 +105,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - run: src/ci/azcopy.sh
-    - uses: actions/upload-artifact@v2.2.2
+    - uses: actions/upload-artifact@v3
       with:
         name: build-artifacts
         path: artifacts
@@ -155,7 +155,7 @@ jobs:
         mkdir -p ${GITHUB_WORKSPACE}/artifacts/sdk/
         cp dist/*.tar.gz dist/*.whl ${GITHUB_WORKSPACE}/artifacts/sdk/
         cp dist/onefuzz.exe ${GITHUB_WORKSPACE}/artifacts/windows-cli/
-    - uses: actions/upload-artifact@v2.2.2
+    - uses: actions/upload-artifact@v3
       with:
         name: build-artifacts
         path: artifacts
@@ -218,7 +218,7 @@ jobs:
       with:
         python-version: 3.7
     - run: src/ci/onefuzztypes.sh
-    - uses: actions/upload-artifact@v2.2.2
+    - uses: actions/upload-artifact@v3
       with:
         name: build-artifacts
         path: artifacts
@@ -250,7 +250,7 @@ jobs:
           proxy-${{ runner.os }}-${{ hashFiles('src/proxy-manager/Cargo.lock') }}-
           proxy-${{ runner.os }}-
     - run: src/ci/proxy.sh
-    - uses: actions/upload-artifact@v2.2.2
+    - uses: actions/upload-artifact@v3
       with:
         name: build-artifacts
         path: artifacts
@@ -278,7 +278,7 @@ jobs:
         zip -r api-service.zip .
         mkdir -p ${GITHUB_WORKSPACE}/artifacts/service
         cp api-service.zip ${GITHUB_WORKSPACE}/artifacts/service
-    - uses: actions/upload-artifact@v2.2.2
+    - uses: actions/upload-artifact@v3
       with:
         name: build-artifacts
         path: artifacts
@@ -363,7 +363,7 @@ jobs:
         zip -r api-service-net.zip .
         mkdir -p ${GITHUB_WORKSPACE}/artifacts/service-net
         cp api-service-net.zip ${GITHUB_WORKSPACE}/artifacts/service-net
-    - uses: actions/upload-artifact@v2.2.2
+    - uses: actions/upload-artifact@v3
       with:
         name: build-artifacts
         path: artifacts
@@ -372,7 +372,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - run: src/ci/afl.sh
-    - uses: actions/upload-artifact@v2.2.2
+    - uses: actions/upload-artifact@v3
       with:
         name: build-artifacts
         path: artifacts
@@ -382,7 +382,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - run: src/ci/aflpp.sh
-    - uses: actions/upload-artifact@v2.2.2
+    - uses: actions/upload-artifact@v3
       with:
         name: build-artifacts
         path: artifacts
@@ -392,7 +392,7 @@ jobs:
     - uses: actions/checkout@v3
     - run: src/ci/dotnet-fuzzing-tools.sh
       shell: bash
-    - uses: actions/upload-artifact@v2.2.2
+    - uses: actions/upload-artifact@v3
       with:
         name: build-artifacts
         path: artifacts
@@ -402,7 +402,7 @@ jobs:
     - uses: actions/checkout@v3
     - run: src/ci/dotnet-fuzzing-tools.ps1
       shell: pwsh
-    - uses: actions/upload-artifact@v2.2.2
+    - uses: actions/upload-artifact@v3
       with:
         name: build-artifacts
         path: artifacts
@@ -419,7 +419,7 @@ jobs:
         path: artifacts
     - run: src/ci/radamsa-linux.sh
       if: steps.cache-radamsa-build-linux.outputs.cache-hit != 'true'
-    - uses: actions/upload-artifact@v2.2.2
+    - uses: actions/upload-artifact@v3
       with:
         name: build-artifacts
         path: artifacts
@@ -436,7 +436,7 @@ jobs:
         path: artifacts
     - run: c:\msys64\usr\bin\bash src/ci/radamsa-windows.sh
       if: steps.cache-radamsa-build-windows.outputs.cache-hit != 'true'
-    - uses: actions/upload-artifact@v2.2.2
+    - uses: actions/upload-artifact@v3
       with:
         name: build-artifacts
         path: artifacts
@@ -504,7 +504,7 @@ jobs:
           cp src/deployment/onefuzz-deployment*zip release-artifacts
           cp -r artifacts/sdk release-artifacts
           cp -r artifacts/windows-cli/onefuzz.exe release-artifacts/onefuzz-cli-$(./src/ci/get-version.sh).exe
-    - uses: actions/upload-artifact@v2.2.2
+    - uses: actions/upload-artifact@v3
       with:
         name: release-artifacts
         path: release-artifacts
@@ -570,7 +570,7 @@ jobs:
           (cd GoodBad; dotnet publish -c Release -o out)
           mv GoodBad/out artifacts/GoodBadDotnet
 
-    - uses: actions/upload-artifact@v2.2.2
+    - uses: actions/upload-artifact@v3
       with:
         name: integration-test-artifacts
         path: src/integration-tests/artifacts
@@ -645,7 +645,7 @@ jobs:
           make CFLAGS='-fsanitize=address -fno-omit-frame-pointer'
           cp fuzz.exe,fuzz.pdb,seeds ../artifacts/windows-trivial-crash-asan -Recurse
       shell: powershell
-    - uses: actions/upload-artifact@v2.2.2
+    - uses: actions/upload-artifact@v3
       with:
         name: integration-test-artifacts
         path: src/integration-tests/artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         #- [ self-hosted, "1ES.Pool=onefuzz-ci", "1ES.ImageOverride=github-runner-image-ubuntu-22.04" ] 
     runs-on: "${{ matrix.os }}"
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install specific Rust version
       uses: actions-rs/toolchain@v1
       # note: keep this in sync with .devcontainer/Dockerfile
@@ -103,7 +103,7 @@ jobs:
   azcopy:
     runs-on: ubuntu-18.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - run: src/ci/azcopy.sh
     - uses: actions/upload-artifact@v2.2.2
       with:
@@ -112,7 +112,7 @@ jobs:
   check-pr:
     runs-on: ubuntu-18.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions/setup-python@v2
       with:
         python-version: 3.7
@@ -124,7 +124,7 @@ jobs:
     - onefuzztypes
     runs-on: windows-2019
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - run: src/ci/set-versions.sh
       shell: bash
     - uses: actions/setup-python@v2
@@ -179,7 +179,7 @@ jobs:
   contrib-webhook-teams-service:
     runs-on: ubuntu-18.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions/setup-python@v2
       with:
         python-version: 3.8
@@ -197,7 +197,7 @@ jobs:
   deploy-onefuzz-via-azure-devops:
     runs-on: ubuntu-18.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions/setup-python@v2
       with:
         python-version: 3.8
@@ -212,7 +212,7 @@ jobs:
   onefuzztypes:
     runs-on: ubuntu-18.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - run: src/ci/set-versions.sh
     - uses: actions/setup-python@v2
       with:
@@ -225,7 +225,7 @@ jobs:
   proxy:
     runs-on: ubuntu-18.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Rust Prereq Cache
       uses: actions/cache@v2
       id: cache-rust-prereqs
@@ -259,7 +259,7 @@ jobs:
     - onefuzztypes
     runs-on: ubuntu-18.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - run: src/ci/set-versions.sh
     - uses: actions/setup-python@v2
       with:
@@ -305,7 +305,7 @@ jobs:
   service-net:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Setup .NET Core SDK
       uses: actions/setup-dotnet@v2
       with:
@@ -370,7 +370,7 @@ jobs:
   afl:
     runs-on: ubuntu-18.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - run: src/ci/afl.sh
     - uses: actions/upload-artifact@v2.2.2
       with:
@@ -380,7 +380,7 @@ jobs:
   aflpp:
     runs-on: ubuntu-18.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - run: src/ci/aflpp.sh
     - uses: actions/upload-artifact@v2.2.2
       with:
@@ -389,7 +389,7 @@ jobs:
   dotnet-fuzzing-tools-linux:
     runs-on: ubuntu-18.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - run: src/ci/dotnet-fuzzing-tools.sh
       shell: bash
     - uses: actions/upload-artifact@v2.2.2
@@ -399,7 +399,7 @@ jobs:
   dotnet-fuzzing-tools-windows:
     runs-on: windows-2022
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - run: src/ci/dotnet-fuzzing-tools.ps1
       shell: pwsh
     - uses: actions/upload-artifact@v2.2.2
@@ -409,7 +409,7 @@ jobs:
   radamsa-linux:
     runs-on: ubuntu-18.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions/cache@v3
       id: cache-radamsa-build-linux
       with:
@@ -426,7 +426,7 @@ jobs:
   radamsa-win64:
     runs-on: windows-2019
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions/cache@v3
       id: cache-radamsa-build-windows
       with:
@@ -454,7 +454,7 @@ jobs:
     - radamsa-win64
     runs-on: ubuntu-18.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions/download-artifact@v3
       with:
         name: build-artifacts
@@ -511,7 +511,7 @@ jobs:
   build-integration-tests-linux:
     runs-on: ubuntu-18.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - run: |
           set -ex
           cd src/integration-tests
@@ -577,7 +577,7 @@ jobs:
   build-integration-tests-windows:
     runs-on: windows-2019
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - run: |
           Set-ExecutionPolicy Bypass -Scope Process -Force
           $ProgressPreference = 'SilentlyContinue'
@@ -669,7 +669,7 @@ jobs:
       - radamsa-linux
       - radamsa-win64
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/download-artifact@v3
         with:
           name: build-artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ env:
   CARGO_TERM_COLOR: always
   SCCACHE_DIR: ${{github.workspace}}/sccache/
   SCCACHE_CACHE_SIZE: 1G
-  ACTIONS_CACHE_KEY_DATE: 2022-09-15-02
+  ACTIONS_CACHE_KEY_DATE: 2022-10-28-01
   CI: true
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,11 +43,11 @@ jobs:
     - name: Get Rust version & build version
       shell: bash
       run: |
-        echo "::set-output name=RUST_VERSION::$(rustc --version)"
+        echo "RUST_VERSION=$(rustc --version)" >> $GITHUB_OUTPUT
         VERSION=$(src/ci/get-version.sh)
         # it's a release build if version doesn't have a hyphen in it
         IS_RELEASE_BUILD=$(if [[ "$VERSION" =~ '-' ]]; then echo 'false'; else echo 'true'; fi)
-        echo "::set-output name=RELEASE_BUILD::$IS_RELEASE_BUILD"
+        echo "RELEASE_BUILD=$IS_RELEASE_BUILD" >> $GITHUB_OUTPUT
       id: rust-version
     - name: Rust artifact cache
       id: cache-agent-artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: lint
@@ -126,7 +126,7 @@ jobs:
     - uses: actions/checkout@v3
     - run: src/ci/set-versions.sh
       shell: bash
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - uses: actions/download-artifact@v3
@@ -179,7 +179,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
       with:
         python-version: 3.8
     - name: lint
@@ -197,7 +197,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
       with:
         python-version: 3.8
     - name: lint
@@ -213,7 +213,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - run: src/ci/set-versions.sh
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - run: src/ci/onefuzztypes.sh
@@ -260,7 +260,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - run: src/ci/set-versions.sh
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
       with:
         python-version: 3.8
     - uses: actions/download-artifact@v3
@@ -458,7 +458,7 @@ jobs:
       with:
         name: build-artifacts
         path: artifacts
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Lint


### PR DESCRIPTION
Node.js 12 actions are deprecated, as well as `::set-output` 

- Update `actions/checkout` to v3
- Update `actions/upload-artifact` to v3
- Update `actions/setup-python` to v4
- Update `actions/cache` to v3
- `set-output` on stdout is deprecated, update to `$GITHOUT_OUTPUT` method
- Change from `actions-rs/toolchain` (unsupported) to `dtolnay/rust-toolchain`

The only warning remaining after this is the one about Ubuntu 18.04.