### PR TITLE
Making machine identity a parameter of the agent config

### DIFF
--- a/src/agent/onefuzz-agent/src/agent.rs
+++ b/src/agent/onefuzz-agent/src/agent.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(clippy::too_many_arguments)]
 use anyhow::{Error, Result};
 use tokio::time;
 

--- a/src/agent/onefuzz-agent/src/agent/tests.rs
+++ b/src/agent/onefuzz-agent/src/agent/tests.rs
@@ -35,6 +35,7 @@ impl Fixture {
             work_queue,
             worker_runner,
             None,
+            true,
         )
     }
 

--- a/src/agent/onefuzz-agent/src/commands.rs
+++ b/src/agent/onefuzz-agent/src/commands.rs
@@ -155,11 +155,6 @@ pub async fn add_ssh_key(key_info: &SshKeyInfo) -> Result<()> {
 
 #[cfg(target_family = "unix")]
 pub async fn add_ssh_key(key_info: &SshKeyInfo) -> Result<()> {
-    if get_scaleset_name().await?.is_none() {
-        warn!("adding ssh keys only supported on managed nodes");
-        return Ok(());
-    }
-
     let user =
         get_user_by_name(ONEFUZZ_SERVICE_USER).ok_or_else(|| format_err!("unable to find user"))?;
     info!("adding ssh key:{:?} to user:{:?}", key_info, user);

--- a/src/agent/onefuzz-agent/src/commands.rs
+++ b/src/agent/onefuzz-agent/src/commands.rs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 use anyhow::{Context, Result};
-use onefuzz::{auth::Secret, machine_id::get_scaleset_name};
+use onefuzz::auth::Secret;
 use std::process::Stdio;
 use tokio::{fs, io::AsyncWriteExt, process::Command};
 
@@ -32,11 +32,6 @@ pub struct SshKeyInfo {
 
 #[cfg(target_family = "windows")]
 pub async fn add_ssh_key(key_info: &SshKeyInfo) -> Result<()> {
-    if get_scaleset_name().await?.is_none() {
-        warn!("adding ssh keys only supported on managed nodes");
-        return Ok(());
-    }
-
     let mut ssh_path =
         PathBuf::from(env::var("ProgramData").unwrap_or_else(|_| "c:\\programdata".to_string()));
     ssh_path.push("ssh");

--- a/src/agent/onefuzz-agent/src/heartbeat.rs
+++ b/src/agent/onefuzz-agent/src/heartbeat.rs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 use crate::onefuzz::heartbeat::HeartbeatClient;
-use crate::onefuzz::machine_id::{get_machine_id, get_machine_name};
 use anyhow::Result;
 use reqwest::Url;
 use serde::{self, Deserialize, Serialize};
@@ -29,9 +28,11 @@ pub struct AgentContext {
 
 pub type AgentHeartbeatClient = HeartbeatClient<AgentContext, HeartbeatData>;
 
-pub async fn init_agent_heartbeat(queue_url: Url) -> Result<AgentHeartbeatClient> {
-    let node_id = get_machine_id().await?;
-    let machine_name = get_machine_name().await?;
+pub async fn init_agent_heartbeat(
+    queue_url: Url,
+    node_id: Uuid,
+    machine_name: String,
+) -> Result<AgentHeartbeatClient> {
     let hb = HeartbeatClient::init_heartbeat(
         AgentContext {
             node_id,

--- a/src/agent/onefuzz-agent/src/main.rs
+++ b/src/agent/onefuzz-agent/src/main.rs
@@ -21,10 +21,7 @@ use std::process::{Command, Stdio};
 
 use anyhow::{Context, Result};
 use clap::Parser;
-use onefuzz::{
-    machine_id::{get_machine_id, get_scaleset_name},
-    process::ExitStatus,
-};
+use onefuzz::process::ExitStatus;
 use onefuzz_telemetry::{self as telemetry, EventData, Role};
 use std::io::{self, Write};
 use uuid::Uuid;
@@ -202,7 +199,7 @@ async fn load_config(opt: RunOpt) -> Result<StaticConfig> {
     info!("loading supervisor agent config");
 
     let config = match &opt.config_path {
-        Some(config_path) => StaticConfig::from_file(config_path)?,
+        Some(config_path) => StaticConfig::from_file(config_path).await?,
         None => StaticConfig::from_env()?,
     };
 
@@ -266,11 +263,11 @@ async fn check_existing_worksets(coordinator: &mut coordinator::Coordinator) -> 
 
 async fn run_agent(config: StaticConfig) -> Result<()> {
     telemetry::set_property(EventData::InstanceId(config.instance_id));
-    telemetry::set_property(EventData::MachineId(get_machine_id().await?));
+    telemetry::set_property(EventData::MachineId(config.machine_identity.machine_id));
     telemetry::set_property(EventData::Version(env!("ONEFUZZ_VERSION").to_string()));
     telemetry::set_property(EventData::Role(Role::Supervisor));
-    let scaleset = get_scaleset_name().await?;
-    if let Some(scaleset_name) = &scaleset {
+
+    if let Some(scaleset_name) = &config.machine_identity.scaleset_name {
         telemetry::set_property(EventData::ScalesetId(scaleset_name.to_string()));
     }
 
@@ -300,7 +297,14 @@ async fn run_agent(config: StaticConfig) -> Result<()> {
     let work_queue = work::WorkQueue::new(registration.clone())?;
 
     let agent_heartbeat = match config.heartbeat_queue {
-        Some(url) => Some(init_agent_heartbeat(url).await?),
+        Some(url) => Some(
+            init_agent_heartbeat(
+                url,
+                config.machine_identity.machine_id,
+                config.machine_identity.machine_name,
+            )
+            .await?,
+        ),
         None => None,
     };
     let mut agent = agent::Agent::new(
@@ -311,6 +315,7 @@ async fn run_agent(config: StaticConfig) -> Result<()> {
         Box::new(work_queue),
         Box::new(worker::WorkerRunner),
         agent_heartbeat,
+        config.managed,
     );
 
     info!("running agent");

--- a/src/agent/onefuzz-agent/src/scheduler.rs
+++ b/src/agent/onefuzz-agent/src/scheduler.rs
@@ -54,10 +54,14 @@ impl Scheduler {
         Self::default()
     }
 
-    pub async fn execute_command(&mut self, cmd: &NodeCommand) -> Result<()> {
+    pub async fn execute_command(&mut self, cmd: &NodeCommand, managed: bool) -> Result<()> {
         match cmd {
             NodeCommand::AddSshKey(ssh_key_info) => {
-                add_ssh_key(ssh_key_info).await?;
+                if managed {
+                    add_ssh_key(ssh_key_info).await?;
+                } else {
+                    warn!("adding ssh keys only supported on managed nodes");
+                }
             }
             NodeCommand::StopTask(stop_task) => {
                 if let Scheduler::Busy(state) = self {

--- a/src/agent/onefuzz-agent/src/worker.rs
+++ b/src/agent/onefuzz-agent/src/worker.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 use std::{
+    collections::HashMap,
     path::{Path, PathBuf},
     process::{Child, ChildStderr, ChildStdout, Command, Stdio},
     thread::{self, JoinHandle},
@@ -8,11 +9,16 @@ use std::{
 
 use anyhow::{format_err, Context as AnyhowContext, Result};
 use downcast_rs::Downcast;
-use onefuzz::process::{ExitStatus, Output};
+use onefuzz::{
+    machine_id::MachineIdentity,
+    process::{ExitStatus, Output},
+};
 use tokio::fs;
 
 use crate::buffer::TailBuffer;
 use crate::work::*;
+
+use serde_json::Value;
 
 // Max length of captured output streams from worker child processes.
 const MAX_TAIL_LEN: usize = 40960;
@@ -209,9 +215,18 @@ impl IWorkerRunner for WorkerRunner {
 
         debug!("created worker working dir: {}", working_dir.display());
 
+        // inject the machine_identity in the config file
+        let work_config = work.config.expose_ref();
+        let mut config: HashMap<String, Value> = serde_json::from_str(work_config.as_str())?;
+
+        config.insert(
+            "machine_identity".to_string(),
+            serde_json::to_value(MachineIdentity::default())?,
+        );
+
         let config_path = work.config_path()?;
 
-        fs::write(&config_path, work.config.expose_ref())
+        fs::write(&config_path, serde_json::to_string(&config)?.as_bytes())
             .await
             .with_context(|| format!("unable to save task config: {}", config_path.display()))?;
 

--- a/src/agent/onefuzz-task/src/local/libfuzzer_test_input.rs
+++ b/src/agent/onefuzz-task/src/local/libfuzzer_test_input.rs
@@ -35,6 +35,7 @@ pub async fn run(args: &clap::ArgMatches<'_>, event_sender: Option<Sender<UiEven
         check_retry_count,
         setup_dir: &context.common_config.setup_dir,
         minimized_stack_depth: None,
+        machine_identity: context.common_config.machine_identity,
     };
 
     let result = test_input(config).await?;

--- a/src/agent/onefuzz-task/src/local/test_input.rs
+++ b/src/agent/onefuzz-task/src/local/test_input.rs
@@ -40,6 +40,7 @@ pub async fn run(args: &clap::ArgMatches<'_>, event_sender: Option<Sender<UiEven
         minimized_stack_depth: None,
         check_asan_log,
         check_debugger,
+        machine_identity: context.common_config.machine_identity.clone(),
     };
 
     let result = test_input(config).await?;

--- a/src/agent/onefuzz-task/src/managed/cmd.rs
+++ b/src/agent/onefuzz-task/src/managed/cmd.rs
@@ -4,7 +4,6 @@ use std::path::PathBuf;
 
 use anyhow::Result;
 use clap::{App, Arg, SubCommand};
-use onefuzz::machine_id::get_machine_id;
 use std::time::Duration;
 
 use crate::tasks::{
@@ -28,7 +27,7 @@ pub async fn run(args: &clap::ArgMatches<'_>) -> Result<()> {
     let check_oom = out_of_memory(min_available_memory_bytes);
 
     let common = config.common().clone();
-    let machine_id = get_machine_id().await?;
+    let machine_id = common.machine_identity.machine_id;
     let task_logger = if let Some(logs) = common.logs.clone() {
         let rx = onefuzz_telemetry::subscribe_to_events()?;
 

--- a/src/agent/onefuzz-task/src/tasks/analysis/generic.rs
+++ b/src/agent/onefuzz-task/src/tasks/analysis/generic.rs
@@ -198,7 +198,7 @@ pub async fn run_tool(
     let target_exe =
         try_resolve_setup_relative_path(&config.common.setup_dir, &config.target_exe).await?;
 
-    let expand = Expand::new()
+    let expand = Expand::new(&config.common.machine_identity)
         .machine_id()
         .await?
         .input_path(&input)

--- a/src/agent/onefuzz-task/src/tasks/coverage/dotnet.rs
+++ b/src/agent/onefuzz-task/src/tasks/coverage/dotnet.rs
@@ -266,7 +266,7 @@ impl<'a> TaskContext<'a> {
         // Try to expand `target_exe` with support for `{tools_dir}`.
         //
         // Allows using `LibFuzzerDotnetLoader.exe` from a shared tools container.
-        let expand = Expand::new().tools_dir(tools_dir);
+        let expand = Expand::new(&self.config.common.machine_identity).tools_dir(tools_dir);
         let expanded = expand.evaluate_value(&self.config.target_exe.to_string_lossy())?;
         let expanded_path = Path::new(&expanded);
 
@@ -293,7 +293,7 @@ impl<'a> TaskContext<'a> {
     async fn command_for_input(&self, input: &Path) -> Result<Command> {
         let target_exe = self.target_exe().await?;
 
-        let expand = Expand::new()
+        let expand = Expand::new(&self.config.common.machine_identity)
             .machine_id()
             .await?
             .input_path(input)

--- a/src/agent/onefuzz-task/src/tasks/coverage/generic.rs
+++ b/src/agent/onefuzz-task/src/tasks/coverage/generic.rs
@@ -288,7 +288,7 @@ impl<'a> TaskContext<'a> {
             try_resolve_setup_relative_path(&self.config.common.setup_dir, &self.config.target_exe)
                 .await?;
 
-        let expand = Expand::new()
+        let expand = Expand::new(&self.config.common.machine_identity)
             .machine_id()
             .await?
             .input_path(input)

--- a/src/agent/onefuzz-task/src/tasks/fuzz/generator.rs
+++ b/src/agent/onefuzz-task/src/tasks/fuzz/generator.rs
@@ -102,6 +102,7 @@ impl GeneratorTask {
             &target_exe,
             &self.config.target_options,
             &self.config.target_env,
+            self.config.common.machine_identity.clone(),
         )
         .check_asan_log(self.config.check_asan_log)
         .check_debugger(self.config.check_debugger)
@@ -163,7 +164,7 @@ impl GeneratorTask {
     ) -> Result<()> {
         utils::reset_tmp_dir(&output_dir).await?;
         let (mut generator, generator_path) = {
-            let expand = Expand::new()
+            let expand = Expand::new(&self.config.common.machine_identity)
                 .machine_id()
                 .await?
                 .setup_dir(&self.config.common.setup_dir)

--- a/src/agent/onefuzz-task/src/tasks/fuzz/libfuzzer/dotnet.rs
+++ b/src/agent/onefuzz-task/src/tasks/fuzz/libfuzzer/dotnet.rs
@@ -86,6 +86,7 @@ impl common::LibFuzzerType for LibFuzzerDotnet {
             options,
             env,
             &config.common.setup_dir,
+            config.common.machine_identity.clone(),
         ))
     }
 

--- a/src/agent/onefuzz-task/src/tasks/fuzz/libfuzzer/generic.rs
+++ b/src/agent/onefuzz-task/src/tasks/fuzz/libfuzzer/generic.rs
@@ -28,6 +28,7 @@ impl common::LibFuzzerType for GenericLibFuzzer {
             config.target_options.clone(),
             config.target_env.clone(),
             &config.common.setup_dir,
+            config.common.machine_identity.clone(),
         ))
     }
 }

--- a/src/agent/onefuzz-task/src/tasks/fuzz/supervisor.rs
+++ b/src/agent/onefuzz-task/src/tasks/fuzz/supervisor.rs
@@ -144,7 +144,7 @@ pub async fn spawn(config: SupervisorConfig) -> Result<(), Error> {
 
     let monitor_path = if let Some(stats_file) = &config.stats_file {
         Some(
-            Expand::new()
+            Expand::new(&config.common.machine_identity)
                 .machine_id()
                 .await?
                 .runtime_dir(runtime_dir.path())
@@ -204,7 +204,7 @@ async fn start_supervisor(
         None
     };
 
-    let expand = Expand::new()
+    let expand = Expand::new(&config.common.machine_identity)
         .machine_id()
         .await?
         .supervisor_exe(&config.supervisor_exe)

--- a/src/agent/onefuzz-task/src/tasks/heartbeat.rs
+++ b/src/agent/onefuzz-task/src/tasks/heartbeat.rs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 use crate::onefuzz::heartbeat::HeartbeatClient;
-use crate::onefuzz::machine_id::{get_machine_id, get_machine_name};
 use anyhow::Result;
 use reqwest::Url;
 use serde::{self, Deserialize, Serialize};
@@ -40,9 +39,9 @@ pub async fn init_task_heartbeat(
     task_id: Uuid,
     job_id: Uuid,
     initial_delay: Option<Duration>,
+    machine_id: Uuid,
+    machine_name: String,
 ) -> Result<TaskHeartbeatClient> {
-    let machine_id = get_machine_id().await?;
-    let machine_name = get_machine_name().await?;
     let hb = HeartbeatClient::init_heartbeat(
         TaskContext {
             task_id,

--- a/src/agent/onefuzz-task/src/tasks/merge/generic.rs
+++ b/src/agent/onefuzz-task/src/tasks/merge/generic.rs
@@ -130,7 +130,7 @@ async fn merge(config: &Config, output_dir: impl AsRef<Path>) -> Result<()> {
     let target_exe =
         try_resolve_setup_relative_path(&config.common.setup_dir, &config.target_exe).await?;
 
-    let expand = Expand::new()
+    let expand = Expand::new(&config.common.machine_identity)
         .machine_id()
         .await?
         .input_marker(&config.supervisor_input_marker)

--- a/src/agent/onefuzz-task/src/tasks/merge/libfuzzer_merge.rs
+++ b/src/agent/onefuzz-task/src/tasks/merge/libfuzzer_merge.rs
@@ -46,6 +46,7 @@ pub async fn spawn(config: Arc<Config>) -> Result<()> {
         config.target_options.clone(),
         config.target_env.clone(),
         &config.common.setup_dir,
+        config.common.machine_identity.clone(),
     );
     fuzzer.verify(config.check_fuzzer_help, None).await?;
 
@@ -159,6 +160,7 @@ pub async fn merge_inputs(
         config.target_options.clone(),
         config.target_env.clone(),
         &config.common.setup_dir,
+        config.common.machine_identity.clone(),
     );
     merger
         .merge(&config.unique_inputs.local_path, &candidates)

--- a/src/agent/onefuzz-task/src/tasks/regression/generic.rs
+++ b/src/agent/onefuzz-task/src/tasks/regression/generic.rs
@@ -74,6 +74,7 @@ impl RegressionHandler for GenericRegressionTask {
             check_asan_log: self.config.check_asan_log,
             check_debugger: self.config.check_debugger,
             minimized_stack_depth: self.config.minimized_stack_depth,
+            machine_identity: self.config.common.machine_identity.clone(),
         };
         generic::test_input(args).await
     }

--- a/src/agent/onefuzz-task/src/tasks/regression/libfuzzer.rs
+++ b/src/agent/onefuzz-task/src/tasks/regression/libfuzzer.rs
@@ -71,6 +71,7 @@ impl RegressionHandler for LibFuzzerRegressionTask {
             target_timeout: self.config.target_timeout,
             check_retry_count: self.config.check_retry_count,
             minimized_stack_depth: self.config.minimized_stack_depth,
+            machine_identity: self.config.common.machine_identity.clone(),
         };
         libfuzzer_report::test_input(args).await
     }

--- a/src/agent/onefuzz-task/src/tasks/report/dotnet/generic.rs
+++ b/src/agent/onefuzz-task/src/tasks/report/dotnet/generic.rs
@@ -132,7 +132,7 @@ impl AsanProcessor {
         // Try to expand `target_exe` with support for `{tools_dir}`.
         //
         // Allows using `LibFuzzerDotnetLoader.exe` from a shared tools container.
-        let expand = Expand::new().tools_dir(tools_dir);
+        let expand = Expand::new(&self.config.common.machine_identity).tools_dir(tools_dir);
         let expanded = expand.evaluate_value(&self.config.target_exe.to_string_lossy())?;
         let expanded_path = Path::new(&expanded);
 
@@ -180,7 +180,7 @@ impl AsanProcessor {
         let mut args = vec![target_exe];
         args.extend(self.config.target_options.clone());
 
-        let expand = Expand::new()
+        let expand = Expand::new(&self.config.common.machine_identity)
             .input_path(input)
             .setup_dir(&self.config.common.setup_dir);
         let expanded_args = expand.evaluate(&args)?;

--- a/src/agent/onefuzz-task/src/tasks/report/generic.rs
+++ b/src/agent/onefuzz-task/src/tasks/report/generic.rs
@@ -10,7 +10,9 @@ use crate::tasks::{
 };
 use anyhow::{Context, Result};
 use async_trait::async_trait;
-use onefuzz::{blob::BlobUrl, input_tester::Tester, sha256, syncdir::SyncedDir};
+use onefuzz::{
+    blob::BlobUrl, input_tester::Tester, machine_id::MachineIdentity, sha256, syncdir::SyncedDir,
+};
 use reqwest::Url;
 use serde::Deserialize;
 use std::{
@@ -118,6 +120,7 @@ pub struct TestInputArgs<'a> {
     pub check_asan_log: bool,
     pub check_debugger: bool,
     pub minimized_stack_depth: Option<usize>,
+    pub machine_identity: MachineIdentity,
 }
 
 pub async fn test_input(args: TestInputArgs<'_>) -> Result<CrashTestResult> {
@@ -126,6 +129,7 @@ pub async fn test_input(args: TestInputArgs<'_>) -> Result<CrashTestResult> {
         args.target_exe,
         args.target_options,
         args.target_env,
+        args.machine_identity.clone(),
     )
     .check_asan_log(args.check_asan_log)
     .check_debugger(args.check_debugger)
@@ -211,6 +215,7 @@ impl<'a> GenericReportProcessor<'a> {
             check_asan_log: self.config.check_asan_log,
             check_debugger: self.config.check_debugger,
             minimized_stack_depth: self.config.minimized_stack_depth,
+            machine_identity: self.config.common.machine_identity.clone(),
         };
         test_input(args).await.context("test input failed")
     }

--- a/src/agent/onefuzz/examples/test-input.rs
+++ b/src/agent/onefuzz/examples/test-input.rs
@@ -53,7 +53,13 @@ async fn main() -> Result<()> {
     }
 
     let env = Default::default();
-    let tester = Tester::new(&setup_dir, &opt.exe, &target_options, &env, MachineIdentity::default());
+    let tester = Tester::new(
+        &setup_dir,
+        &opt.exe,
+        &target_options,
+        &env,
+        MachineIdentity::default(),
+    );
 
     let check_debugger = !opt.no_check_debugger;
     let tester = tester

--- a/src/agent/onefuzz/examples/test-input.rs
+++ b/src/agent/onefuzz/examples/test-input.rs
@@ -4,7 +4,7 @@
 use std::path::PathBuf;
 
 use anyhow::Result;
-use onefuzz::input_tester::Tester;
+use onefuzz::{input_tester::Tester, machine_id::MachineIdentity};
 use structopt::StructOpt;
 
 #[derive(Debug, PartialEq, Eq, StructOpt)]
@@ -53,7 +53,7 @@ async fn main() -> Result<()> {
     }
 
     let env = Default::default();
-    let tester = Tester::new(&setup_dir, &opt.exe, &target_options, &env);
+    let tester = Tester::new(&setup_dir, &opt.exe, &target_options, &env, MachineIdentity::default());
 
     let check_debugger = !opt.no_check_debugger;
     let tester = tester

--- a/src/agent/onefuzz/src/expand.rs
+++ b/src/agent/onefuzz/src/expand.rs
@@ -520,12 +520,11 @@ mod tests {
     #[tokio::test]
     async fn test_expand_machine_id() -> Result<()> {
         let machine_id = Uuid::new_v4();
-        let expand = Expand::new(&MachineIdentity {
-            machine_id: machine_id,
+        let machine_identity = MachineIdentity {
+            machine_id,
             ..Default::default()
-        })
-        .machine_id()
-        .await?;
+        };
+        let expand = Expand::new(&machine_identity).machine_id().await?;
         let expanded = expand.evaluate_value("{machine_id}")?;
         // Check that "{machine_id}" expands to a valid UUID, but don't worry about the actual value.
         let expanded_machine_id = Uuid::parse_str(&expanded)?;

--- a/src/agent/onefuzz/src/input_tester.rs
+++ b/src/agent/onefuzz/src/input_tester.rs
@@ -7,6 +7,7 @@ use crate::{
     asan::{add_asan_log_env, check_asan_path, check_asan_string},
     env::{get_path_with_directory, update_path, LD_LIBRARY_PATH, PATH},
     expand::Expand,
+    machine_id::MachineIdentity,
     process::run_cmd,
 };
 use anyhow::{Context, Error, Result};
@@ -36,6 +37,7 @@ pub struct Tester<'a> {
     check_retry_count: u64,
     add_setup_to_ld_library_path: bool,
     add_setup_to_path: bool,
+    machine_identity: MachineIdentity,
 }
 
 #[derive(Debug)]
@@ -57,6 +59,7 @@ impl<'a> Tester<'a> {
         exe_path: &'a Path,
         arguments: &'a [String],
         environ: &'a HashMap<String, String>,
+        machine_identity: MachineIdentity,
     ) -> Self {
         Self {
             setup_dir,
@@ -70,6 +73,7 @@ impl<'a> Tester<'a> {
             check_retry_count: 0,
             add_setup_to_ld_library_path: false,
             add_setup_to_path: false,
+            machine_identity,
         }
     }
 
@@ -289,7 +293,7 @@ impl<'a> Tester<'a> {
         };
 
         let (argv, env) = {
-            let expand = Expand::new()
+            let expand = Expand::new(&self.machine_identity)
                 .machine_id()
                 .await?
                 .input_path(input_file)

--- a/src/agent/onefuzz/src/libfuzzer.rs
+++ b/src/agent/onefuzz/src/libfuzzer.rs
@@ -445,6 +445,7 @@ mod tests {
             options.clone(),
             env.clone(),
             &temp_setup_dir.path(),
+            MachineIdentity::default(),
         );
 
         // verify catching bad exits with -help=1
@@ -473,6 +474,7 @@ mod tests {
             options.clone(),
             env.clone(),
             &temp_setup_dir.path(),
+            MachineIdentity::default(),
         );
         // verify good exits with -help=1
         assert!(

--- a/src/agent/onefuzz/src/machine_id.rs
+++ b/src/agent/onefuzz/src/machine_id.rs
@@ -28,9 +28,6 @@ const VM_NAME_URL: &str =
 const VM_SCALESET_NAME: &str =
 "http://169.254.169.254/metadata/instance/compute/vmScaleSetName?api-version=2020-06-01&format=text";
 
-const COMPUTE_METADATA_URL: &str =
-    "http://169.254.169.254/metadata/instance/compute?api-version=2020-06-01";
-
 impl MachineIdentity {
     pub async fn from_metadata() -> Result<Self> {
         let machine_id = Self::get_machine_id().await?;

--- a/src/agent/onefuzz/src/machine_id.rs
+++ b/src/agent/onefuzz/src/machine_id.rs
@@ -10,6 +10,13 @@ use std::time::Duration;
 use tokio::fs;
 use uuid::Uuid;
 
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Default, Serialize)]
+pub struct MachineIdentity {
+    pub machine_id: Uuid,
+    pub machine_name: String,
+    pub scaleset_name: Option<String>,
+}
+
 // https://docs.microsoft.com/en-us/azure/virtual-machines/windows/instance-metadata-service#tracking-vm-running-on-azure
 const IMS_ID_URL: &str =
     "http://169.254.169.254/metadata/instance/compute/vmId?api-version=2020-06-01&format=text";
@@ -19,127 +26,156 @@ const VM_NAME_URL: &str =
     "http://169.254.169.254/metadata/instance/compute/name?api-version=2020-06-01&format=text";
 
 const VM_SCALESET_NAME: &str =
-    "http://169.254.169.254/metadata/instance/compute/vmScaleSetName?api-version=2020-06-01&format=text";
+"http://169.254.169.254/metadata/instance/compute/vmScaleSetName?api-version=2020-06-01&format=text";
 
-pub async fn get_ims_id() -> Result<Uuid> {
-    let path = onefuzz_etc()?.join("ims_id");
-    let body = match fs::read_to_string(&path).await {
-        Ok(body) => body,
-        Err(_) => {
-            let resp = reqwest::Client::new()
-                .get(IMS_ID_URL)
-                .timeout(Duration::from_millis(500))
-                .header("Metadata", "true")
-                .send_retry_default()
-                .await
-                .context("get_ims_id")?;
+const COMPUTE_METADATA_URL: &str =
+    "http://169.254.169.254/metadata/instance/compute?api-version=2020-06-01";
+
+impl MachineIdentity {
+    pub async fn from_metadata() -> Result<Self> {
+        let machine_id = Self::get_machine_id().await?;
+        let machine_name = Self::get_machine_name().await?;
+        let scaleset_name = Self::get_scaleset_name().await?;
+
+        Ok(Self {
+            machine_id,
+            machine_name,
+            scaleset_name,
+        })
+    }
+
+    pub fn from_env() -> Result<Self> {
+        let machine_id = Uuid::parse_str(&std::env::var("ONEFUZZ_MACHINE_ID")?)?;
+        let machine_name = std::env::var("ONEFUZZ_MACHINE_NAME")?;
+        let scaleset_name = std::env::var("ONEFUZZ_SCALESET_NAME").ok();
+
+        Ok(Self {
+            machine_id,
+            machine_name,
+            scaleset_name,
+        })
+    }
+
+    pub async fn get_ims_id() -> Result<Uuid> {
+        let path = onefuzz_etc()?.join("ims_id");
+        let body = match fs::read_to_string(&path).await {
+            Ok(body) => body,
+            Err(_) => {
+                let resp = reqwest::Client::new()
+                    .get(IMS_ID_URL)
+                    .timeout(Duration::from_millis(500))
+                    .header("Metadata", "true")
+                    .send_retry_default()
+                    .await
+                    .context("get_ims_id")?;
+                let body = resp.text().await?;
+                write_file(path, &body).await?;
+                body
+            }
+        };
+
+        let value = Uuid::parse_str(&body)?;
+        Ok(value)
+    }
+
+    pub async fn get_machine_name() -> Result<String> {
+        let path = onefuzz_etc()?.join("machine_name");
+        let body = match fs::read_to_string(&path).await {
+            Ok(body) => body,
+            Err(_) => {
+                let resp = reqwest::Client::new()
+                    .get(VM_NAME_URL)
+                    .timeout(Duration::from_millis(500))
+                    .header("Metadata", "true")
+                    .send_retry_default()
+                    .await
+                    .context("get_machine_name")?;
+                let body = resp.text().await?;
+                write_file(path, &body).await?;
+                body
+            }
+        };
+
+        Ok(body)
+    }
+
+    pub async fn get_scaleset_name() -> Result<Option<String>> {
+        let path = onefuzz_etc()?.join("scaleset_name");
+        if let Ok(scaleset_name) = fs::read_to_string(&path).await {
+            return Ok(Some(scaleset_name));
+        }
+
+        if let Ok(resp) = reqwest::Client::new()
+            .get(VM_SCALESET_NAME)
+            .timeout(Duration::from_millis(500))
+            .header("Metadata", "true")
+            .send_retry_default()
+            .await
+        {
             let body = resp.text().await?;
             write_file(path, &body).await?;
-            body
+            Ok(Some(body))
+        } else {
+            Ok(None)
         }
-    };
+    }
 
-    let value = Uuid::parse_str(&body)?;
-    Ok(value)
-}
+    #[cfg(target_os = "linux")]
+    pub async fn get_os_machine_id() -> Result<Uuid> {
+        let path = Path::new("/etc/machine-id");
+        let contents = fs::read_to_string(&path)
+            .await
+            .with_context(|| format!("unable to read machine_id: {}", path.display()))?;
+        let uuid = Uuid::parse_str(contents.trim())?;
+        Ok(uuid)
+    }
 
-pub async fn get_machine_name() -> Result<String> {
-    let path = onefuzz_etc()?.join("machine_name");
-    let body = match fs::read_to_string(&path).await {
-        Ok(body) => body,
-        Err(_) => {
-            let resp = reqwest::Client::new()
-                .get(VM_NAME_URL)
-                .timeout(Duration::from_millis(500))
-                .header("Metadata", "true")
-                .send_retry_default()
-                .await
-                .context("get_machine_name")?;
-            let body = resp.text().await?;
-            write_file(path, &body).await?;
-            body
+    #[cfg(target_os = "windows")]
+    pub async fn get_os_machine_id() -> Result<Uuid> {
+        use winreg::enums::{HKEY_LOCAL_MACHINE, KEY_READ, KEY_WOW64_64KEY};
+        use winreg::RegKey;
+
+        let key: &str = "SOFTWARE\\Microsoft\\Cryptography";
+
+        let hklm = RegKey::predef(HKEY_LOCAL_MACHINE);
+        let crypt = if let Ok(crypt) = hklm.open_subkey_with_flags(key, KEY_READ) {
+            crypt
+        } else {
+            hklm.open_subkey_with_flags(key, KEY_READ | KEY_WOW64_64KEY)?
+        };
+        let guid: String = crypt.get_value("MachineGuid")?;
+        Ok(Uuid::parse_str(&guid)?)
+    }
+
+    async fn get_machine_id_impl() -> Result<Uuid> {
+        let ims_id = Self::get_ims_id().await;
+        if ims_id.is_ok() {
+            return ims_id;
         }
-    };
 
-    Ok(body)
-}
-
-pub async fn get_scaleset_name() -> Result<Option<String>> {
-    let path = onefuzz_etc()?.join("scaleset_name");
-    if let Ok(scaleset_name) = fs::read_to_string(&path).await {
-        return Ok(Some(scaleset_name));
-    }
-
-    if let Ok(resp) = reqwest::Client::new()
-        .get(VM_SCALESET_NAME)
-        .timeout(Duration::from_millis(500))
-        .header("Metadata", "true")
-        .send_retry_default()
-        .await
-    {
-        let body = resp.text().await?;
-        write_file(path, &body).await?;
-        Ok(Some(body))
-    } else {
-        Ok(None)
-    }
-}
-
-#[cfg(target_os = "linux")]
-pub async fn get_os_machine_id() -> Result<Uuid> {
-    let path = Path::new("/etc/machine-id");
-    let contents = fs::read_to_string(&path)
-        .await
-        .with_context(|| format!("unable to read machine_id: {}", path.display()))?;
-    let uuid = Uuid::parse_str(contents.trim())?;
-    Ok(uuid)
-}
-
-#[cfg(target_os = "windows")]
-pub async fn get_os_machine_id() -> Result<Uuid> {
-    use winreg::enums::{HKEY_LOCAL_MACHINE, KEY_READ, KEY_WOW64_64KEY};
-    use winreg::RegKey;
-
-    let key: &str = "SOFTWARE\\Microsoft\\Cryptography";
-
-    let hklm = RegKey::predef(HKEY_LOCAL_MACHINE);
-    let crypt = if let Ok(crypt) = hklm.open_subkey_with_flags(key, KEY_READ) {
-        crypt
-    } else {
-        hklm.open_subkey_with_flags(key, KEY_READ | KEY_WOW64_64KEY)?
-    };
-    let guid: String = crypt.get_value("MachineGuid")?;
-    Ok(Uuid::parse_str(&guid)?)
-}
-
-async fn get_machine_id_impl() -> Result<Uuid> {
-    let ims_id = get_ims_id().await;
-    if ims_id.is_ok() {
-        return ims_id;
-    }
-
-    let machine_id = get_os_machine_id().await;
-    if machine_id.is_ok() {
-        return machine_id;
-    }
-
-    Ok(Uuid::new_v4())
-}
-
-pub async fn get_machine_id() -> Result<Uuid> {
-    let path = onefuzz_etc()?.join("machine_id");
-    let result = match fs::read_to_string(&path).await {
-        Ok(body) => Uuid::parse_str(&body)?,
-        Err(_) => {
-            let value = get_machine_id_impl().await?;
-            write_file(path, &value.to_string()).await?;
-            value
+        let machine_id = Self::get_os_machine_id().await;
+        if machine_id.is_ok() {
+            return machine_id;
         }
-    };
-    Ok(result)
+
+        Ok(Uuid::new_v4())
+    }
+
+    pub async fn get_machine_id() -> Result<Uuid> {
+        let path = onefuzz_etc()?.join("machine_id");
+        let result = match fs::read_to_string(&path).await {
+            Ok(body) => Uuid::parse_str(&body)?,
+            Err(_) => {
+                let value = Self::get_machine_id_impl().await?;
+                write_file(path, &value.to_string()).await?;
+                value
+            }
+        };
+        Ok(result)
+    }
 }
 
 #[tokio::test]
 async fn test_get_machine_id() {
-    get_os_machine_id().await.unwrap();
+    MachineIdentity::get_os_machine_id().await.unwrap();
 }

--- a/src/deny.toml
+++ b/src/deny.toml
@@ -17,6 +17,7 @@ yanked = "deny"
 ignore = [
     "RUSTSEC-2022-0048", # xml-rs is unmaintained
     "RUSTSEC-2021-0139", # ansi_term is unmaintained
+    "RUSTSEC-2021-0145", # atty bug: we are unaffected (no custom allocator)
 ]
 
 [bans]


### PR DESCRIPTION
## Summary of the Pull Request

This is part of the unmanaged node work

This PR introduces `MachineIdentity` as new configuration field to the agent  and the tasks. 
It contains the `machine_name`, `machine_id` and `scaleset name`. 
When setting this field on the agent, we bypass the current behavior of reading those values from files or the environment.
This allows multiple instances of the agent on the same machine to behave as different nodes. 

The existing behavior stays the same when the `MachineIdentity` is not specified in the config

closes #2521


