### PR TITLE
Reduce mutation in the agent state machine

### DIFF
--- a/src/agent/onefuzz-agent/src/agent.rs
+++ b/src/agent/onefuzz-agent/src/agent.rs
@@ -90,7 +90,7 @@ impl Agent {
             (state, done) = state.update().await?;
         }
 
-        debug!("agent done, exiting loop");
+        info!("agent done, exiting loop");
         Ok(())
     }
 
@@ -187,7 +187,7 @@ impl Agent {
                     // Otherwise, the work was not stopped, but we still should not execute it. This is likely
                     // our because agent version is out of date. Do nothing, so another node can see the work.
                     // The service will eventually send us a stop command and reimage our node, if appropriate.
-                    debug!(
+                    info!(
                         "not scheduling active work set, not dropping: {:?}",
                         msg.work_set
                     );
@@ -210,7 +210,7 @@ impl Agent {
     }
 
     async fn setting_up(mut self, state: State<SettingUp>, previous: NodeState) -> Result<Self> {
-        debug!("agent setting up");
+        info!("agent setting up");
 
         let tasks = state.work_set().task_ids();
         self.emit_state_update_if_changed(StateUpdateEvent::SettingUp { tasks })
@@ -234,7 +234,7 @@ impl Agent {
         state: State<PendingReboot>,
         _previous: NodeState,
     ) -> Result<Self> {
-        debug!("agent pending reboot");
+        info!("agent pending reboot");
         self.emit_state_update_if_changed(StateUpdateEvent::Rebooting)
             .await?;
 
@@ -246,7 +246,7 @@ impl Agent {
     }
 
     async fn ready(self, state: State<Ready>, previous: NodeState) -> Result<Self> {
-        debug!("agent ready");
+        info!("agent ready");
         self.emit_state_update_if_changed(StateUpdateEvent::Ready)
             .await?;
         Ok(Self {
@@ -285,7 +285,7 @@ impl Agent {
     }
 
     async fn done(self, state: State<Done>, previous: NodeState) -> Result<Self> {
-        debug!("agent done");
+        info!("agent done");
         set_done_lock(self.machine_id).await?;
 
         let event = match state.cause() {

--- a/src/agent/onefuzz-agent/src/agent/tests.rs
+++ b/src/agent/onefuzz-agent/src/agent/tests.rs
@@ -111,7 +111,6 @@ async fn test_update_free_has_work() {
 
     let (agent, done) = agent.update().await.unwrap();
     assert!(!done);
-    let (agent, _done) = agent.update().await.unwrap();
     assert!(matches!(agent.scheduler.unwrap(), Scheduler::SettingUp(..)));
 
     let double: &WorkQueueDouble = agent.work_queue.downcast_ref().unwrap();

--- a/src/agent/onefuzz-agent/src/agent/tests.rs
+++ b/src/agent/onefuzz-agent/src/agent/tests.rs
@@ -145,9 +145,9 @@ async fn test_emitted_state() {
         .available
         .push(Fixture.message());
 
+    let mut done;
     for _i in 0..10 {
-        let (new_agent, done) = agent.update().await.unwrap();
-        agent = new_agent;
+        (agent, done) = agent.update().await.unwrap();
         if done {
             break;
         }
@@ -204,9 +204,9 @@ async fn test_emitted_state_failed_setup() {
         .available
         .push(Fixture.message());
 
+    let mut done;
     for _i in 0..10 {
-        let (new_agent, done) = agent.update().await.unwrap();
-        agent = new_agent;
+        (agent, done) = agent.update().await.unwrap();
         if done {
             break;
         }

--- a/src/agent/onefuzz-agent/src/commands.rs
+++ b/src/agent/onefuzz-agent/src/commands.rs
@@ -25,7 +25,7 @@ const ONEFUZZ_SERVICE_USER: &str = "onefuzz";
 #[cfg(target_family = "windows")]
 static SET_PERMISSION_ONCE: OnceCell<()> = OnceCell::const_new();
 
-#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Debug, Deserialize, Eq, PartialEq, Serialize, Clone)]
 pub struct SshKeyInfo {
     pub public_key: Secret<String>,
 }

--- a/src/agent/onefuzz-agent/src/coordinator.rs
+++ b/src/agent/onefuzz-agent/src/coordinator.rs
@@ -166,15 +166,15 @@ impl_downcast!(ICoordinator);
 #[async_trait]
 impl ICoordinator for Coordinator {
     async fn poll_commands(&mut self) -> Result<Option<NodeCommand>, PollCommandError> {
-        self.poll_commands().await
+        Coordinator::poll_commands(self).await
     }
 
     async fn emit_event(&self, event: NodeEvent) -> Result<()> {
-        self.emit_event(event).await
+        Coordinator::emit_event(self, event).await
     }
 
     async fn can_schedule(&self, work_set: &WorkSet) -> Result<CanSchedule> {
-        self.can_schedule(work_set).await
+        Coordinator::can_schedule(self, work_set).await
     }
 }
 

--- a/src/agent/onefuzz-agent/src/coordinator/double.rs
+++ b/src/agent/onefuzz-agent/src/coordinator/double.rs
@@ -5,22 +5,24 @@ use super::*;
 
 #[derive(Debug, Default)]
 pub struct CoordinatorDouble {
-    pub commands: Vec<NodeCommand>,
-    pub events: Vec<NodeEvent>,
+    pub commands: Arc<RwLock<Vec<NodeCommand>>>,
+    pub events: Arc<RwLock<Vec<NodeEvent>>>,
 }
 
 #[async_trait]
 impl ICoordinator for CoordinatorDouble {
     async fn poll_commands(&mut self) -> Result<Option<NodeCommand>, PollCommandError> {
-        Ok(self.commands.pop())
+        let mut commands = self.commands.write().await;
+        Ok(commands.pop())
     }
 
-    async fn emit_event(&mut self, event: NodeEvent) -> Result<()> {
-        self.events.push(event);
+    async fn emit_event(&self, event: NodeEvent) -> Result<()> {
+        let mut events = self.events.write().await;
+        events.push(event);
         Ok(())
     }
 
-    async fn can_schedule(&mut self, _work: &WorkSet) -> Result<CanSchedule> {
+    async fn can_schedule(&self, _work: &WorkSet) -> Result<CanSchedule> {
         Ok(CanSchedule {
             allowed: true,
             work_stopped: true,

--- a/src/agent/onefuzz-agent/src/debug.rs
+++ b/src/agent/onefuzz-agent/src/debug.rs
@@ -180,7 +180,7 @@ fn debug_run_worker(opt: RunWorkerOpt) -> Result<()> {
 
 async fn run_worker(mut work_set: WorkSet) -> Result<Vec<WorkerEvent>> {
     use crate::setup::SetupRunner;
-    let mut setup_runner = SetupRunner {
+    let setup_runner = SetupRunner {
         machine_id: Uuid::new_v4(),
     };
     setup_runner.run(&work_set).await?;

--- a/src/agent/onefuzz-agent/src/main.rs
+++ b/src/agent/onefuzz-agent/src/main.rs
@@ -306,7 +306,7 @@ async fn run_agent(config: StaticConfig, reset_node: bool) -> Result<()> {
     let mut coordinator = coordinator::Coordinator::new(registration.clone()).await?;
     debug!("initialized coordinator");
 
-    let mut reboot = reboot::Reboot;
+    let reboot = reboot::Reboot;
     let reboot_context = reboot.load_context().await?;
     if reset_node {
         WorkSet::remove_context(config.machine_identity.machine_id).await?;
@@ -331,7 +331,7 @@ async fn run_agent(config: StaticConfig, reset_node: bool) -> Result<()> {
         ),
         None => None,
     };
-    let mut agent = agent::Agent::new(
+    let agent = agent::Agent::new(
         Box::new(coordinator),
         Box::new(reboot),
         scheduler,

--- a/src/agent/onefuzz-agent/src/reboot.rs
+++ b/src/agent/onefuzz-agent/src/reboot.rs
@@ -12,26 +12,26 @@ use crate::work::*;
 
 #[async_trait]
 pub trait IReboot: Downcast {
-    async fn save_context(&mut self, ctx: RebootContext) -> Result<()>;
+    async fn save_context(&self, ctx: RebootContext) -> Result<()>;
 
-    async fn load_context(&mut self) -> Result<Option<RebootContext>>;
+    async fn load_context(&self) -> Result<Option<RebootContext>>;
 
-    fn invoke(&mut self) -> Result<()>;
+    fn invoke(&self) -> Result<()>;
 }
 
 impl_downcast!(IReboot);
 
 #[async_trait]
 impl IReboot for Reboot {
-    async fn save_context(&mut self, ctx: RebootContext) -> Result<()> {
+    async fn save_context(&self, ctx: RebootContext) -> Result<()> {
         self.save_context(ctx).await
     }
 
-    async fn load_context(&mut self) -> Result<Option<RebootContext>> {
+    async fn load_context(&self) -> Result<Option<RebootContext>> {
         self.load_context().await
     }
 
-    fn invoke(&mut self) -> Result<()> {
+    fn invoke(&self) -> Result<()> {
         self.invoke()
     }
 }
@@ -39,7 +39,7 @@ impl IReboot for Reboot {
 pub struct Reboot;
 
 impl Reboot {
-    pub async fn save_context(&mut self, ctx: RebootContext) -> Result<()> {
+    pub async fn save_context(&self, ctx: RebootContext) -> Result<()> {
         let path = reboot_context_path()?;
 
         info!("saving reboot context to: {}", path.display());
@@ -54,7 +54,7 @@ impl Reboot {
         Ok(())
     }
 
-    pub async fn load_context(&mut self) -> Result<Option<RebootContext>> {
+    pub async fn load_context(&self) -> Result<Option<RebootContext>> {
         use std::io::ErrorKind;
         let path = reboot_context_path()?;
 
@@ -82,7 +82,7 @@ impl Reboot {
     }
 
     #[cfg(target_family = "unix")]
-    pub fn invoke(&mut self) -> Result<()> {
+    pub fn invoke(&self) -> Result<()> {
         info!("invoking local reboot command");
 
         Command::new("reboot").arg("-f").status()?;
@@ -91,7 +91,7 @@ impl Reboot {
     }
 
     #[cfg(target_family = "windows")]
-    pub fn invoke(&mut self) -> Result<()> {
+    pub fn invoke(&self) -> Result<()> {
         info!("invoking local reboot command");
 
         Command::new("powershell.exe")

--- a/src/agent/onefuzz-agent/src/scheduler.rs
+++ b/src/agent/onefuzz-agent/src/scheduler.rs
@@ -55,18 +55,22 @@ impl Scheduler {
         Self::default()
     }
 
-    pub async fn execute_command(&mut self, cmd: &NodeCommand, managed: bool) -> Result<()> {
+    pub async fn execute_command(self, cmd: NodeCommand, managed: bool) -> Result<Self> {
         match cmd {
             NodeCommand::AddSshKey(ssh_key_info) => {
                 if managed {
-                    add_ssh_key(ssh_key_info).await?;
+                    add_ssh_key(&ssh_key_info).await?;
                 } else {
                     warn!("adding ssh keys only supported on managed nodes");
                 }
+                Ok(self)
             }
             NodeCommand::StopTask(stop_task) => {
                 if let Scheduler::Busy(state) = self {
-                    state.stop(stop_task.task_id)?;
+                    let state = state.stop(stop_task.task_id)?;
+                    Ok(state.into())
+                } else {
+                    Ok(self)
                 }
             }
             NodeCommand::Stop {} => {
@@ -74,7 +78,7 @@ impl Scheduler {
                 let state = State {
                     ctx: Done { cause },
                 };
-                *self = state.into();
+                Ok(state.into())
             }
             NodeCommand::StopIfFree {} => {
                 if let Scheduler::Free(_) = self {
@@ -82,12 +86,12 @@ impl Scheduler {
                     let state = State {
                         ctx: Done { cause },
                     };
-                    *self = state.into();
+                    Ok(state.into())
+                } else {
+                    Ok(self)
                 }
             }
         }
-
-        Ok(())
     }
 }
 
@@ -187,7 +191,7 @@ pub enum SetupDone {
 }
 
 impl State<SettingUp> {
-    pub async fn finish(self, runner: &mut dyn ISetupRunner) -> Result<SetupDone> {
+    pub async fn finish(self, runner: &dyn ISetupRunner) -> Result<SetupDone> {
         let work_set = self.ctx.work_set;
 
         let output = runner.run(&work_set).await;
@@ -289,7 +293,7 @@ impl State<Busy> {
             .all(|worker| worker.as_ref().unwrap().is_done())
     }
 
-    pub fn stop(&mut self, task_id: TaskId) -> Result<()> {
+    pub fn stop(mut self, task_id: TaskId) -> Result<Self> {
         for worker in &mut self.ctx.workers {
             let worker = worker.as_mut().unwrap();
 
@@ -300,7 +304,7 @@ impl State<Busy> {
             }
         }
 
-        Ok(())
+        Ok(self)
     }
 }
 

--- a/src/agent/onefuzz-agent/src/setup.rs
+++ b/src/agent/onefuzz-agent/src/setup.rs
@@ -24,14 +24,14 @@ pub type SetupOutput = Option<Output>;
 
 #[async_trait]
 pub trait ISetupRunner: Downcast {
-    async fn run(&mut self, work_set: &WorkSet) -> Result<SetupOutput>;
+    async fn run(&self, work_set: &WorkSet) -> Result<SetupOutput>;
 }
 
 impl_downcast!(ISetupRunner);
 
 #[async_trait]
 impl ISetupRunner for SetupRunner {
-    async fn run(&mut self, work_set: &WorkSet) -> Result<SetupOutput> {
+    async fn run(&self, work_set: &WorkSet) -> Result<SetupOutput> {
         self.run(work_set).await
     }
 }
@@ -42,7 +42,7 @@ pub struct SetupRunner {
 }
 
 impl SetupRunner {
-    pub async fn run(&mut self, work_set: &WorkSet) -> Result<SetupOutput> {
+    pub async fn run(&self, work_set: &WorkSet) -> Result<SetupOutput> {
         info!("running setup for work set");
         work_set.save_context(self.machine_id).await?;
         // Download the setup container.

--- a/src/agent/onefuzz-agent/src/setup/double.rs
+++ b/src/agent/onefuzz-agent/src/setup/double.rs
@@ -1,19 +1,24 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+use std::sync::Arc;
+
+use tokio::sync::RwLock;
+
 use super::*;
 
 #[derive(Clone, Debug, Default)]
 pub struct SetupRunnerDouble {
-    pub ran: Vec<WorkSet>,
+    pub ran: Arc<RwLock<Vec<WorkSet>>>,
     pub script: SetupOutput,
     pub error_message: Option<String>,
 }
 
 #[async_trait]
 impl ISetupRunner for SetupRunnerDouble {
-    async fn run(&mut self, work_set: &WorkSet) -> Result<SetupOutput> {
-        self.ran.push(work_set.clone());
+    async fn run(&self, work_set: &WorkSet) -> Result<SetupOutput> {
+        let mut ran = self.ran.write().await;
+        ran.push(work_set.clone());
         if let Some(error) = self.error_message.clone() {
             anyhow::bail!(error);
         }

--- a/src/agent/onefuzz-agent/src/work.rs
+++ b/src/agent/onefuzz-agent/src/work.rs
@@ -1,14 +1,15 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use std::io::ErrorKind;
 use std::path::PathBuf;
+use std::{io::ErrorKind, sync::Arc};
 
 use anyhow::{Context, Result};
 use downcast_rs::Downcast;
 use onefuzz::{auth::Secret, blob::BlobContainerUrl, http::is_auth_error};
 use storage_queue::{Message as QueueMessage, QueueClient};
 use tokio::fs;
+use tokio::sync::RwLock;
 use uuid::Uuid;
 
 use crate::config::Registration;
@@ -145,7 +146,7 @@ pub struct Message {
 
 pub struct WorkQueue {
     queue: QueueClient,
-    registration: Registration,
+    registration: Arc<RwLock<Registration>>,
 }
 
 impl WorkQueue {
@@ -155,16 +156,17 @@ impl WorkQueue {
 
         Ok(Self {
             queue,
-            registration,
+            registration: Arc::new(RwLock::new(registration)),
         })
     }
 
     async fn renew(&mut self) -> Result<()> {
-        self.registration
+        let mut registration = self.registration.write().await;
+        *registration = registration
             .renew()
             .await
             .context("unable to renew registration in workqueue")?;
-        let url = self.registration.dynamic_config.work_queue.clone();
+        let url = registration.dynamic_config.work_queue.clone();
         self.queue = QueueClient::new(url)?;
         Ok(())
     }
@@ -207,7 +209,13 @@ impl WorkQueue {
                 Err(err) => {
                     if is_auth_error(&err) {
                         self.renew().await.context("unable to renew registration")?;
-                        let url = self.registration.dynamic_config.work_queue.clone();
+                        let url = self
+                            .registration
+                            .read()
+                            .await
+                            .dynamic_config
+                            .work_queue
+                            .clone();
                         queue_message
                             .update_url(url)
                             .delete()

--- a/src/agent/onefuzz-agent/src/worker.rs
+++ b/src/agent/onefuzz-agent/src/worker.rs
@@ -189,7 +189,7 @@ impl_from_state_for_worker!(Done);
 
 #[async_trait]
 pub trait IWorkerRunner: Downcast {
-    async fn run(&mut self, setup_dir: &Path, work: &WorkUnit) -> Result<Box<dyn IWorkerChild>>;
+    async fn run(&self, setup_dir: &Path, work: &WorkUnit) -> Result<Box<dyn IWorkerChild>>;
 }
 
 impl_downcast!(IWorkerRunner);
@@ -214,7 +214,7 @@ impl WorkerRunner {
 
 #[async_trait]
 impl IWorkerRunner for WorkerRunner {
-    async fn run(&mut self, setup_dir: &Path, work: &WorkUnit) -> Result<Box<dyn IWorkerChild>> {
+    async fn run(&self, setup_dir: &Path, work: &WorkUnit) -> Result<Box<dyn IWorkerChild>> {
         let working_dir = work.working_dir(self.machine_identity.machine_id)?;
 
         debug!("worker working dir = {}", working_dir.display());
@@ -268,12 +268,12 @@ impl IWorkerRunner for WorkerRunner {
 }
 
 trait SuspendableChild {
-    fn suspend(&mut self) -> Result<()>;
+    fn suspend(&self) -> Result<()>;
 }
 
 #[cfg(target_os = "windows")]
 impl SuspendableChild for Child {
-    fn suspend(&mut self) -> Result<()> {
+    fn suspend(&self) -> Result<()> {
         // DebugActiveProcess suspends all threads in the process.
         // https://docs.microsoft.com/en-us/windows/win32/api/debugapi/nf-debugapi-debugactiveprocess#remarks
         let result = unsafe { winapi::um::debugapi::DebugActiveProcess(self.id() as u32) };
@@ -286,7 +286,7 @@ impl SuspendableChild for Child {
 
 #[cfg(target_os = "linux")]
 impl SuspendableChild for Child {
-    fn suspend(&mut self) -> Result<()> {
+    fn suspend(&self) -> Result<()> {
         use nix::sys::signal;
         signal::kill(
             nix::unistd::Pid::from_raw(self.id() as _),

--- a/src/agent/onefuzz-agent/src/worker/double.rs
+++ b/src/agent/onefuzz-agent/src/worker/double.rs
@@ -10,7 +10,7 @@ pub struct WorkerRunnerDouble {
 
 #[async_trait]
 impl IWorkerRunner for WorkerRunnerDouble {
-    async fn run(&mut self, _setup_dir: &Path, _work: &WorkUnit) -> Result<Box<dyn IWorkerChild>> {
+    async fn run(&self, _setup_dir: &Path, _work: &WorkUnit) -> Result<Box<dyn IWorkerChild>> {
         Ok(Box::new(self.child.clone()))
     }
 }

--- a/src/agent/onefuzz-agent/src/worker/tests.rs
+++ b/src/agent/onefuzz-agent/src/worker/tests.rs
@@ -55,7 +55,7 @@ struct RunnerDouble {
 
 #[async_trait]
 impl IWorkerRunner for RunnerDouble {
-    async fn run(&mut self, _setup_dir: &Path, _work: &WorkUnit) -> Result<Box<dyn IWorkerChild>> {
+    async fn run(&self, _setup_dir: &Path, _work: &WorkUnit) -> Result<Box<dyn IWorkerChild>> {
         Ok(Box::new(self.child.clone()))
     }
 }


### PR DESCRIPTION
## Summary of the Pull Request
Removing the shared mutable state (&mut self) from the agent state machine. The intent is to make the code easier to reason with. 