### PR TITLE
More default devcontainer settings (format on save, Python linters)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,11 +13,16 @@
 		},
 		"rust-analyzer.checkOnSave.command": "clippy",
 		"rust-analyzer.linkedProjects": [
-			"/workspaces/onefuzz/src/agent/Cargo.toml"
+			"/workspaces/onefuzz/src/agent/Cargo.toml",
+			"/workspaces/onefuzz/src/proxy-manager/Cargo.toml"
 		],
 		"python.defaultInterpreterPath": "/workspaces/onefuzz/src/venv/bin/python",
+		"python.formatting.provider": "black",
+		"python.linting.flake8Enabled": true,
+		"python.linting.mypyEnabled": true,
 		"omnisharp.enableRoslynAnalyzers": true,
-		"omnisharp.enableEditorConfigSupport": true
+		"omnisharp.enableEditorConfigSupport": true,
+		"editor.formatOnSave": true
 	},
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [


### PR DESCRIPTION
Set some more devcontainer VS Code settings by default:

- set desired Python formatter & linters
- set format-on-save by default
- add `proxy-manager` to default Rust projects