### PR TITLE
Remove reportgenerator

### DIFF
--- a/src/ApiService/.config/dotnet-tools.json
+++ b/src/ApiService/.config/dotnet-tools.json
@@ -1,12 +1,5 @@
 {
   "version": 1,
   "isRoot": true,
-  "tools": {
-    "dotnet-reportgenerator-globaltool": {
-      "version": "5.1.9",
-      "commands": [
-        "reportgenerator"
-      ]
-    }
-  }
+  "tools": {}
 }


### PR DESCRIPTION
This was needed to generate Markdown-based code coverage reports which we don't use any more.