### PR TITLE
Apply allowlist to all blocks within a function

### DIFF
--- a/src/agent/coverage/src/binary.rs
+++ b/src/agent/coverage/src/binary.rs
@@ -131,12 +131,20 @@ pub fn find_coverage_sites(
                 if let Some(file) = location.file() {
                     let path = file.full_path();
 
-                    // Apply allowlists per block to account for inlining.
-                    if allowlist.source_files.is_allowed(&path) {
-                        offsets.insert(block.offset);
+                    // Apply allowlists per block, to account for inlining. The `location` values
+                    // here describe the top of the inline-inclusive call stack.
+                    if !allowlist.functions.is_allowed(&path) {
+                        continue;
                     }
+
+                    if !allowlist.source_files.is_allowed(&path) {
+                        continue;
+                    }
+
+                    offsets.insert(block.offset);
                 }
             }
+            println!();
         }
     }
 

--- a/src/agent/coverage/src/binary.rs
+++ b/src/agent/coverage/src/binary.rs
@@ -124,14 +124,16 @@ pub fn find_coverage_sites(
             continue;
         }
 
-        if let Some(location) = symcache.lookup(function.offset.0).next() {
-            if let Some(file) = location.file() {
-                let path = file.full_path();
+        let blocks = block::sweep_region(module, &debuginfo, function.offset, function.size)?;
 
-                if allowlist.source_files.is_allowed(path) {
-                    let blocks =
-                        block::sweep_region(module, &debuginfo, function.offset, function.size)?;
-                    offsets.extend(blocks.iter().map(|b| b.offset));
+        for block in &blocks {
+            if let Some(location) = symcache.lookup(block.offset.0).next() {
+                if let Some(file) = location.file() {
+                    let path = file.full_path();
+
+                    if allowlist.source_files.is_allowed(&path) {
+                        offsets.insert(block.offset);
+                    }
                 }
             }
         }

--- a/src/agent/coverage/src/binary.rs
+++ b/src/agent/coverage/src/binary.rs
@@ -131,6 +131,7 @@ pub fn find_coverage_sites(
                 if let Some(file) = location.file() {
                     let path = file.full_path();
 
+                    // Apply allowlists per block to account for inlining.
                     if allowlist.source_files.is_allowed(&path) {
                         offsets.insert(block.offset);
                     }


### PR DESCRIPTION
Before this change, we only applied source allowlists to a function's entry offset. However, inlined blocks could come from other functions, including some that would be filtered out by deny rules. As a result, the allowlist could incompletely exclude coverage recording for such inlinees.

Instead, apply the source allowlist to each block entrypoint. This assumes that all instructions within a basic block come from the same function. The result is that block-level expansion and source-line mapping correctly inherits allowlist rule application at the binary level.