### PR TITLE
Check agent binary dependencies in CI

### DIFF
--- a/src/ci/agent.sh
+++ b/src/ci/agent.sh
@@ -5,6 +5,8 @@
 
 set -ex
 
+script_dir=$(dirname "$(realpath "${BASH_SOURCE[0]}")")
+
 exists() {
     [ -e "$1" ]
 }
@@ -68,6 +70,10 @@ cargo build --release --locked --manifest-path ./onefuzz-telemetry/Cargo.toml --
 if [ -n "$SCCACHE" ]; then
     sccache --show-stats
 fi
+
+echo "Checking dependencies of binaries"
+
+"$script_dir/check-dependencies.sh"
 
 echo "Copying artifacts to $output_dir"
 

--- a/src/ci/check-dependencies.sh
+++ b/src/ci/check-dependencies.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# This script checks the OneFuzz agent binaries to ensure
+# that we don't accidentally change their dependencies, and 
+# create a binary that won't work on our standard Ubuntu images.
+# 
+# If we do make changes on purpose, the lists below should be updated.
+
+# See issue and related links:
+# https://github.com/microsoft/onefuzz/issues/1966
+
+set -euo pipefail
+
+script_dir=$(dirname "$(realpath "${BASH_SOURCE[0]}")")
+
+function get-deps {
+    ldd "$1" | awk '{ print $1 }' | sort -u
+}
+
+function check {
+    wanted=$2
+    got=$(get-deps "$1")
+    if ! difference=$(diff -u --color <(echo "$wanted") <(echo "$got")); then 
+        echo "unexpected dependencies for $1"
+        echo "wanted:"
+        echo "$wanted"
+        echo "got:"
+        echo "$got"
+        echo "diff:"
+        echo "$difference"
+        echo "check and update dependency lists in src/ci/check-dependencies.sh, if needed"
+        exit 1
+    fi
+}
+
+check "$script_dir/../agent/target/release/onefuzz-task" \
+"/lib64/ld-linux-x86-64.so.2
+libc.so.6
+liblzma.so.5
+libm.so.6
+libunwind-ptrace.so.0
+libunwind.so.8
+libunwind-x86_64.so.8
+linux-vdso.so.1"
+
+check "$script_dir/../agent/target/release/onefuzz-agent" \
+"/lib64/ld-linux-x86-64.so.2
+libc.so.6
+liblzma.so.5
+libm.so.6
+libunwind.so.8
+linux-vdso.so.1"
+
+check "$script_dir/../agent/target/release/srcview" \
+"/lib64/ld-linux-x86-64.so.2
+libc.so.6
+libgcc_s.so.1
+linux-vdso.so.1"

--- a/src/ci/check-dependencies.sh
+++ b/src/ci/check-dependencies.sh
@@ -19,6 +19,9 @@ function get-deps {
 
 function check {
     wanted=$2
+    if [ "$(uname)" != 'Linux' ]; then 
+        wanted=$3
+    fi
     got=$(get-deps "$1")
     if ! difference=$(diff -u --color <(echo "$wanted") <(echo "$got")); then 
         echo "unexpected dependencies for $1"
@@ -43,7 +46,25 @@ libpthread.so.0
 libunwind-ptrace.so.0
 libunwind-x86_64.so.8
 libunwind.so.8
-linux-vdso.so.1"
+linux-vdso.so.1" \
+\
+"ADVAPI32.dll
+KERNEL32.DLL
+KERNELBASE.dll
+MSASN1.dll
+PSAPI.DLL
+RPCRT4.dll
+SSPICLI.DLL
+apphelp.dll
+bcrypt.dll
+crypt32.dll
+dbghelp.dll
+msvcrt.dll
+ntdll.dll
+sechost.dll
+secur32.dll
+ucrtbase.dll
+ws2_32.dll"
 
 check "$script_dir/../agent/target/release/onefuzz-agent" \
 "/lib64/ld-linux-x86-64.so.2
@@ -53,11 +74,33 @@ liblzma.so.5
 libm.so.6
 libpthread.so.0
 libunwind.so.8
-linux-vdso.so.1"
+linux-vdso.so.1" \
+\
+"KERNEL32.DLL
+KERNELBASE.dll
+MSASN1.dll
+RPCRT4.dll
+SSPICLI.DLL
+advapi32.dll
+apphelp.dll
+bcrypt.dll
+crypt32.dll
+msvcrt.dll
+ntdll.dll
+sechost.dll
+secur32.dll
+ucrtbase.dll
+ws2_32.dll"
 
 check "$script_dir/../agent/target/release/srcview" \
 "/lib64/ld-linux-x86-64.so.2
 libc.so.6
 libgcc_s.so.1
 libpthread.so.0
-linux-vdso.so.1"
+linux-vdso.so.1" \
+\
+"KERNEL32.DLL
+KERNELBASE.dll
+apphelp.dll
+bcrypt.dll
+ntdll.dll"

--- a/src/ci/check-dependencies.sh
+++ b/src/ci/check-dependencies.sh
@@ -36,11 +36,13 @@ function check {
 check "$script_dir/../agent/target/release/onefuzz-task" \
 "/lib64/ld-linux-x86-64.so.2
 libc.so.6
+libdl.so.2
 liblzma.so.5
 libm.so.6
+libpthread.so.0
 libunwind-ptrace.so.0
-libunwind.so.8
 libunwind-x86_64.so.8
+libunwind.so.8
 linux-vdso.so.1"
 
 check "$script_dir/../agent/target/release/onefuzz-agent" \

--- a/src/ci/check-dependencies.sh
+++ b/src/ci/check-dependencies.sh
@@ -48,8 +48,10 @@ linux-vdso.so.1"
 check "$script_dir/../agent/target/release/onefuzz-agent" \
 "/lib64/ld-linux-x86-64.so.2
 libc.so.6
+libdl.so.2
 liblzma.so.5
 libm.so.6
+libpthread.so.0
 libunwind.so.8
 linux-vdso.so.1"
 
@@ -57,4 +59,5 @@ check "$script_dir/../agent/target/release/srcview" \
 "/lib64/ld-linux-x86-64.so.2
 libc.so.6
 libgcc_s.so.1
+libpthread.so.0
 linux-vdso.so.1"


### PR DESCRIPTION
Closes #1966. Check the list of dynamic dependencies of the agent binaries to ensure we don't accidentally take a dependency on some new or unknown library.