### PR TITLE
Fully escape allowlist rules

### DIFF
--- a/src/agent/coverage/src/allowlist.rs
+++ b/src/agent/coverage/src/allowlist.rs
@@ -167,16 +167,10 @@ impl AllowListLine {
 
 #[allow(clippy::single_char_pattern)]
 fn glob_to_regex(expr: &str) -> Result<Regex> {
-    // Treat `.` as literal, not match-any.
-    //
-    // Use character class syntax to avoid double-escaping.
-    let expr = expr.replace(".", r"[.]");
+    let expr = regex::escape(expr);
 
-    // Don't make users escape Windows path separators.
-    let expr = expr.replace(r"\", r"\\");
-
-    // Translate glob wildcards into quantified regexes.
-    let expr = expr.replace("*", ".*");
+    // Translate escaped glob wildcards into quantified regexes.
+    let expr = expr.replace(r"\*", ".*");
 
     // Anchor to line start and end.
     let expr = format!("^{expr}$");

--- a/src/agent/coverage/src/allowlist/tests.rs
+++ b/src/agent/coverage/src/allowlist/tests.rs
@@ -161,3 +161,17 @@ bad/*
 
     Ok(())
 }
+
+#[test]
+fn test_allowlist_escape() -> Result<()> {
+    const GOOD: &str = "good (x[y]) {z}+ %#S";
+    const BAD: &str = "bad* a+b @!{ (x)[y]{z}";
+
+    let text = format!("{GOOD}\n! {BAD}");
+    let allowlist = AllowList::parse(&text)?;
+
+    assert!(allowlist.is_allowed(GOOD));
+    assert!(!allowlist.is_allowed(BAD));
+
+    Ok(())
+}


### PR DESCRIPTION
Use `regex::escape()` to comprehensively treat rule expressions as regex literals. Then convert an escaped asterisk to a regex wildcard, and anchor.