### PR TITLE
Use broker or browser login instead of device flow

### DIFF
--- a/src/cli/onefuzz/backend.py
+++ b/src/cli/onefuzz/backend.py
@@ -236,7 +236,6 @@ class Backend:
                 authority=self.config.authority,
                 token_cache=self.token_cache,
                 allow_broker=True,
-                parent_window_handle=msal.PublicClientApplication.CONSOLE_WINDOW_HANDLE,
             )
 
         access_token = None
@@ -252,7 +251,10 @@ class Backend:
         for scope in scopes:
             LOGGER.info("Attempting interactive device login")
             try:
-                access_token = self.app.acquire_token_interactive(scopes=[scope])
+                access_token = self.app.acquire_token_interactive(
+                    scopes=[scope],
+                    parent_window_handle=msal.PublicClientApplication.CONSOLE_WINDOW_HANDLE,
+                )
                 check_msal_error(access_token, ["access_token"])
             except KeyboardInterrupt:
                 result = input(

--- a/src/cli/onefuzz/backend.py
+++ b/src/cli/onefuzz/backend.py
@@ -236,7 +236,7 @@ class Backend:
                 authority=self.config.authority,
                 token_cache=self.token_cache,
                 allow_broker=True,
-                parent_window_handle=msal.PublicClientApplication.CONSOLE_WINDOW_HANDLE
+                parent_window_handle=msal.PublicClientApplication.CONSOLE_WINDOW_HANDLE,
             )
 
         access_token = None

--- a/src/cli/onefuzz/backend.py
+++ b/src/cli/onefuzz/backend.py
@@ -235,7 +235,7 @@ class Backend:
                 self.config.client_id,
                 authority=self.config.authority,
                 token_cache=self.token_cache,
-                allow_broker=True
+                allow_broker=True,
             )
 
         access_token = None
@@ -254,7 +254,9 @@ class Backend:
                 access_token = self.app.acquire_token_interactive(scopes=[scope])
                 check_msal_error(access_token, ["access_token"])
             except KeyboardInterrupt:
-                result = input("\nInteractive login cancelled. Use device login (Y/n)? ")
+                result = input(
+                    "\nInteractive login cancelled. Use device login (Y/n)? "
+                )
                 if result == "" or result.startswith("y") or result.startswith("Y"):
                     print("Falling back to device flow, please sign in:", flush=True)
                     flow = self.app.initiate_device_flow(scopes=[scope])

--- a/src/cli/onefuzz/backend.py
+++ b/src/cli/onefuzz/backend.py
@@ -235,6 +235,7 @@ class Backend:
                 self.config.client_id,
                 authority=self.config.authority,
                 token_cache=self.token_cache,
+                allow_broker=True
             )
 
         access_token = None

--- a/src/cli/onefuzz/backend.py
+++ b/src/cli/onefuzz/backend.py
@@ -236,6 +236,7 @@ class Backend:
                 authority=self.config.authority,
                 token_cache=self.token_cache,
                 allow_broker=True,
+                parent_window_handle=msal.PublicClientApplication.CONSOLE_WINDOW_HANDLE
             )
 
         access_token = None

--- a/src/cli/requirements.txt
+++ b/src/cli/requirements.txt
@@ -1,4 +1,4 @@
-msal==1.18.0b1
+msal==1.20.0
 requests~=2.27.1
 jmespath~=0.10.0
 semver~=2.13.0
@@ -12,7 +12,7 @@ azure-applicationinsights==0.1.0
 tenacity==8.0.1
 docstring_parser==0.8.1
 azure-identity==1.10.0
-azure-cli-core==2.40.0
+azure-cli-core==2.42.0
 # packaging is required but not specified by azure-cli-core
 packaging==21.3
 # urllib3[secure] needs to be specifically stated for azure-cli-core

--- a/src/deployment/deploy.py
+++ b/src/deployment/deploy.py
@@ -486,7 +486,7 @@ class Client:
 
             requiredRedirectUris = [
                 "http://localhost",  # required for browser-based auth
-                "ms-appx-web://Microsoft.AAD.BrokerPlugin/3b5603df-3ddc-464c-a1ea-6a186bdee389",  # required for broker auth
+                f"ms-appx-web://Microsoft.AAD.BrokerPlugin/{onefuzz_cli_app['appId']}",  # required for broker auth
             ]
 
             redirectUris: List[str] = onefuzz_cli_app["publicClient"]["redirectUris"]

--- a/src/deployment/deploy.py
+++ b/src/deployment/deploy.py
@@ -484,15 +484,22 @@ class Client:
             if "redirectUris" not in onefuzz_cli_app["publicClient"]:
                 onefuzz_cli_app["publicClient"]["redirectUris"] = []
 
-            replyUrl = "http://localhost"  # required for browser-based auth
+            requiredRedirectUris = [
+                "http://localhost",  # required for browser-based auth
+                "ms-appx-web://Microsoft.AAD.BrokerPlugin/3b5603df-3ddc-464c-a1ea-6a186bdee389",  # required for broker auth
+            ]
 
             redirectUris: List[str] = onefuzz_cli_app["publicClient"]["redirectUris"]
-            if replyUrl not in redirectUris:
-                logger.info("Updating replyUrls for CLI app")
+            updatedRedirectUris = list(
+                set(requiredRedirectUris) | set(redirectUris)
+            )
+
+            if len(updatedRedirectUris) > len(redirectUris):
+                logger.info("Updating redirectUris for CLI app")
                 query_microsoft_graph(
                     method="PATCH",
                     resource=f"applications/{onefuzz_cli_app['id']}",
-                    body={"publicClient": {"redirectUris": redirectUris + [replyUrl]}},
+                    body={"publicClient": {"redirectUris": updatedRedirectUris}},
                     subscription=self.get_subscription_id(),
                 )
 

--- a/src/deployment/deploy.py
+++ b/src/deployment/deploy.py
@@ -490,9 +490,7 @@ class Client:
             ]
 
             redirectUris: List[str] = onefuzz_cli_app["publicClient"]["redirectUris"]
-            updatedRedirectUris = list(
-                set(requiredRedirectUris) | set(redirectUris)
-            )
+            updatedRedirectUris = list(set(requiredRedirectUris) | set(redirectUris))
 
             if len(updatedRedirectUris) > len(redirectUris):
                 logger.info("Updating redirectUris for CLI app")

--- a/src/deployment/deploy.py
+++ b/src/deployment/deploy.py
@@ -17,7 +17,7 @@ import time
 import uuid
 import zipfile
 from datetime import datetime, timedelta
-from typing import Any, Dict, List, Optional, Tuple, TypeVar, Union, cast
+from typing import Any, Dict, List, Optional, Tuple, Union, cast
 from uuid import UUID
 
 from azure.common.credentials import get_cli_profile
@@ -102,17 +102,6 @@ DOTNET_AGENT_FUNCTIONS = [
     "agent_registration",
 ]
 logger = logging.getLogger("deploy")
-
-T = TypeVar("T")
-
-
-def union_lists(list1: List[T], list2: List[T]) -> List[T]:
-    # this doesn’t use the set() type since we need
-    # to support values that are not hashable
-    result = []
-    result.extend(list1)
-    result.extend([x for x in list2 if x not in result])
-    return result
 
 
 def gen_guid() -> str:
@@ -525,8 +514,8 @@ class Client:
 
         # find any identifier URIs that need updating
         identifier_uris: List[str] = app["identifierUris"]
-        updated_identifier_uris = union_lists(
-            identifier_uris, self.get_identifier_urls()
+        updated_identifier_uris = list(
+            set(identifier_uris) | set(self.get_identifier_urls())
         )
         if len(updated_identifier_uris) > len(identifier_uris):
             update_properties["identifierUris"] = updated_identifier_uris

--- a/src/deployment/deploylib/registration.py
+++ b/src/deployment/deploylib/registration.py
@@ -257,13 +257,6 @@ def create_application_registration(
     params = {
         "isDeviceOnlyAuthSupported": True,
         "displayName": name,
-        "publicClient": {
-            "redirectUris": [
-                "https://%s.azurewebsites.net" % onefuzz_instance_name,
-                "http://localhost",  # required for browser auth
-                "ms-appx-web://Microsoft.AAD.BrokerPlugin/3b5603df-3ddc-464c-a1ea-6a186bdee389",  # required for broker auth
-            ]
-        },
         "isFallbackPublicClient": True,
         "requiredResourceAccess": (
             [
@@ -281,6 +274,23 @@ def create_application_registration(
         method="POST",
         resource="applications",
         body=params,
+        subscription=subscription_id,
+    )
+
+    # next patch the redirect URIs; we must do this
+    # separately because we need the AppID to include
+    query_microsoft_graph(
+        method="PATCH",
+        resource=f"applications/{registered_app['id']}",
+        body={
+            "publicClient": {
+                "redirectUris": [
+                    "https://%s.azurewebsites.net" % onefuzz_instance_name,
+                    "http://localhost",  # required for browser auth
+                    f"ms-appx-web://Microsoft.AAD.BrokerPlugin/{app['appId']}",  # required for broker auth
+                ]
+            },
+        },
         subscription=subscription_id,
     )
 

--- a/src/deployment/deploylib/registration.py
+++ b/src/deployment/deploylib/registration.py
@@ -261,6 +261,7 @@ def create_application_registration(
             "redirectUris": [
                 "https://%s.azurewebsites.net" % onefuzz_instance_name,
                 "http://localhost",  # required for browser auth
+                "ms-appx-web://Microsoft.AAD.BrokerPlugin/3b5603df-3ddc-464c-a1ea-6a186bdee389",  # required for broker auth
             ]
         },
         "isFallbackPublicClient": True,

--- a/src/deployment/deploylib/registration.py
+++ b/src/deployment/deploylib/registration.py
@@ -258,7 +258,10 @@ def create_application_registration(
         "isDeviceOnlyAuthSupported": True,
         "displayName": name,
         "publicClient": {
-            "redirectUris": ["https://%s.azurewebsites.net" % onefuzz_instance_name]
+            "redirectUris": [
+                "https://%s.azurewebsites.net" % onefuzz_instance_name,
+                "http://localhost",  # required for browser auth
+            ]
         },
         "isFallbackPublicClient": True,
         "requiredResourceAccess": (


### PR DESCRIPTION
Update CLI to attempt broker or browser-based authentication first; if you `Ctrl-C` to cancel it, you can fall back to device code login.

Also updated the MSAL dependency to latest version and pass `allow_broker=True` which will allow the use of Web Account Manager (WAM), if it is available.

Using browser auth requires the `http://localhost` redirect URI, and using the broker requires a special custom URI including the app ID (see code).