### PR TITLE
Fix invocation of functionapp in the deployment script

### DIFF
--- a/src/deployment/deploy.py
+++ b/src/deployment/deploy.py
@@ -1237,7 +1237,7 @@ class Client:
                             "--name",
                             self.application_name,
                             "--resource-group",
-                            self.application_name,
+                            self.resource_group,
                             "--settings",
                         ]
                         + python_settings,
@@ -1254,7 +1254,7 @@ class Client:
                             "--name",
                             self.application_name + DOTNET_APPLICATION_SUFFIX,
                             "--resource-group",
-                            self.application_name,
+                            self.resource_group,
                             "--settings",
                         ]
                         + dotnet_settings,


### PR DESCRIPTION
## Summary of the Pull Request
The deployment script was using the application name as the resource group when updating the pp settings

#2644

