### PR TITLE
Fix NullRef exception when getting a scaleset that does not exist

### DIFF
--- a/src/ApiService/ApiService/onefuzzlib/ScalesetOperations.cs
+++ b/src/ApiService/ApiService/onefuzzlib/ScalesetOperations.cs
@@ -514,7 +514,7 @@ public class ScalesetOperations : StatefulOrm<Scaleset, ScalesetState, ScalesetO
 
         //ground truth of existing nodes
         var azureNodes = await _context.VmssOperations.ListInstanceIds(scaleSet.ScalesetId);
-        if (azureNodes is null) {
+        if (!azureNodes.Any()) {
             // didn't find scaleset
             return (false, scaleSet);
         }

--- a/src/ApiService/ApiService/onefuzzlib/VmssOperations.cs
+++ b/src/ApiService/ApiService/onefuzzlib/VmssOperations.cs
@@ -21,7 +21,7 @@ public interface IVmssOperations {
 
     Async.Task<bool> DeleteVmss(Guid name, bool? forceDeletion = null);
 
-    Async.Task<IDictionary<Guid, string>?> ListInstanceIds(Guid name);
+    Async.Task<IDictionary<Guid, string>> ListInstanceIds(Guid name);
 
     Async.Task<long?> GetVmssSize(Guid name);
 
@@ -167,7 +167,7 @@ public class VmssOperations : IVmssOperations {
         }
     }
 
-    public async Async.Task<IDictionary<Guid, string>?> ListInstanceIds(Guid name) {
+    public async Async.Task<IDictionary<Guid, string>> ListInstanceIds(Guid name) {
         _log.Verbose($"get instance IDs for scaleset {name:Tag:VmssName}");
         try {
             var results = new Dictionary<Guid, string>();
@@ -183,7 +183,7 @@ public class VmssOperations : IVmssOperations {
             return results;
         } catch (RequestFailedException ex) when (ex.Status == 404) {
             _log.Verbose($"scaleset does not exist {name:Tag:VmssName}");
-            return null;
+            return new Dictionary<Guid, string>();
         }
     }
 
@@ -448,7 +448,7 @@ public class VmssOperations : IVmssOperations {
         // only initialize this if we find a missing InstanceId
         var machineToInstanceLazy = new Lazy<Task<IDictionary<Guid, string>>>(async () => {
             var machineToInstance = await ListInstanceIds(scalesetId);
-            if (machineToInstance is null) {
+            if (!machineToInstance.Any()) {
                 throw new Exception($"cannot find nodes in scaleset {scalesetId}: scaleset does not exist");
             }
 

--- a/src/ApiService/IntegrationTests/Fakes/TestVmssOperations.cs
+++ b/src/ApiService/IntegrationTests/Fakes/TestVmssOperations.cs
@@ -40,7 +40,7 @@ sealed class TestVmssOperations : IVmssOperations {
     }
 
 
-    public Task<IDictionary<Guid, string>?> ListInstanceIds(Guid name) {
+    public Task<IDictionary<Guid, string>> ListInstanceIds(Guid name) {
         throw new NotImplementedException();
     }
 


### PR DESCRIPTION
## Summary of the Pull Request

Updated the ScalesetOperations.GetNodes to return a non-nullable dictionary

