### PR TITLE
Maintenance: switch to quick-xml

### DIFF
--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -159,7 +159,7 @@ dependencies = [
  "reqwest",
  "rustc_version",
  "serde",
- "serde-xml-rs 0.6.0",
+ "serde-xml-rs",
  "serde_json",
  "time",
  "url",
@@ -182,7 +182,7 @@ dependencies = [
  "log",
  "once_cell",
  "serde",
- "serde-xml-rs 0.6.0",
+ "serde-xml-rs",
  "serde_derive",
  "serde_json",
  "sha2",
@@ -206,7 +206,7 @@ dependencies = [
  "log",
  "md5",
  "serde",
- "serde-xml-rs 0.6.0",
+ "serde-xml-rs",
  "serde_derive",
  "serde_json",
  "time",
@@ -521,7 +521,9 @@ dependencies = [
  "msvc-demangler",
  "pdb 0.7.0",
  "pete",
+ "pretty_assertions",
  "procfs",
+ "quick-xml",
  "regex",
  "rustc-demangle",
  "serde",
@@ -531,7 +533,6 @@ dependencies = [
  "uuid 0.8.2",
  "win-util",
  "winapi",
- "xml-rs",
 ]
 
 [[package]]
@@ -1984,7 +1985,7 @@ dependencies = [
  "reqwest",
  "reqwest-retry",
  "serde",
- "serde-xml-rs 0.5.1",
+ "serde-xml-rs",
  "serde_json",
  "stacktrace-parser",
  "storage-queue",
@@ -2390,9 +2391,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58e21a144a0ffb5fad7b464babcdab934a325ad69b7c0373bcfef5cbd9799ca9"
+checksum = "7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd"
 dependencies = [
  "memchr",
 ]
@@ -2755,18 +2756,6 @@ dependencies = [
 
 [[package]]
 name = "serde-xml-rs"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65162e9059be2f6a3421ebbb4fef3e74b7d9e7c60c50a0e292c6239f19f1edfa"
-dependencies = [
- "log",
- "serde",
- "thiserror",
- "xml-rs",
-]
-
-[[package]]
-name = "serde-xml-rs"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb3aa78ecda1ebc9ec9847d5d3aba7d618823446a049ba2491940506da6e2782"
@@ -3007,7 +2996,7 @@ dependencies = [
  "reqwest",
  "reqwest-retry",
  "serde",
- "serde-xml-rs 0.5.1",
+ "serde-xml-rs",
  "serde_derive",
  "serde_json",
  "tokio",

--- a/src/agent/coverage/Cargo.toml
+++ b/src/agent/coverage/Cargo.toml
@@ -27,7 +27,7 @@ serde = { version = "1.0", features = ["derive"] }
 symbolic = { version = "8.8", features = ["debuginfo", "demangle", "symcache"] }
 uuid = { version = "0.8", features = ["guid"] }
 win-util = { path = "../win-util" }
-xml-rs = "0.8"
+quick-xml = "0.26"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 pdb = "0.7"
@@ -43,3 +43,4 @@ procfs = { version = "0.12", default-features = false, features=["flate2"] }
 env_logger = "0.9"
 serde_json = { version = "1.0", features = ["preserve_order"] }
 structopt = "0.3"
+pretty_assertions ="1.3"

--- a/src/agent/onefuzz-task/Cargo.toml
+++ b/src/agent/onefuzz-task/Cargo.toml
@@ -29,7 +29,7 @@ regex = "1.6.0"
 reqwest = { version = "0.11", features = ["json", "stream", "native-tls-vendored"], default-features=false }
 serde = "1.0"
 serde_json = "1.0"
-serde-xml-rs = "0.5.1"
+serde-xml-rs = "0.6"
 onefuzz = { path = "../onefuzz" }
 onefuzz-telemetry = { path = "../onefuzz-telemetry" }
 path-absolutize = "3.0"

--- a/src/agent/srcview/Cargo.toml
+++ b/src/agent/srcview/Cargo.toml
@@ -15,7 +15,7 @@ nom = "7"
 pdb = "0.8"
 regex = "1"
 serde = { version = "1", features = ["derive"] }
-quick-xml = "0.25.0"
+quick-xml = "0.26"
 anyhow = "1.0"
 structopt = "0.3"
 env_logger = "0.9"

--- a/src/agent/storage-queue/Cargo.toml
+++ b/src/agent/storage-queue/Cargo.toml
@@ -20,7 +20,7 @@ reqwest-retry = { path = "../reqwest-retry" }
 serde = { version = "1.0", features = ["derive"]}
 serde_derive = "1.0"
 serde_json = "1.0"
-serde-xml-rs = "0.5"
+serde-xml-rs = "0.6"
 tokio = { version = "1.16" , features=["full"] }
 queue-file = "1.4"
 uuid = { version = "0.8", features = ["serde", "v4"] }


### PR DESCRIPTION
Per Rust security advisory [RUSTSEC-2022-0048](https://rustsec.org/advisories/RUSTSEC-2022-0048.html), update from `xml-rs`, which is unmaintained, to `quick-xml`. (We are already using `quick-xml` as of #2515.)

We still consume `xml-rs` through the `azure_*` dependencies so we cannot yet disable the suppression in `agent.sh`.

Also update tests to match, which closes #1774.
