### PR TITLE
Temporarily disable `pipenv check` call

### DIFF
--- a/contrib/deploy-onefuzz-via-azure-devops/tox.ini
+++ b/contrib/deploy-onefuzz-via-azure-devops/tox.ini
@@ -10,6 +10,6 @@ deps =
 commands =
   python -m pip install --upgrade pip
   pipenv install --dev
-  pipenv check
+  # pipenv check  # temporary, see microsoft/onefuzz#2593
   pipenv run black --diff --check .
   pipenv run pylint .


### PR DESCRIPTION
Unbreak the build until `wheel >=0.38.0` is published to PyPI.

Context: https://github.com/microsoft/onefuzz/pull/2593#issuecomment-1299331019