### PR TITLE
Support allowlist extension

### DIFF
--- a/src/agent/coverage/src/allowlist.rs
+++ b/src/agent/coverage/src/allowlist.rs
@@ -24,6 +24,7 @@ impl TargetAllowList {
         }
     }
 
+    #[allow(clippy::field_reassign_with_default)]
     pub fn extend(&self, other: &Self) -> Self {
         let mut new = Self::default();
 

--- a/src/agent/coverage/src/allowlist.rs
+++ b/src/agent/coverage/src/allowlist.rs
@@ -23,6 +23,16 @@ impl TargetAllowList {
             source_files,
         }
     }
+
+    pub fn extend(&self, other: &Self) -> Self {
+        let mut new = Self::default();
+
+        new.functions = self.functions.extend(&other.functions);
+        new.modules = self.modules.extend(&other.modules);
+        new.source_files = self.source_files.extend(&other.source_files);
+
+        new
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -93,6 +103,22 @@ impl AllowList {
         // Allowed if rule-allowed but not excluded by a negative (deny) rule.
         self.allow.is_match(path) && !self.deny.is_match(path)
     }
+
+    /// Build a new `Allowlist` that adds the allow and deny rules of `other` to `self`.
+    pub fn extend(&self, other: &Self) -> Self {
+        let allow = add_regexsets(&self.allow, &other.allow);
+        let deny = add_regexsets(&self.deny, &other.deny);
+
+        AllowList::new(allow, deny)
+    }
+}
+
+fn add_regexsets(lhs: &RegexSet, rhs: &RegexSet) -> RegexSet {
+    let mut patterns = lhs.patterns().to_vec();
+    patterns.extend(rhs.patterns().iter().map(|s| s.to_owned()));
+
+    // Can't panic: patterns were accepted by input `RegexSet` ctors.
+    RegexSet::new(patterns).unwrap()
 }
 
 impl Default for AllowList {


### PR DESCRIPTION
Enable extending allowlists. We will use this feature in the task executor to add a baseline denylist that will avoid errors that occur on ASan interceptor initialization in the presence of software breakpoints.

For #2741.