### PR TITLE
Make Proxy TelemetryKey optional

### DIFF
--- a/src/ApiService/ApiService/OneFuzzTypes/Model.cs
+++ b/src/ApiService/ApiService/OneFuzzTypes/Model.cs
@@ -146,9 +146,8 @@ public record ProxyConfig
     Guid? ProxyId,
     List<Forward> Forwards,
     string InstanceTelemetryKey,
-    string MicrosoftTelemetryKey,
+    string? MicrosoftTelemetryKey,
     Guid InstanceId
-
 );
 
 public record Proxy

--- a/src/ApiService/ApiService/onefuzzlib/ProxyOperations.cs
+++ b/src/ApiService/ApiService/onefuzzlib/ProxyOperations.cs
@@ -127,7 +127,7 @@ public class ProxyOperations : StatefulOrm<Proxy, VmState, ProxyOperations>, IPr
             ProxyId: proxy.ProxyId,
             Forwards: forwards,
             InstanceTelemetryKey: _context.ServiceConfiguration.ApplicationInsightsInstrumentationKey.EnsureNotNull("missing InstrumentationKey"),
-            MicrosoftTelemetryKey: _context.ServiceConfiguration.OneFuzzTelemetry.EnsureNotNull("missing Telemetry"),
+            MicrosoftTelemetryKey: _context.ServiceConfiguration.OneFuzzTelemetry,
             InstanceId: await _context.Containers.GetInstanceId());
 
         await _context.Containers.SaveBlob(WellKnownContainers.ProxyConfigs, $"{proxy.Region}/{proxy.ProxyId}/config.json", EntityConverter.ToJsonString(proxyConfig), StorageType.Config);


### PR DESCRIPTION
This is already optional on the Rust side (see: [microsoft_telemetry_key](https://github.com/microsoft/onefuzz/blob/5c5dfd3b23e421eaa0e2eb79aa6860f2aa49f811/src/proxy-manager/src/config.rs#L49)). Make it optional on the C# side as well.