### PR TITLE
Bump Tokio from 1.16.0 to 1.24.1 in /src/agent

### DIFF
--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -3588,9 +3588,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.16.1"
+version = "1.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c27a64b625de6d309e8c57716ba93021dccf1b3b5c97edd6d3dd2d2135afc0a"
+checksum = "1d9f76183f91ecfb55e1d7d5602bd1d979e38a3a522fe900241cf195624d67ae"
 dependencies = [
  "bytes",
  "libc",

--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -1833,9 +1833,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.2"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52da4364ffb0e4fe33a9841a98a3f3014fb964045ce4f7a45a398243c8d6b0c9"
+checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
 dependencies = [
  "libc",
  "log",
@@ -1983,7 +1983,7 @@ dependencies = [
  "inotify",
  "kqueue",
  "libc",
- "mio 0.8.2",
+ "mio 0.8.5",
  "walkdir",
  "winapi",
 ]
@@ -3588,9 +3588,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.24.1"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d9f76183f91ecfb55e1d7d5602bd1d979e38a3a522fe900241cf195624d67ae"
+checksum = "0c27a64b625de6d309e8c57716ba93021dccf1b3b5c97edd6d3dd2d2135afc0a"
 dependencies = [
  "bytes",
  "libc",

--- a/src/agent/onefuzz-agent/Cargo.toml
+++ b/src/agent/onefuzz-agent/Cargo.toml
@@ -22,7 +22,7 @@ reqwest = { version = "0.11", features = [
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 storage-queue = { path = "../storage-queue" }
-tokio = { version = "1.16", features = ["full"] }
+tokio = { version = "1.24", features = ["full"] }
 url = { version = "2.3", features = ["serde"] }
 uuid = { version = "0.8", features = ["serde", "v4"] }
 clap = { version = "3.2.4", features = ["derive", "cargo"] }

--- a/src/agent/onefuzz-task/Cargo.toml
+++ b/src/agent/onefuzz-task/Cargo.toml
@@ -44,7 +44,7 @@ stacktrace-parser = { path = "../stacktrace-parser" }
 storage-queue = { path = "../storage-queue" }
 tempfile = "3.2"
 thiserror = "1.0"
-tokio = { version = "1.16", features = ["full"] }
+tokio = { version = "1.24", features = ["full"] }
 tokio-util = { version = "0.7", features = ["full"] }
 tokio-stream = "0.1"
 tui = { version = "0.18", default-features = false, features = ['crossterm'] }

--- a/src/agent/onefuzz-telemetry/Cargo.toml
+++ b/src/agent/onefuzz-telemetry/Cargo.toml
@@ -18,6 +18,6 @@ uuid = { version = "0.8", features = ["serde", "v4"] }
 serde = { version = "1.0", features = ["derive"] }
 z3-sys = { version = "0.6", optional = true}
 iced-x86 = { version = "1.17", optional = true}
-tokio = { version = "1.16", features = ["full"] }
+tokio = { version = "1.24", features = ["full"] }
 lazy_static = "1.4"
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }

--- a/src/agent/onefuzz/Cargo.toml
+++ b/src/agent/onefuzz/Cargo.toml
@@ -27,7 +27,7 @@ serde = "1.0"
 serde_json = "1.0"
 rand = "0.8"
 serde_derive = "1.0"
-tokio = { version = "1.16", features = ["full"] }
+tokio = { version = "1.24", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["fs", "time", "tokio-util"] }
 tokio-util = { version = "0.7", features = ["full"] }
 uuid = { version = "0.8", features = ["serde", "v4"] }

--- a/src/agent/reqwest-retry/Cargo.toml
+++ b/src/agent/reqwest-retry/Cargo.toml
@@ -15,5 +15,5 @@ reqwest = { version = "0.11", features = ["json", "stream", "native-tls-vendored
 thiserror = "1.0"
 
 [dev-dependencies]
-tokio = { version = "1.16", features = ["macros"] }
+tokio = { version = "1.24", features = ["macros"] }
 wiremock = "0.5"

--- a/src/agent/storage-queue/Cargo.toml
+++ b/src/agent/storage-queue/Cargo.toml
@@ -22,6 +22,6 @@ serde_derive = "1.0"
 serde_json = "1.0"
 serde-xml-rs = "0.6"
 bincode = "1.3"
-tokio = { version = "1.16" , features=["full"] }
+tokio = { version = "1.24" , features=["full"] }
 queue-file = "1.4"
 uuid = { version = "0.8", features = ["serde", "v4"] }


### PR DESCRIPTION
## Summary of the Pull Request

Bumps [tokio](https://github.com/tokio-rs/tokio) from 1.16.0 to 1.24.1.

Also bumps dependent [mio](https://github.com/tokio-rs/mio) from 0.8.2 to 0.8.5
