### PR TITLE
Fix a logic bug in the notification hook

### DIFF
--- a/contrib/webhook-teams-service/webhook/__init__.py
+++ b/contrib/webhook-teams-service/webhook/__init__.py
@@ -45,7 +45,8 @@ async def send_message(req: func.HttpRequest) -> None:
         async with client.post(teams_url, json=message) as response:
             if not response.ok:
                 raise RuntimeError(
-                    f"Teams endpoint failed to consume message: {response}")
+                    f"Teams endpoint failed to consume message: {response}"
+                )
 
 
 def verify(req: func.HttpRequest) -> bool:

--- a/contrib/webhook-teams-service/webhook/__init__.py
+++ b/contrib/webhook-teams-service/webhook/__init__.py
@@ -21,7 +21,7 @@ def code_block(data: str) -> str:
     return "\n```\n%s\n```\n" % data
 
 
-async def send_message(req: func.HttpRequest) -> bool:
+async def send_message(req: func.HttpRequest) -> None:
     data = req.get_json()
     teams_url = os.environ.get("TEAMS_URL")
     if teams_url is None:
@@ -43,7 +43,9 @@ async def send_message(req: func.HttpRequest) -> bool:
     }
     async with aiohttp.ClientSession() as client:
         async with client.post(teams_url, json=message) as response:
-            return response.ok
+            if not response.ok:
+                raise RuntimeError(
+                    f"Teams endpoint failed to consume message: {response}")
 
 
 def verify(req: func.HttpRequest) -> bool:
@@ -67,9 +69,11 @@ def verify(req: func.HttpRequest) -> bool:
 
 async def main(req: func.HttpRequest) -> func.HttpResponse:
     if not verify(req):
-        return func.HttpResponse("no thanks")
+        return func.HttpResponse("no thanks", status_code=400)
 
-    if await send_message(req):
-        return func.HttpResponse("unable to send message")
+    try:
+        await send_message(req)
+    except Exception:
+        return func.HttpResponse("unable to send message", status_code=500)
 
     return func.HttpResponse("thanks")


### PR DESCRIPTION
## Summary of the Pull Request

This PR fixes a simple logic error in the notification hook, which caused it to return an error response if the Teams endpoint succeeded.
In addition, this changes the code to return proper HTTP error codes if the script fails.

## PR Checklist
* [ ] Applies to work item: #xxx
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/onefuzz) and sign the CLI.
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx
