### PR TITLE
Add more into-JSON coverage conversions

### DIFF
--- a/src/agent/onefuzz-file-format/src/coverage/binary.rs
+++ b/src/agent/onefuzz-file-format/src/coverage/binary.rs
@@ -31,6 +31,17 @@ impl BinaryCoverageJson {
     }
 }
 
+impl From<v0::BinaryCoverageJson> for BinaryCoverageJson {
+    fn from(v0: v0::BinaryCoverageJson) -> Self {
+        Self::V0(v0)
+    }
+}
+impl From<v1::BinaryCoverageJson> for BinaryCoverageJson {
+    fn from(v1: v1::BinaryCoverageJson) -> Self {
+        Self::V1(v1)
+    }
+}
+
 impl TryFrom<BinaryCoverageJson> for BinaryCoverage {
     type Error = anyhow::Error;
 

--- a/src/agent/onefuzz-file-format/src/coverage/binary.rs
+++ b/src/agent/onefuzz-file-format/src/coverage/binary.rs
@@ -31,6 +31,13 @@ impl BinaryCoverageJson {
     }
 }
 
+// Convert into the latest format.
+impl From<BinaryCoverage> for BinaryCoverageJson {
+    fn from(source: BinaryCoverage) -> Self {
+        v1::BinaryCoverageJson::from(source).into()
+    }
+}
+
 impl From<v0::BinaryCoverageJson> for BinaryCoverageJson {
     fn from(v0: v0::BinaryCoverageJson) -> Self {
         Self::V0(v0)

--- a/src/agent/onefuzz-file-format/src/coverage/source.rs
+++ b/src/agent/onefuzz-file-format/src/coverage/source.rs
@@ -31,6 +31,17 @@ impl SourceCoverageJson {
     }
 }
 
+impl From<v0::SourceCoverageJson> for SourceCoverageJson {
+    fn from(v0: v0::SourceCoverageJson) -> Self {
+        Self::V0(v0)
+    }
+}
+impl From<v1::SourceCoverageJson> for SourceCoverageJson {
+    fn from(v1: v1::SourceCoverageJson) -> Self {
+        Self::V1(v1)
+    }
+}
+
 impl TryFrom<SourceCoverageJson> for SourceCoverage {
     type Error = anyhow::Error;
 

--- a/src/agent/onefuzz-file-format/src/coverage/source.rs
+++ b/src/agent/onefuzz-file-format/src/coverage/source.rs
@@ -31,6 +31,13 @@ impl SourceCoverageJson {
     }
 }
 
+// Convert into the latest format.
+impl From<SourceCoverage> for SourceCoverageJson {
+    fn from(source: SourceCoverage) -> Self {
+        v1::SourceCoverageJson::from(source).into()
+    }
+}
+
 impl From<v0::SourceCoverageJson> for SourceCoverageJson {
     fn from(v0: v0::SourceCoverageJson) -> Self {
         Self::V0(v0)

--- a/src/agent/onefuzz-file-format/src/coverage/source/v1.rs
+++ b/src/agent/onefuzz-file-format/src/coverage/source/v1.rs
@@ -12,15 +12,35 @@ pub type SourceFile = String;
 pub type HitCount = u32;
 pub use line_number::LineNumber;
 
-#[derive(Deserialize, Serialize)]
+#[derive(Default, Deserialize, Serialize)]
 pub struct SourceCoverageJson {
     #[serde(flatten)]
     pub files: BTreeMap<SourceFile, FileCoverageJson>,
 }
 
-#[derive(Deserialize, Serialize)]
+#[derive(Default, Deserialize, Serialize)]
 pub struct FileCoverageJson {
     pub lines: BTreeMap<LineNumber, HitCount>,
+}
+
+impl From<SourceCoverage> for SourceCoverageJson {
+    fn from(source: SourceCoverage) -> Self {
+        let mut json = SourceCoverageJson::default();
+
+        for (path, file) in source.files {
+            let mut file_json = FileCoverageJson::default();
+
+            for (line, count) in file {
+                let line_number = LineNumber(line.number());
+                let hit_count = Count.0;
+                file_json.lines.insert(line_number, hit_count);
+            }
+
+            json.insert(path.to_string(), file_json);
+        }
+
+        json
+    }
 }
 
 impl TryFrom<SourceCoverageJson> for SourceCoverage {

--- a/src/agent/onefuzz-file-format/src/coverage/source/v1.rs
+++ b/src/agent/onefuzz-file-format/src/coverage/source/v1.rs
@@ -30,13 +30,13 @@ impl From<SourceCoverage> for SourceCoverageJson {
         for (path, file) in source.files {
             let mut file_json = FileCoverageJson::default();
 
-            for (line, count) in file {
+            for (line, count) in file.lines {
                 let line_number = LineNumber(line.number());
-                let hit_count = Count.0;
+                let hit_count = count.0;
                 file_json.lines.insert(line_number, hit_count);
             }
 
-            json.insert(path.to_string(), file_json);
+            json.files.insert(path.to_string(), file_json);
         }
 
         json


### PR DESCRIPTION
Add additional coverage conversions from in-memory structures directly into JSON-serializable formats. Note that we can now convert directly from coverage data into the JSON container enum (via conversion into the latest versioned format).