### PR TITLE
Fixes & improvements to `Expand` behaviour

### DIFF
--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -2123,6 +2123,7 @@ dependencies = [
  "notify",
  "onefuzz-telemetry",
  "pete",
+ "pretty_assertions",
  "proc-maps",
  "process_control",
  "rand 0.8.4",

--- a/src/agent/onefuzz-task/src/tasks/coverage/dotnet.rs
+++ b/src/agent/onefuzz-task/src/tasks/coverage/dotnet.rs
@@ -341,12 +341,12 @@ impl<'a> TaskContext<'a> {
         let input = PlaceHolder::Input.get_string();
 
         for entry in &self.config.target_options {
-            if entry.contains(&input) {
+            if entry.contains(input) {
                 return true;
             }
         }
         for (k, v) in &self.config.target_env {
-            if k == &input || v.contains(&input) {
+            if k == input || v.contains(input) {
                 return true;
             }
         }

--- a/src/agent/onefuzz-task/src/tasks/coverage/generic.rs
+++ b/src/agent/onefuzz-task/src/tasks/coverage/generic.rs
@@ -270,12 +270,12 @@ impl<'a> TaskContext<'a> {
         let input = PlaceHolder::Input.get_string();
 
         for entry in &self.config.target_options {
-            if entry.contains(&input) {
+            if entry.contains(input) {
                 return true;
             }
         }
         for (k, v) in &self.config.target_env {
-            if k == &input || v.contains(&input) {
+            if k == input || v.contains(input) {
                 return true;
             }
         }

--- a/src/agent/onefuzz/Cargo.toml
+++ b/src/agent/onefuzz/Cargo.toml
@@ -20,7 +20,11 @@ lazy_static = "1.4"
 log = "0.4"
 notify = "5.0.0-pre.14"
 regex = "1.6.0"
-reqwest = { version = "0.11", features = ["json", "stream", "native-tls-vendored"], default-features=false }
+reqwest = { version = "0.11", features = [
+    "json",
+    "stream",
+    "native-tls-vendored",
+], default-features = false }
 sha2 = "0.10.2"
 url = { version = "2.3", features = ["serde"] }
 serde = "1.0"
@@ -38,8 +42,8 @@ strum = "0.24"
 strum_macros = "0.24"
 tempfile = "3.2"
 process_control = "4.0"
-reqwest-retry = { path = "../reqwest-retry"}
-onefuzz-telemetry = { path = "../onefuzz-telemetry"}
+reqwest-retry = { path = "../reqwest-retry" }
+onefuzz-telemetry = { path = "../onefuzz-telemetry" }
 stacktrace-parser = { path = "../stacktrace-parser" }
 backoff = { version = "0.4", features = ["tokio"] }
 
@@ -60,3 +64,4 @@ proc-maps = "0.2"
 
 [dev-dependencies]
 structopt = "0.3"
+pretty_assertions = "1.3.0"

--- a/src/agent/onefuzz/src/expand.rs
+++ b/src/agent/onefuzz/src/expand.rs
@@ -692,26 +692,42 @@ mod tests {
 
     #[test]
     fn missing_input() {
-        let result = Expand::new(&test_machine_identity()).evaluate_value("{input_file_sha256}");
+        for mapping_fn in [
+            "{input_file_sha256}",
+            "{input_file_name}",
+            "{input_file_name_no_ext}",
+        ] {
+            let result = Expand::new(&test_machine_identity()).evaluate_value(mapping_fn);
 
-        assert_eq!(
-            format!("{:#}", result.err().unwrap()),
-            "unable to get value of {input_file_sha256}: \
-            no value found for {input}, unable to evaluate {input_file_sha256}"
-        );
+            assert_eq!(
+                format!("{:#}", result.err().unwrap()),
+                format!(
+                    "unable to get value of {mapping_fn}: \
+                    no value found for {{input}}, unable to evaluate {mapping_fn}"
+                )
+            );
+        }
     }
 
     #[test]
     fn wrong_input_type() {
-        let result = Expand::new(&test_machine_identity())
-            .input_marker("not a path") // this inserts {input} with a Scalar type
-            .evaluate_value("{input_file_sha256}");
+        for mapping_fn in [
+            "{input_file_sha256}",
+            "{input_file_name}",
+            "{input_file_name_no_ext}",
+        ] {
+            let result = Expand::new(&test_machine_identity())
+                .input_marker("not a path") // this inserts {input} with a Scalar type
+                .evaluate_value(mapping_fn);
 
-        assert_eq!(
-            format!("{:#}", result.err().unwrap()),
-            "unable to get value of {input_file_sha256}: \
-            {input_file_sha256} must be used with a path value for {input}"
-        );
+            assert_eq!(
+                format!("{:#}", result.err().unwrap()),
+                format!(
+                    "unable to get value of {mapping_fn}: \
+                    {mapping_fn} must be used with a path value for {{input}}"
+                )
+            );
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
- Recursively expand Paths before canonicalization; fixes #2387
- Detect and error on infinitely-expanding variables (due to self-reference or mutual recursion); this fixes an existing problem with list expansion as well
- Detect and report references to unknown replacements (e.g. typoes)
- Detect and report references to _known_ replacements which are not available

---

There is a behavioural change here which is that values which were previously unknown such as `{x}` were unexpanded; from now on these will be errors. It's possible that something somewhere is relying on this.