### PR TITLE
Ignore benign recv hangup in timer

### DIFF
--- a/src/agent/coverage/src/timer.rs
+++ b/src/agent/coverage/src/timer.rs
@@ -17,12 +17,12 @@ where
 
     let _worker = thread::spawn(move || {
         let out = function();
-        worker_sender.send(Timed::Done(out)).unwrap();
+        let _ = worker_sender.send(Timed::Done(out));
     });
 
     let _timer = thread::spawn(move || {
         thread::sleep(timeout);
-        timer_sender.send(Timed::Timeout).unwrap();
+        let _ = timer_sender.send(Timed::Timeout);
     });
 
     match receiver.recv()? {


### PR DESCRIPTION
Remove a stray unwrap. There's no reason to panic the thread, since the timeout and worker function are inherently racy.