### PR TITLE
Update LLVM from v10 to v12

### DIFF
--- a/src/ci/dotnet-fuzzing-tools.sh
+++ b/src/ci/dotnet-fuzzing-tools.sh
@@ -20,7 +20,7 @@ mkdir -p $ARTIFACTS/LibFuzzerDotnetLoader
 mkdir -p $ARTIFACTS/sharpfuzz
 
 # Install `libfuzzer-dotnet` pre-reqs.
-sudo apt-get install -y llvm-10 llvm-10-dev clang-10
+sudo apt-get install -y llvm-14 llvm-14-dev clang-14
 
 # Note that dotnet pre-reqs are presumed to be installed
 # by the ci.yml setup (`setup-dotnet` action).

--- a/src/ci/dotnet-fuzzing-tools.sh
+++ b/src/ci/dotnet-fuzzing-tools.sh
@@ -20,7 +20,7 @@ mkdir -p $ARTIFACTS/LibFuzzerDotnetLoader
 mkdir -p $ARTIFACTS/sharpfuzz
 
 # Install `libfuzzer-dotnet` pre-reqs.
-sudo apt-get install -y llvm-14 llvm-14-dev clang-14
+sudo apt-get install -y llvm-12 llvm-12-dev clang-12
 
 # Note that dotnet pre-reqs are presumed to be installed
 # by the ci.yml setup (`setup-dotnet` action).

--- a/src/runtime-tools/linux/setup.sh
+++ b/src/runtime-tools/linux/setup.sh
@@ -124,14 +124,14 @@ if type apt > /dev/null 2> /dev/null; then
     done
 
     if ! [ -f ${LLVM_SYMBOLIZER_PATH} ]; then
-        until sudo apt install -y llvm-10; do
+        until sudo apt install -y llvm-14; do
             echo "apt failed, sleeping 10s then retrying"
             sleep 10
         done
 
         # If specifying symbolizer, exe name must be a "known symbolizer".
         # Using `llvm-symbolizer` works for clang 8 .. 10.
-        sudo ln -f -s $(which llvm-symbolizer-10) $LLVM_SYMBOLIZER_PATH
+        sudo ln -f -s $(which llvm-symbolizer-14) $LLVM_SYMBOLIZER_PATH
     fi
 
     # Install dotnet

--- a/src/runtime-tools/linux/setup.sh
+++ b/src/runtime-tools/linux/setup.sh
@@ -130,7 +130,7 @@ if type apt > /dev/null 2> /dev/null; then
         done
 
         # If specifying symbolizer, exe name must be a "known symbolizer".
-        # Using `llvm-symbolizer` works for clang 8 .. 10.
+        # Using `llvm-symbolizer` works for clang 8 .. 12.
         sudo ln -f -s $(which llvm-symbolizer-12) $LLVM_SYMBOLIZER_PATH
     fi
 

--- a/src/runtime-tools/linux/setup.sh
+++ b/src/runtime-tools/linux/setup.sh
@@ -124,14 +124,14 @@ if type apt > /dev/null 2> /dev/null; then
     done
 
     if ! [ -f ${LLVM_SYMBOLIZER_PATH} ]; then
-        until sudo apt install -y llvm-14; do
+        until sudo apt install -y llvm-12; do
             echo "apt failed, sleeping 10s then retrying"
             sleep 10
         done
 
         # If specifying symbolizer, exe name must be a "known symbolizer".
         # Using `llvm-symbolizer` works for clang 8 .. 10.
-        sudo ln -f -s $(which llvm-symbolizer-14) $LLVM_SYMBOLIZER_PATH
+        sudo ln -f -s $(which llvm-symbolizer-12) $LLVM_SYMBOLIZER_PATH
     fi
 
     # Install dotnet

--- a/src/runtime-tools/win64/onefuzz.ps1
+++ b/src/runtime-tools/win64/onefuzz.ps1
@@ -126,7 +126,7 @@ function Install-LLVM {
   log "installing llvm"
   $ProgressPreference = 'SilentlyContinue'
   $exe_path = "llvm-setup.exe"
-  Invoke-WebRequest -uri https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.0/LLVM-10.0.0-win64.exe -OutFile $exe_path
+  Invoke-WebRequest -uri https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.6/LLVM-14.0.6-win64.exe -OutFile $exe_path
   cmd /c start /wait $exe_path /S
   $env:Path += ";$env:ProgramFiles\LLVM\bin"
   log "installing llvm: done"

--- a/src/runtime-tools/win64/onefuzz.ps1
+++ b/src/runtime-tools/win64/onefuzz.ps1
@@ -126,7 +126,7 @@ function Install-LLVM {
   log "installing llvm"
   $ProgressPreference = 'SilentlyContinue'
   $exe_path = "llvm-setup.exe"
-  Invoke-WebRequest -uri https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.6/LLVM-14.0.6-win64.exe -OutFile $exe_path
+  Invoke-WebRequest -uri https://github.com/llvm/llvm-project/releases/download/llvmorg-12.0.1/LLVM-12.0.1-win64.exe -OutFile $exe_path
   cmd /c start /wait $exe_path /S
   $env:Path += ";$env:ProgramFiles\LLVM\bin"
   log "installing llvm: done"


### PR DESCRIPTION
While I was investigating `llvm-symbolizer` issues, I found that we are installing LLVM-10 by default.

Now that we are using the Ubuntu 20.04 image as the default, use the latest LLVM version available for that release. (In addition, v12 is also available on 22.04, whereas v10 is not.)