### PR TITLE
Bump azure_* crates

### DIFF
--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -141,9 +141,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "azure_core"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6424becb946de1b1eff7bf5fbc86fabf7457637c88b63dd967b219a712c322c"
+checksum = "e691a99e962919e047217367613b3dd39d7510ef1cebbe1e04980117d8fab42f"
 dependencies = [
  "async-trait",
  "base64",
@@ -168,9 +168,9 @@ dependencies = [
 
 [[package]]
 name = "azure_storage"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d0de4ed66067ca1afa0a07d787a6fe001288a162409b8308c45909044552ca"
+checksum = "8f53f36301c968007aa54f40a39cf95bb710f47b3fe2ed360fc82d8080854621"
 dependencies = [
  "RustyXML",
  "async-trait",
@@ -193,9 +193,9 @@ dependencies = [
 
 [[package]]
 name = "azure_storage_blobs"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69ea7177f0b3c64196766fcd442ac9664658a194070d082ae8876406800040b"
+checksum = "7d965285e7d3ebe8c34d921149bb2f1972ccba71ac5588cb82cfe9252a9578b5"
 dependencies = [
  "RustyXML",
  "azure_core",

--- a/src/agent/onefuzz-task/Cargo.toml
+++ b/src/agent/onefuzz-task/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 license = "MIT"
 
 [features]
-integration_test=[]
+integration_test = []
 
 [dependencies]
 anyhow = { version = "1.0", features = ["backtrace"] }
@@ -26,7 +26,11 @@ lazy_static = "1.4"
 log = "0.4"
 num_cpus = "1.13"
 regex = "1.6.0"
-reqwest = { version = "0.11", features = ["json", "stream", "native-tls-vendored"], default-features=false }
+reqwest = { version = "0.11", features = [
+    "json",
+    "stream",
+    "native-tls-vendored",
+], default-features = false }
 serde = "1.0"
 serde_json = "1.0"
 serde-xml-rs = "0.6"
@@ -46,8 +50,17 @@ tokio-stream = "0.1"
 tui = { version = "0.18", default-features = false, features = ['crossterm'] }
 url = { version = "2.3", features = ["serde"] }
 uuid = { version = "0.8", features = ["serde", "v4"] }
-chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
+chrono = { version = "0.4", default-features = false, features = [
+    "clock",
+    "std",
+] }
 
-azure_core = { version = "0.5", default-features = false, features = ["enable_reqwest"] }
-azure_storage = { version = "0.6", default-features = false, features = ["enable_reqwest"] }
-azure_storage_blobs = { version = "0.6", default-features = false, features = ["enable_reqwest"] }
+azure_core = { version = "0.6", default-features = false, features = [
+    "enable_reqwest",
+] }
+azure_storage = { version = "0.7", default-features = false, features = [
+    "enable_reqwest",
+] }
+azure_storage_blobs = { version = "0.7", default-features = false, features = [
+    "enable_reqwest",
+] }

--- a/src/agent/onefuzz-task/src/tasks/task_logger.rs
+++ b/src/agent/onefuzz-task/src/tasks/task_logger.rs
@@ -103,7 +103,6 @@ impl BlobLogWriter {
                 let blob_client = container_client.blob_client(format!("{}/1.log", prefix));
                 blob_client
                     .put_append_blob()
-                    .into_future()
                     .await
                     .map_err(|e| anyhow!(e.to_string()))?;
                 1
@@ -154,7 +153,6 @@ impl LogWriter<BlobLogWriter> for BlobLogWriter {
         let result = blob_client
             .append_block(data_stream)
             .condition_max_size(self.max_log_size)
-            .into_future()
             .await;
 
         match result {
@@ -191,7 +189,6 @@ impl LogWriter<BlobLogWriter> for BlobLogWriter {
 
         blob_client
             .put_append_blob()
-            .into_future()
             .await
             .map_err(|e| anyhow!(e.to_string()))?;
 


### PR DESCRIPTION
Bump the crates which dependabot is trying to bump.

Remove invocations of `into_future` as `.await` now automatically uses the [`IntoFuture` trait](https://doc.rust-lang.org/std/future/trait.IntoFuture.html) as of 1.64. 