### PR TITLE
`LLVM_SYMBOLIZER_PATH` must be absolute on Windows

### DIFF
--- a/src/runtime-tools/win64/onefuzz.ps1
+++ b/src/runtime-tools/win64/onefuzz.ps1
@@ -4,7 +4,7 @@
 $env:Path += ";C:\Program Files (x86)\Windows Kits\10\Debuggers\x64\;C:\onefuzz\win64;C:\onefuzz\tools\win64;C:\onefuzz\tools\win64\radamsa;$env:ProgramFiles\LLVM\bin"
 $env:ONEFUZZ_ROOT = "C:\onefuzz"
 $env:ONEFUZZ_TOOLS = "C:\onefuzz\tools"
-$env:LLVM_SYMBOLIZER_PATH = "llvm-symbolizer"
+$env:LLVM_SYMBOLIZER_PATH = "C:\Program Files\LLVM\bin\llvm-symbolizer.exe"
 $env:RUST_LOG = "info"
 $env:DOTNET_VERSIONS = "7.0.100;6.0.403"
 # Set a session and machine scoped env var


### PR DESCRIPTION
`LLVM_SYMBOLIZER_PATH` is being used to set the `ASAN_SYMBOLIZER_PATH`, but on Windows this is not working correctly; the ASAN output includes:

    WARNING: Failed to use and restart external symbolizer!

After experimentation it appears that this path must be absolute.