### PR TITLE
Fixing `status top` bug

### DIFF
--- a/src/ApiService/ApiService/Functions/Negotiate.cs
+++ b/src/ApiService/ApiService/Functions/Negotiate.cs
@@ -1,5 +1,4 @@
 ﻿using System.Net;
-using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;


### PR DESCRIPTION
Fixes #2572. 

For some reason, the well-typed `SignalRConnectionInfoInput` object does not contain an access-token. The string version does.