### PR TITLE
Add binary coverage merging

### DIFF
--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -566,6 +566,7 @@ dependencies = [
  "iced-x86",
  "log",
  "pete",
+ "pretty_assertions",
  "procfs",
  "regex",
  "symbolic 10.1.4",

--- a/src/agent/coverage/Cargo.toml
+++ b/src/agent/coverage/Cargo.toml
@@ -24,3 +24,4 @@ procfs = { version = "0.12", default-features = false, features=["flate2"] }
 
 [dev-dependencies]
 clap = { version = "4.0", features = ["derive"] }
+pretty_assertions = "1.3.0"

--- a/src/agent/coverage/src/binary.rs
+++ b/src/agent/coverage/src/binary.rs
@@ -3,7 +3,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
-use anyhow::{bail, Result};
+use anyhow::Result;
 use debuggable_module::Module;
 pub use debuggable_module::{block, path::FilePath, Offset};
 use symbolic::debuginfo::Object;
@@ -16,24 +16,62 @@ pub struct BinaryCoverage {
     pub modules: BTreeMap<FilePath, ModuleBinaryCoverage>,
 }
 
+impl BinaryCoverage {
+    pub fn add(&mut self, other: &Self) {
+        for (path, other_module) in &other.modules {
+            let module = self.modules.entry(path.clone()).or_default();
+            module.add(other_module);
+        }
+    }
+
+    pub fn merge(&mut self, other: &Self) {
+        for (path, other_module) in &other.modules {
+            let module = self.modules.entry(path.clone()).or_default();
+            module.merge(other_module);
+        }
+    }
+}
+
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct ModuleBinaryCoverage {
     pub offsets: BTreeMap<Offset, Count>,
 }
 
 impl ModuleBinaryCoverage {
-    pub fn increment(&mut self, offset: Offset) -> Result<()> {
-        if let Some(count) = self.offsets.get_mut(&offset) {
-            count.increment();
-        } else {
-            bail!("unknown coverage offset: {offset:x}");
-        };
+    pub fn increment(&mut self, offset: Offset) {
+        let count = self.offsets.entry(offset).or_default();
+        count.increment();
+    }
 
-        Ok(())
+    pub fn add(&mut self, other: &Self) {
+        for (&offset, &other_count) in &other.offsets {
+            let count = self.offsets.entry(offset).or_default();
+            *count = Count::add(*count, other_count);
+        }
+    }
+
+    pub fn merge(&mut self, other: &Self) {
+        for (&offset, &other_count) in &other.offsets {
+            let count = self.offsets.entry(offset).or_default();
+            *count = Count::max(*count, other_count)
+        }
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+impl<O> From<O> for ModuleBinaryCoverage
+where
+    O: IntoIterator<Item = Offset>,
+{
+    fn from(offsets: O) -> Self {
+        let offsets = offsets.into_iter().map(|o| (o, Count(0)));
+
+        let mut coverage = Self::default();
+        coverage.offsets.extend(offsets);
+        coverage
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct Count(pub u32);
 
 impl Count {
@@ -43,6 +81,14 @@ impl Count {
 
     pub fn reached(&self) -> bool {
         self.0 > 0
+    }
+
+    pub fn add(self, other: Self)  -> Self {
+        Count(self.0.saturating_add(other.0))
+    }
+
+    pub fn max(self, other: Self) -> Self {
+        Count(u32::max(self.0, other.0))
     }
 }
 
@@ -81,10 +127,7 @@ pub fn find_coverage_sites<'data>(
         }
     }
 
-    let mut coverage = ModuleBinaryCoverage::default();
-    coverage
-        .offsets
-        .extend(offsets.into_iter().map(|o| (o, Count(0))));
+    let coverage = ModuleBinaryCoverage::from(offsets.into_iter());
 
     Ok(coverage)
 }
@@ -94,3 +137,6 @@ impl AsRef<BTreeMap<Offset, Count>> for ModuleBinaryCoverage {
         &self.offsets
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/src/agent/coverage/src/binary.rs
+++ b/src/agent/coverage/src/binary.rs
@@ -83,7 +83,7 @@ impl Count {
         self.0 > 0
     }
 
-    pub fn add(self, other: Self)  -> Self {
+    pub fn add(self, other: Self) -> Self {
         Count(self.0.saturating_add(other.0))
     }
 

--- a/src/agent/coverage/src/binary/tests.rs
+++ b/src/agent/coverage/src/binary/tests.rs
@@ -44,25 +44,34 @@ fn test_module_increment() -> Result<()> {
 
     module.increment(Offset(2));
 
-    assert_eq!(module, module! {
-        1 => 1,
-        2 => 1,
-    });
+    assert_eq!(
+        module,
+        module! {
+            1 => 1,
+            2 => 1,
+        }
+    );
 
     module.increment(Offset(2));
 
-    assert_eq!(module, module! {
-        1 => 1,
-        2 => 2,
-    });
+    assert_eq!(
+        module,
+        module! {
+            1 => 1,
+            2 => 2,
+        }
+    );
 
     module.increment(Offset(3));
 
-    assert_eq!(module, module! {
-        1 => 1,
-        2 => 2,
-        3 => 1,
-    });
+    assert_eq!(
+        module,
+        module! {
+            1 => 1,
+            2 => 2,
+            3 => 1,
+        }
+    );
 
     Ok(())
 }
@@ -92,21 +101,24 @@ fn test_coverage_add() -> Result<()> {
         },
     });
 
-    assert_eq!(coverage, coverage! {
-        "main.exe" => {
-            1 => 2,
-            2 => 1,
-            3 => 1,
-            4 => 0,
-            5 => 1,
-        },
-        "old.dll" => {
-            1 => 0,
-        },
-        "new.dll" => {
-            1 => 1,
-        },
-    });
+    assert_eq!(
+        coverage,
+        coverage! {
+            "main.exe" => {
+                1 => 2,
+                2 => 1,
+                3 => 1,
+                4 => 0,
+                5 => 1,
+            },
+            "old.dll" => {
+                1 => 0,
+            },
+            "new.dll" => {
+                1 => 1,
+            },
+        }
+    );
 
     Ok(())
 }
@@ -136,21 +148,24 @@ fn test_coverage_merge() -> Result<()> {
         },
     });
 
-    assert_eq!(coverage, coverage! {
-        "main.exe" => {
-            1 => 1,
-            2 => 1,
-            3 => 1,
-            4 => 0,
-            5 => 1,
-        },
-        "old.dll" => {
-            1 => 0,
-        },
-        "new.dll" => {
-            1 => 1,
-        },
-    });
+    assert_eq!(
+        coverage,
+        coverage! {
+            "main.exe" => {
+                1 => 1,
+                2 => 1,
+                3 => 1,
+                4 => 0,
+                5 => 1,
+            },
+            "old.dll" => {
+                1 => 0,
+            },
+            "new.dll" => {
+                1 => 1,
+            },
+        }
+    );
 
     Ok(())
 }

--- a/src/agent/coverage/src/binary/tests.rs
+++ b/src/agent/coverage/src/binary/tests.rs
@@ -1,0 +1,156 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use anyhow::Result;
+use debuggable_module::path::FilePath;
+use pretty_assertions::assert_eq;
+
+use crate::binary::{Count, Offset};
+
+use super::*;
+
+macro_rules! module {
+    ( $( $offset: expr => $count: expr, )* ) => {{
+        let mut module = ModuleBinaryCoverage::default();
+
+        $(
+            module.offsets.insert(Offset($offset), Count($count));
+        )*
+
+        module
+    }}
+}
+
+macro_rules! coverage {
+    ( $( $path: expr => { $( $offset: expr => $count: expr, )* }, )* ) => {{
+        let mut coverage = BinaryCoverage::default();
+
+        $(
+            let path = FilePath::new($path)?;
+            let module = module! { $( $offset => $count, )* };
+            coverage.modules.insert(path, module);
+        )*
+
+        coverage
+    }}
+}
+
+#[test]
+fn test_module_increment() -> Result<()> {
+    let mut module = module! {
+        1 => 1,
+        2 => 0,
+    };
+
+    module.increment(Offset(2));
+
+    assert_eq!(module, module! {
+        1 => 1,
+        2 => 1,
+    });
+
+    module.increment(Offset(2));
+
+    assert_eq!(module, module! {
+        1 => 1,
+        2 => 2,
+    });
+
+    module.increment(Offset(3));
+
+    assert_eq!(module, module! {
+        1 => 1,
+        2 => 2,
+        3 => 1,
+    });
+
+    Ok(())
+}
+
+#[test]
+fn test_coverage_add() -> Result<()> {
+    let mut coverage = coverage! {
+        "main.exe" => {
+            1 => 1,
+            2 => 0,
+            3 => 1,
+            4 => 0,
+        },
+        "old.dll" => {
+            1 => 0,
+        },
+    };
+
+    coverage.add(&coverage! {
+        "main.exe" => {
+            1 => 1,
+            2 => 1,
+            5 => 1,
+        },
+        "new.dll" => {
+            1 => 1,
+        },
+    });
+
+    assert_eq!(coverage, coverage! {
+        "main.exe" => {
+            1 => 2,
+            2 => 1,
+            3 => 1,
+            4 => 0,
+            5 => 1,
+        },
+        "old.dll" => {
+            1 => 0,
+        },
+        "new.dll" => {
+            1 => 1,
+        },
+    });
+
+    Ok(())
+}
+
+#[test]
+fn test_coverage_merge() -> Result<()> {
+    let mut coverage = coverage! {
+        "main.exe" => {
+            1 => 1,
+            2 => 0,
+            3 => 1,
+            4 => 0,
+        },
+        "old.dll" => {
+            1 => 0,
+        },
+    };
+
+    coverage.merge(&coverage! {
+        "main.exe" => {
+            1 => 1,
+            2 => 1,
+            5 => 1,
+        },
+        "new.dll" => {
+            1 => 1,
+        },
+    });
+
+    assert_eq!(coverage, coverage! {
+        "main.exe" => {
+            1 => 1,
+            2 => 1,
+            3 => 1,
+            4 => 0,
+            5 => 1,
+        },
+        "old.dll" => {
+            1 => 0,
+        },
+        "new.dll" => {
+            1 => 1,
+        },
+    });
+
+    Ok(())
+}

--- a/src/agent/coverage/src/record/linux.rs
+++ b/src/agent/coverage/src/record/linux.rs
@@ -48,7 +48,7 @@ impl<'data> LinuxRecorder<'data> {
         if let Some(image) = context.find_image_for_addr(addr) {
             if let Some(coverage) = self.coverage.modules.get_mut(image.path()) {
                 let offset = addr.offset_from(image.base())?;
-                coverage.increment(offset)?;
+                coverage.increment(offset);
             } else {
                 bail!("coverage not initialized for module {}", image.path());
             }

--- a/src/agent/coverage/src/record/windows.rs
+++ b/src/agent/coverage/src/record/windows.rs
@@ -75,7 +75,7 @@ impl<'data> WindowsRecorder<'data> {
             .get_mut(&breakpoint.module)
             .ok_or_else(|| anyhow!("coverage not initialized for module: {}", breakpoint.module))?;
 
-        coverage.increment(breakpoint.offset)?;
+        coverage.increment(breakpoint.offset);
 
         Ok(())
     }


### PR DESCRIPTION
Enable merging binary coverage measurements, combining offset counts via saturating addition or integer maximum.