### PR TITLE
Only ignore known `wheel` issue

### DIFF
--- a/contrib/deploy-onefuzz-via-azure-devops/tox.ini
+++ b/contrib/deploy-onefuzz-via-azure-devops/tox.ini
@@ -10,6 +10,12 @@ deps =
 commands =
   python -m pip install --upgrade pip
   pipenv install --dev
-  # pipenv check  # temporary, see microsoft/onefuzz#2593
+
+  # Temporarily ignore unreachable (and non-actionable)
+  # DoS in `wheel`.
+  #
+  # See: microsoft/onefuzz#2593
+  pipenv check -i 51499
+
   pipenv run black --diff --check .
   pipenv run pylint .


### PR DESCRIPTION
Still run `pipenv check`, but ignore the known (non-actionable) `wheel` issue.

Context: https://github.com/microsoft/onefuzz/pull/2593#issuecomment-1299331019