### PR TITLE
Target URL notification template parameter fix

### DIFF
--- a/src/ApiService/ApiService/onefuzzlib/notifications/NotificationsBase.cs
+++ b/src/ApiService/ApiService/onefuzzlib/notifications/NotificationsBase.cs
@@ -1,4 +1,5 @@
-﻿using Scriban;
+﻿using System.IO;
+using Scriban;
 
 namespace Microsoft.OneFuzz.Service;
 
@@ -53,7 +54,8 @@ public abstract class NotificationsBase {
 
             if (targetUrl == null) {
                 var setupContainer = Scheduler.GetSetupContainer(checkedTask.Config);
-                targetUrl = new Uri(context.Containers.AuthDownloadUrl(setupContainer, ReplaceFirstSetup(report.Executable)));
+                var exeName = Path.GetFileName(ReplaceFirstSetup(report.Executable));
+                targetUrl = new Uri(context.Containers.AuthDownloadUrl(setupContainer, exeName));
             }
 
             if (reportUrl == null) {


### PR DESCRIPTION
## Summary of the Pull Request

[_targetUrl in NotificationsBase.cs](https://github.com/microsoft/onefuzz/blob/main/src/ApiService/ApiService/onefuzzlib/notifications/NotificationsBase.cs#L33) incorrectly uses the target exe's absolute path in the URL. This changes the URL to only use the filename.

## PR Checklist
* [ ] Applies to work item: #xxx
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/onefuzz) and sign the CLI.
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_

## Validation Steps Performed

_How does someone test & validate?_
