### PR TITLE
Add deserialization compat functions

### DIFF
--- a/src/agent/onefuzz-file-format/src/coverage/binary.rs
+++ b/src/agent/onefuzz-file-format/src/coverage/binary.rs
@@ -8,13 +8,27 @@ pub mod v0;
 pub mod v1;
 
 #[derive(Serialize, Deserialize)]
-#[serde(tag = "version")]
+#[serde(tag = "version", content = "coverage")]
 pub enum BinaryCoverageJson {
-    #[serde(rename = "0")]
+    #[serde(rename = "0.1")]
     V0(v0::BinaryCoverageJson),
 
-    #[serde(rename = "1")]
+    #[serde(rename = "1.0")]
     V1(v1::BinaryCoverageJson),
+}
+
+impl BinaryCoverageJson {
+    pub fn deserialize(text: &str) -> Result<Self> {
+        // Try unversioned legacy format.
+        let v0 = serde_json::from_str::<v0::BinaryCoverageJson>(text);
+
+        if let Ok(v0) = v0 {
+            return Ok(Self::V0(v0));
+        }
+
+        // Try versioned formats.
+        Ok(serde_json::from_str(text)?)
+    }
 }
 
 impl TryFrom<BinaryCoverageJson> for BinaryCoverage {

--- a/src/agent/onefuzz-file-format/src/coverage/source.rs
+++ b/src/agent/onefuzz-file-format/src/coverage/source.rs
@@ -8,13 +8,27 @@ pub mod v0;
 pub mod v1;
 
 #[derive(Serialize, Deserialize)]
-#[serde(tag = "version")]
+#[serde(tag = "version", content = "coverage")]
 pub enum SourceCoverageJson {
-    #[serde(rename = "0")]
+    #[serde(rename = "0.1")]
     V0(v0::SourceCoverageJson),
 
-    #[serde(rename = "1")]
+    #[serde(rename = "1.0")]
     V1(v1::SourceCoverageJson),
+}
+
+impl SourceCoverageJson {
+    pub fn deserialize(text: &str) -> Result<Self> {
+        // Try unversioned legacy format.
+        let v0 = serde_json::from_str::<v0::SourceCoverageJson>(text);
+
+        if let Ok(v0) = v0 {
+            return Ok(Self::V0(v0));
+        }
+
+        // Try versioned formats.
+        Ok(serde_json::from_str(text)?)
+    }
 }
 
 impl TryFrom<SourceCoverageJson> for SourceCoverage {

--- a/src/agent/onefuzz-file-format/tests/binary.rs
+++ b/src/agent/onefuzz-file-format/tests/binary.rs
@@ -5,7 +5,7 @@ use pretty_assertions::assert_eq;
 
 use anyhow::Result;
 use coverage::binary::{BinaryCoverage, Count, FilePath, ModuleBinaryCoverage, Offset};
-use onefuzz_file_format::coverage::binary::{v0, v1};
+use onefuzz_file_format::coverage::binary::BinaryCoverageJson;
 
 fn expected_binary_coverage() -> Result<BinaryCoverage> {
     let main_exe_path = FilePath::new("/setup/main.exe")?;
@@ -32,12 +32,12 @@ fn test_binary_coverage_formats() -> Result<()> {
     let expected = expected_binary_coverage()?;
 
     let v0_text = include_str!("files/binary-coverage.v0.json");
-    let v0_json: v0::BinaryCoverageJson = serde_json::from_str(v0_text)?;
+    let v0_json = BinaryCoverageJson::deserialize(v0_text)?;
     let from_v0 = BinaryCoverage::try_from(v0_json)?;
     assert_eq!(from_v0, expected);
 
     let v1_text = include_str!("files/binary-coverage.v1.json");
-    let v1_json: v1::BinaryCoverageJson = serde_json::from_str(v1_text)?;
+    let v1_json = BinaryCoverageJson::deserialize(v1_text)?;
     let from_v1 = BinaryCoverage::try_from(v1_json)?;
     assert_eq!(from_v1, expected);
 

--- a/src/agent/onefuzz-file-format/tests/files/binary-coverage.v1.json
+++ b/src/agent/onefuzz-file-format/tests/files/binary-coverage.v1.json
@@ -1,15 +1,18 @@
 {
-    "/setup/main.exe": {
-        "blocks": {
-            "1": 0,
-            "12c": 1,
-            "1388": 0
-        }
-    },
-    "/setup/lib/some.dll": {
-        "blocks": {
-            "7b": 0,
-            "1c8": 10
+    "version": "1.0",
+    "coverage": {
+        "/setup/main.exe": {
+            "blocks": {
+                "1": 0,
+                "12c": 1,
+                "1388": 0
+            }
+        },
+        "/setup/lib/some.dll": {
+            "blocks": {
+                "7b": 0,
+                "1c8": 10
+            }
         }
     }
 }

--- a/src/agent/onefuzz-file-format/tests/files/source-coverage.v1.json
+++ b/src/agent/onefuzz-file-format/tests/files/source-coverage.v1.json
@@ -1,15 +1,18 @@
 {
-    "src/bin/main.c": {
-        "lines": {
-            "4": 1,
-            "9": 0,
-            "12": 5
-        }
-    },
-    "src/lib/common.c": {
-        "lines": {
-            "5": 1,
-            "8": 0
+    "version": "1.0",
+    "coverage": {
+        "src/bin/main.c": {
+            "lines": {
+                "4": 1,
+                "9": 0,
+                "12": 5
+            }
+        },
+        "src/lib/common.c": {
+            "lines": {
+                "5": 1,
+                "8": 0
+            }
         }
     }
 }

--- a/src/agent/onefuzz-file-format/tests/source.rs
+++ b/src/agent/onefuzz-file-format/tests/source.rs
@@ -6,7 +6,7 @@ use pretty_assertions::assert_eq;
 use anyhow::Result;
 use coverage::source::{Count, Line, SourceCoverage};
 use debuggable_module::path::FilePath;
-use onefuzz_file_format::coverage::source::{v0, v1};
+use onefuzz_file_format::coverage::source::{v0, v1, SourceCoverageJson};
 
 fn expected_source_coverage() -> Result<SourceCoverage> {
     let main_path = FilePath::new("src/bin/main.c")?;
@@ -31,12 +31,12 @@ fn test_source_coverage_formats() -> Result<()> {
     let expected = expected_source_coverage()?;
 
     let v0_text = include_str!("files/source-coverage.v0.json");
-    let v0_json: v0::SourceCoverageJson = serde_json::from_str(v0_text)?;
+    let v0_json = SourceCoverageJson::deserialize(v0_text)?;
     let from_v0 = SourceCoverage::try_from(v0_json)?;
     assert_eq!(from_v0, expected);
 
     let v1_text = include_str!("files/source-coverage.v1.json");
-    let v1_json: v1::SourceCoverageJson = serde_json::from_str(v1_text)?;
+    let v1_json = SourceCoverageJson::deserialize(v1_text)?;
     let from_v1 = SourceCoverage::try_from(v1_json)?;
     assert_eq!(from_v1, expected);
 

--- a/src/agent/onefuzz-file-format/tests/source.rs
+++ b/src/agent/onefuzz-file-format/tests/source.rs
@@ -6,7 +6,7 @@ use pretty_assertions::assert_eq;
 use anyhow::Result;
 use coverage::source::{Count, Line, SourceCoverage};
 use debuggable_module::path::FilePath;
-use onefuzz_file_format::coverage::source::{v0, v1, SourceCoverageJson};
+use onefuzz_file_format::coverage::source::SourceCoverageJson;
 
 fn expected_source_coverage() -> Result<SourceCoverage> {
     let main_path = FilePath::new("src/bin/main.c")?;


### PR DESCRIPTION
- Use semver strings for coverage file versioning
- Use adjacent tagging for coverage file formats (`{ "version": "...", "coverage": { ... } }`)
- Add compat `deserialize()` functions to handle unversioned `v0`/0.1 files