### PR TITLE
Fix SignalR client code not reading responses correctly

### DIFF
--- a/src/cli/onefuzz/status/raw.py
+++ b/src/cli/onefuzz/status/raw.py
@@ -6,6 +6,7 @@
 import logging
 import time
 from typing import Any, List
+from ..api import Onefuzz
 
 from six.moves import input  # workaround for static analysis
 
@@ -14,12 +15,12 @@ from .signalr import Stream
 SIGNALR_CONNECT_TIMEOUT_SECONDS = 0.1
 
 
-def log_entry(onefuzz: Any, entries: List[Any]) -> None:
+def log_entry(onefuzz: Onefuzz, entries: List[Any]) -> None:
     for entry in entries:
         onefuzz.logger.info("%s", entry)
 
 
-def raw(onefuzz: Any, logger: logging.Logger) -> None:
+def raw(onefuzz: Onefuzz, logger: logging.Logger) -> None:
     client = Stream(onefuzz, logger)
     client.setup(lambda x: log_entry(onefuzz, x))
 

--- a/src/cli/onefuzz/status/raw.py
+++ b/src/cli/onefuzz/status/raw.py
@@ -6,10 +6,10 @@
 import logging
 import time
 from typing import Any, List
-from ..api import Onefuzz
 
 from six.moves import input  # workaround for static analysis
 
+from ..api import Onefuzz
 from .signalr import Stream
 
 SIGNALR_CONNECT_TIMEOUT_SECONDS = 0.1

--- a/src/cli/onefuzz/status/signalr.py
+++ b/src/cli/onefuzz/status/signalr.py
@@ -4,25 +4,29 @@
 # Licensed under the MIT License.
 
 import logging
-from typing import Any, Callable, Optional, cast
+from typing import Callable, Optional, cast
 
 from signalrcore.hub_connection_builder import HubConnectionBuilder
+
+from ..api import Onefuzz
 
 
 class Stream:
     connected = None
     hub: Optional[HubConnectionBuilder] = None
 
-    def __init__(self, onefuzz: Any, logger: logging.Logger) -> None:
+    def __init__(self, onefuzz: Onefuzz, logger: logging.Logger) -> None:
         self.onefuzz = onefuzz
         self.logger = logger
 
     def get_token(self) -> str:
-        negotiate = self.onefuzz._backend.request("POST", "negotiate")
+        response = self.onefuzz._backend.request("POST", "negotiate")
+        negotiate = response.json()
         return cast(str, negotiate["accessToken"])
 
     def setup(self, handler: Callable) -> None:
-        config = self.onefuzz._backend.request("POST", "negotiate")
+        response = self.onefuzz._backend.request("POST", "negotiate")
+        config = response.json()
         url = config["url"].replace("https://", "wss://")
         self.hub = (
             HubConnectionBuilder()


### PR DESCRIPTION
The `Response` object must have the JSON loaded via `json()` (`backend.request` was updated but this callsite was missed).

Also, import the `Onefuzz` type so that this is type-checked to avoid the same problem in future.