### PR TITLE
Include a reason when telling a node it is not allowed to schedule work

### DIFF
--- a/src/ApiService/ApiService/Functions/AgentCanSchedule.cs
+++ b/src/ApiService/ApiService/Functions/AgentCanSchedule.cs
@@ -56,8 +56,7 @@ public class AgentCanSchedule {
 
         if (workStopped) {
             _log.Info($"Work stopped for: {canScheduleRequest.MachineId:Tag:MachineId} and {canScheduleRequest.TaskId:Tag:TaskId}");
-            allowed = false;
-            reason = "Work stopped";
+            return await RequestHandling.Ok(req, new CanSchedule(Allowed: false, WorkStopped: workStopped, Reason: "Work stopped"));
         }
 
         var scp = await _context.NodeOperations.AcquireScaleInProtection(node);

--- a/src/ApiService/ApiService/OneFuzzTypes/Responses.cs
+++ b/src/ApiService/ApiService/OneFuzzTypes/Responses.cs
@@ -11,7 +11,8 @@ public abstract record BaseResponse() {
 
 public record CanSchedule(
     bool Allowed,
-    bool WorkStopped
+    bool WorkStopped,
+    string? Reason
 ) : BaseResponse();
 
 public record PendingNodeCommand(

--- a/src/ApiService/ApiService/onefuzzlib/NodeOperations.cs
+++ b/src/ApiService/ApiService/onefuzzlib/NodeOperations.cs
@@ -6,10 +6,15 @@ using Azure.Data.Tables;
 
 namespace Microsoft.OneFuzz.Service;
 
+public record CanProcessNewWorkResponse(bool IsAllowed, string? Reason) {
+    public static CanProcessNewWorkResponse Allowed() => new CanProcessNewWorkResponse(true, null);
+    public static CanProcessNewWorkResponse NotAllowed(string reason) => new CanProcessNewWorkResponse(false, reason);
+};
+
 public interface INodeOperations : IStatefulOrm<Node, NodeState> {
     Task<Node?> GetByMachineId(Guid machineId);
 
-    Task<bool> CanProcessNewWork(Node node);
+    Task<CanProcessNewWorkResponse> CanProcessNewWork(Node node);
 
     Task<OneFuzzResult<Node>> AcquireScaleInProtection(Node node);
     Task<OneFuzzResultVoid> ReleaseScaleInProtection(Node node);
@@ -165,74 +170,65 @@ public class NodeOperations : StatefulOrm<Node, NodeState, NodeOperations>, INod
         return new NodeInfo(node, scalesetResult.OkV, instanceId);
     }
 
-    public async Task<bool> CanProcessNewWork(Node node) {
+
+
+    public async Task<CanProcessNewWorkResponse> CanProcessNewWork(Node node) {
         if (IsOutdated(node) && _context.ServiceConfiguration.OneFuzzAllowOutdatedAgent != "true") {
-            _logTracer.Info($"can_process_new_work agent and service versions differ, stopping node. {node.MachineId:Tag:MachineId} {node.Version:Tag:AgentVersion} {_context.ServiceConfiguration.OneFuzzVersion:Tag:ServiceVersion}");
             _ = await Stop(node, done: true);
-            return false;
+            return CanProcessNewWorkResponse.NotAllowed("agent and service versions differ");
         }
 
         if (IsTooOld(node)) {
-            _logTracer.Info($"can_process_new_work node is too old {node.MachineId:Tag:MachineId}");
             _ = await Stop(node, done: true);
-            return false;
+            return CanProcessNewWorkResponse.NotAllowed("node is too old");
         }
 
         if (!node.State.CanProcessNewWork()) {
-            _logTracer.Info($"can_process_new_work node not in appropriate state for new work {node.MachineId:Tag:MachineId} {node.State:Tag:State}");
-            return false;
+            return CanProcessNewWorkResponse.NotAllowed("node not in appropriate state for new work");
         }
 
         if (node.State.ReadyForReset()) {
-            _logTracer.Info($"can_process_new_work node is set for reset {node.MachineId:Tag:MachineId}");
-            return false;
+            return CanProcessNewWorkResponse.NotAllowed("node is set for reset");
         }
 
         if (node.DeleteRequested) {
-            _logTracer.Info($"can_process_new_work is set to be deleted {node.MachineId:Tag:MachineId}");
             _ = await Stop(node, done: true);
-            return false;
+            return CanProcessNewWorkResponse.NotAllowed("node is set to be deleted");
         }
 
         if (node.ReimageRequested) {
-            _logTracer.Info($"can_process_new_work is set to be reimaged {node.MachineId:Tag:MachineId}");
             _ = await Stop(node, done: true);
-            return false;
+            return CanProcessNewWorkResponse.NotAllowed("node is set to be reimaged");
         }
 
         if (await CouldShrinkScaleset(node)) {
-            _logTracer.Info($"can_process_new_work node scheduled to shrink {node.MachineId:Tag:MachineId}");
             _ = await SetHalt(node);
-            return false;
+            return CanProcessNewWorkResponse.NotAllowed("node is scheduled to shrink");
         }
 
         if (node.ScalesetId != null) {
             var scalesetResult = await _context.ScalesetOperations.GetById(node.ScalesetId.Value);
             if (!scalesetResult.IsOk) {
-                _logTracer.Info($"can_process_new_work invalid scaleset {node.ScalesetId:Tag:ScalesetId} - {node.MachineId:Tag:MachineId}");
-                return false;
+                return CanProcessNewWorkResponse.NotAllowed("invalid scaleset");
             }
 
             var scaleset = scalesetResult.OkV;
             if (!scaleset.State.IsAvailable()) {
-                _logTracer.Info($"can_process_new_work scaleset not available for work {scaleset.ScalesetId:Tag:ScalesetId} - {node.MachineId:Tag:MachineId} {scaleset.State:Tag:State}");
-                return false;
+                return CanProcessNewWorkResponse.NotAllowed($"scaleset not available for work. Scaleset state '{scaleset.State}'"); ;
             }
         }
 
         var poolResult = await _context.PoolOperations.GetByName(node.PoolName);
         if (!poolResult.IsOk) {
-            _logTracer.Info($"can_schedule - invalid pool {node.PoolName:Tag:PoolName} - {node.MachineId:Tag:MachineId}");
-            return false;
+            return CanProcessNewWorkResponse.NotAllowed("invalid pool"); ;
         }
 
         var pool = poolResult.OkV;
         if (!PoolStateHelper.Available.Contains(pool.State)) {
-            _logTracer.Info($"can_schedule - pool is not available for work {node.PoolName:Tag:PoolName} - {node.MachineId:Tag:MachineId}");
-            return false;
+            return CanProcessNewWorkResponse.NotAllowed("pool is not available for work"); ;
         }
 
-        return true;
+        return CanProcessNewWorkResponse.Allowed();
     }
 
 

--- a/src/agent/onefuzz-agent/src/agent.rs
+++ b/src/agent/onefuzz-agent/src/agent.rs
@@ -159,10 +159,14 @@ impl Agent {
                     }
                 }
             } else {
+                let reason = can_schedule.reason.map_or("".to_string(), |r| r);
                 // We cannot schedule the work set. Depending on why, we want to either drop the work
                 // (because it is no longer valid for anyone) or do nothing (because our version is out
                 // of date, and we want another node to pick it up).
-                warn!("unable to schedule work set: {:?}", msg.work_set);
+                warn!(
+                    "unable to schedule work set: {:?}, Reason {}",
+                    msg.work_set, reason
+                );
 
                 // If `work_stopped`, the work set is not valid for any node, and we should drop it for the
                 // entire pool by claiming but not executing it.

--- a/src/agent/onefuzz-agent/src/coordinator.rs
+++ b/src/agent/onefuzz-agent/src/coordinator.rs
@@ -125,7 +125,7 @@ pub struct CanScheduleRequest {
     task_id: Uuid,
 }
 
-#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct CanSchedule {
     /// If true, then the receiving node can schedule the work.
     /// Otherwise, the receiver should inspect `work_stopped`.
@@ -137,6 +137,9 @@ pub struct CanSchedule {
     /// No node in the pool may schedule the work, so the receiving node should
     /// claim (delete) and drop the work set.
     pub work_stopped: bool,
+
+    /// contains the reason why the work was stopped or not allowed.
+    pub reason: Option<String>,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]

--- a/src/agent/onefuzz-agent/src/coordinator/double.rs
+++ b/src/agent/onefuzz-agent/src/coordinator/double.rs
@@ -24,6 +24,7 @@ impl ICoordinator for CoordinatorDouble {
         Ok(CanSchedule {
             allowed: true,
             work_stopped: true,
+            reason: None,
         })
     }
 }

--- a/src/deny.toml
+++ b/src/deny.toml
@@ -17,6 +17,8 @@ yanked = "deny"
 ignore = [
     "RUSTSEC-2022-0048", # xml-rs is unmaintained
     "RUSTSEC-2021-0139", # ansi_term is unmaintained
+    "RUSTSEC-2021-0145", # atty bug: we are unaffected (no custom allocator)
+]
 ]
 
 [bans]

--- a/src/deny.toml
+++ b/src/deny.toml
@@ -19,7 +19,6 @@ ignore = [
     "RUSTSEC-2021-0139", # ansi_term is unmaintained
     "RUSTSEC-2021-0145", # atty bug: we are unaffected (no custom allocator)
 ]
-]
 
 [bans]
 


### PR DESCRIPTION
Updated the response given by the server when denying work to a node. 
We now include a reason field to containing an explanation 