### PR TITLE
Validate scriban from cli

### DIFF
--- a/docs/webhook_events.md
+++ b/docs/webhook_events.md
@@ -330,9 +330,7 @@ If webhook is set to have Event Grid message format then the payload will look a
             },
             "required": [
                 "job_id",
-                "task",
-                "containers",
-                "tags"
+                "task"
             ],
             "title": "TaskConfig",
             "type": "object"
@@ -2239,9 +2237,7 @@ If webhook is set to have Event Grid message format then the payload will look a
             },
             "required": [
                 "job_id",
-                "task",
-                "containers",
-                "tags"
+                "task"
             ],
             "title": "TaskConfig",
             "type": "object"
@@ -2969,9 +2965,7 @@ If webhook is set to have Event Grid message format then the payload will look a
             },
             "required": [
                 "job_id",
-                "task",
-                "containers",
-                "tags"
+                "task"
             ],
             "title": "TaskConfig",
             "type": "object"
@@ -3490,9 +3484,7 @@ If webhook is set to have Event Grid message format then the payload will look a
             },
             "required": [
                 "job_id",
-                "task",
-                "containers",
-                "tags"
+                "task"
             ],
             "title": "TaskConfig",
             "type": "object"
@@ -3954,9 +3946,7 @@ If webhook is set to have Event Grid message format then the payload will look a
             },
             "required": [
                 "job_id",
-                "task",
-                "containers",
-                "tags"
+                "task"
             ],
             "title": "TaskConfig",
             "type": "object"
@@ -4392,9 +4382,7 @@ If webhook is set to have Event Grid message format then the payload will look a
             },
             "required": [
                 "job_id",
-                "task",
-                "containers",
-                "tags"
+                "task"
             ],
             "title": "TaskConfig",
             "type": "object"
@@ -4857,9 +4845,7 @@ If webhook is set to have Event Grid message format then the payload will look a
             },
             "required": [
                 "job_id",
-                "task",
-                "containers",
-                "tags"
+                "task"
             ],
             "title": "TaskConfig",
             "type": "object"
@@ -6606,9 +6592,7 @@ If webhook is set to have Event Grid message format then the payload will look a
             },
             "required": [
                 "job_id",
-                "task",
-                "containers",
-                "tags"
+                "task"
             ],
             "title": "TaskConfig",
             "type": "object"

--- a/src/cli/onefuzz/api.py
+++ b/src/cli/onefuzz/api.py
@@ -1713,6 +1713,17 @@ class InstanceConfigCmd(Endpoint):
         )
 
 
+class ValidateScriban(Endpoint):
+    """Interact with Validate Scriban"""
+
+    endpoint = "ValidateScriban"
+
+    def post(self, req: requests.TemplateValidationPost) -> responses.TemplateValidationResponse:
+        return self._req_model(
+            "POST",
+            responses.TemplateValidationResponse,
+            data=req)
+
 class Command:
     def __init__(self, onefuzz: "Onefuzz", logger: logging.Logger):
         self.onefuzz = onefuzz
@@ -1803,6 +1814,7 @@ class Onefuzz:
         self.webhooks = Webhooks(self)
         self.tools = Tools(self)
         self.instance_config = InstanceConfigCmd(self)
+        self.validate_scriban = ValidateScriban(self)
 
         if self._backend.is_feature_enabled(PreviewFeature.job_templates.name):
             self.job_templates = JobTemplates(self)

--- a/src/cli/onefuzz/api.py
+++ b/src/cli/onefuzz/api.py
@@ -529,10 +529,11 @@ class Containers(Endpoint):
     ) -> None:
         to_download: Dict[str, str] = {}
         for task in tasks:
-            for container in task.config.containers:
-                info = self.onefuzz.containers.get(container.name)
-                name = os.path.join(container.type.name, container.name)
-                to_download[name] = info.sas_url
+            if task.config.containers is not None:
+                for container in task.config.containers:
+                    info = self.onefuzz.containers.get(container.name)
+                    name = os.path.join(container.type.name, container.name)
+                    to_download[name] = info.sas_url
 
         if output is None:
             output = primitives.Directory(os.getcwd())
@@ -1099,9 +1100,14 @@ class JobContainers(Endpoint):
         containers = set()
         tasks = self.onefuzz.tasks.list(job_id=job_id, state=[])
         for task in tasks:
-            containers.update(
-                set(x.name for x in task.config.containers if x.type == container_type)
-            )
+            if task.config.containers is not None:
+                containers.update(
+                    set(
+                        x.name
+                        for x in task.config.containers
+                        if x.type == container_type
+                    )
+                )
 
         results: Dict[str, List[str]] = {}
         for container in containers:
@@ -1133,23 +1139,24 @@ class JobContainers(Endpoint):
         containers = set()
         to_delete = set()
         for task in self.onefuzz.jobs.tasks.list(job_id=job.job_id):
-            for container in task.config.containers:
-                containers.add(container.name)
-                if container.type not in SAFE_TO_REMOVE:
-                    continue
-                elif not only_job_specific:
-                    to_delete.add(container.name)
-                elif only_job_specific and (
-                    self.onefuzz.utils.build_container_name(
-                        container_type=container.type,
-                        project=job.config.project,
-                        name=job.config.name,
-                        build=job.config.build,
-                        platform=task.os,
-                    )
-                    == container.name
-                ):
-                    to_delete.add(container.name)
+            if task.config.containers is not None:
+                for container in task.config.containers:
+                    containers.add(container.name)
+                    if container.type not in SAFE_TO_REMOVE:
+                        continue
+                    elif not only_job_specific:
+                        to_delete.add(container.name)
+                    elif only_job_specific and (
+                        self.onefuzz.utils.build_container_name(
+                            container_type=container.type,
+                            project=job.config.project,
+                            name=job.config.name,
+                            build=job.config.build,
+                            platform=task.os,
+                        )
+                        == container.name
+                    ):
+                        to_delete.add(container.name)
 
         to_keep = containers - to_delete
         for container_name in to_keep:
@@ -1718,11 +1725,11 @@ class ValidateScriban(Endpoint):
 
     endpoint = "ValidateScriban"
 
-    def post(self, req: requests.TemplateValidationPost) -> responses.TemplateValidationResponse:
-        return self._req_model(
-            "POST",
-            responses.TemplateValidationResponse,
-            data=req)
+    def post(
+        self, req: requests.TemplateValidationPost
+    ) -> responses.TemplateValidationResponse:
+        return self._req_model("POST", responses.TemplateValidationResponse, data=req)
+
 
 class Command:
     def __init__(self, onefuzz: "Onefuzz", logger: logging.Logger):

--- a/src/cli/onefuzz/debug.py
+++ b/src/cli/onefuzz/debug.py
@@ -18,9 +18,12 @@ from azure.applicationinsights import ApplicationInsightsDataClient
 from azure.applicationinsights.models import QueryBody
 from azure.identity import AzureCliCredential
 from azure.storage.blob import ContainerClient
+from onefuzztypes import requests
+from onefuzztypes import models
 from onefuzztypes.enums import ContainerType, TaskType
-from onefuzztypes.models import BlobRef, Job, NodeAssignment, Report, Task, TaskConfig
+from onefuzztypes.models import BlobRef, Job, NodeAssignment, Report, Task, TaskConfig, NotificationConfig
 from onefuzztypes.primitives import Container, Directory, PoolName
+from onefuzztypes.responses import TemplateValidationResponse
 
 from onefuzz.api import UUID_EXPANSION, Command, Onefuzz
 
@@ -730,6 +733,15 @@ class DebugNotification(Command):
         sas_url = self.onefuzz.containers.get(container_name).sas_url
         _, netloc, _, _, _, _ = urlparse(sas_url)
         return netloc.split(".")[0]
+
+    def template(
+        self,
+        template: str,
+        context: Optional[models.TemplateRenderContext]
+    ) -> TemplateValidationResponse:
+        """Validate scriban rendering of notification config"""
+        req = requests.TemplateValidationPost(template=template, context=context)
+        return self.onefuzz.validate_scriban.post(req)
 
     def job(
         self,

--- a/src/cli/onefuzz/debug.py
+++ b/src/cli/onefuzz/debug.py
@@ -18,10 +18,9 @@ from azure.applicationinsights import ApplicationInsightsDataClient
 from azure.applicationinsights.models import QueryBody
 from azure.identity import AzureCliCredential
 from azure.storage.blob import ContainerClient
-from onefuzztypes import requests
-from onefuzztypes import models
+from onefuzztypes import models, requests
 from onefuzztypes.enums import ContainerType, TaskType
-from onefuzztypes.models import BlobRef, Job, NodeAssignment, Report, Task, TaskConfig, NotificationConfig
+from onefuzztypes.models import BlobRef, Job, NodeAssignment, Report, Task, TaskConfig
 from onefuzztypes.primitives import Container, Directory, PoolName
 from onefuzztypes.responses import TemplateValidationResponse
 
@@ -724,9 +723,10 @@ class DebugNotification(Command):
     def _get_container(
         self, task: Task, container_type: ContainerType
     ) -> Optional[Container]:
-        for container in task.config.containers:
-            if container.type == container_type:
-                return container.name
+        if task.config.containers is not None:
+            for container in task.config.containers:
+                if container.type == container_type:
+                    return container.name
         return None
 
     def _get_storage_account(self, container_name: Container) -> str:
@@ -735,9 +735,7 @@ class DebugNotification(Command):
         return netloc.split(".")[0]
 
     def template(
-        self,
-        template: str,
-        context: Optional[models.TemplateRenderContext]
+        self, template: str, context: Optional[models.TemplateRenderContext]
     ) -> TemplateValidationResponse:
         """Validate scriban rendering of notification config"""
         req = requests.TemplateValidationPost(template=template, context=context)

--- a/src/cli/onefuzz/status/cmd.py
+++ b/src/cli/onefuzz/status/cmd.py
@@ -115,10 +115,11 @@ class Status(Command):
 
         containers: DefaultDict[ContainerType, Set[Container]] = defaultdict(set)
         for task in tasks:
-            for container in task.config.containers:
-                if container.type not in containers:
-                    containers[container.type] = set()
-                containers[container.type].add(container.name)
+            if task.config.containers is not None:
+                for container in task.config.containers:
+                    if container.type not in containers:
+                        containers[container.type] = set()
+                    containers[container.type].add(container.name)
 
         print("\ncontainers:")
         for container_type in containers:

--- a/src/cli/onefuzz/status/top.py
+++ b/src/cli/onefuzz/status/top.py
@@ -68,8 +68,9 @@ class Top:
 
             for task in self.onefuzz.tasks.list(job_id=job.job_id):
                 self.cache.add_task(task)
-                for container in task.config.containers:
-                    self.add_container(container.name)
+                if task.config.containers is not None:
+                    for container in task.config.containers:
+                        self.add_container(container.name)
 
         nodes = self.onefuzz.nodes.list()
         for node in nodes:

--- a/src/cli/onefuzz/template.py
+++ b/src/cli/onefuzz/template.py
@@ -63,7 +63,11 @@ class Template(Command):
                     self.onefuzz.tasks.delete(task.task_id)
 
                 if stop_notifications:
-                    container_names = [x.name for x in task.config.containers]
+                    container_names = (
+                        [x.name for x in task.config.containers]
+                        if task.config.containers is not None
+                        else []
+                    )
                     notifications = self.onefuzz.notifications.list(
                         container=container_names
                     )

--- a/src/pytypes/onefuzztypes/models.py
+++ b/src/pytypes/onefuzztypes/models.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from typing import Any, Dict, Generic, List, Optional, TypeVar, Union
 from uuid import UUID, uuid4
 
-from pydantic import BaseModel, Field, root_validator, validator
+from pydantic import BaseModel, Field, root_validator, validator, AnyHttpUrl
 from pydantic.dataclasses import dataclass
 
 from ._monkeypatch import _check_hotfix
@@ -868,6 +868,17 @@ class AzureVmExtensionConfig(BaseModel):
 class ApiAccessRule(BaseModel):
     methods: List[str]
     allowed_groups: List[UUID]
+
+class TemplateRenderContext(BaseModel):
+    report: Report
+    task: TaskConfig
+    job: JobConfig
+    report_url: AnyHttpUrl
+    input_url: AnyHttpUrl
+    target_url: AnyHttpUrl
+    report_container: Container
+    report_filename: str
+    repro_cmd: str
 
 
 Endpoint = str

--- a/src/pytypes/onefuzztypes/models.py
+++ b/src/pytypes/onefuzztypes/models.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from typing import Any, Dict, Generic, List, Optional, TypeVar, Union
 from uuid import UUID, uuid4
 
-from pydantic import BaseModel, Field, root_validator, validator, AnyHttpUrl
+from pydantic import AnyHttpUrl, BaseModel, Field, root_validator, validator
 from pydantic.dataclasses import dataclass
 
 from ._monkeypatch import _check_hotfix
@@ -868,6 +868,7 @@ class AzureVmExtensionConfig(BaseModel):
 class ApiAccessRule(BaseModel):
     methods: List[str]
     allowed_groups: List[UUID]
+
 
 class TemplateRenderContext(BaseModel):
     report: Report

--- a/src/pytypes/onefuzztypes/models.py
+++ b/src/pytypes/onefuzztypes/models.py
@@ -193,8 +193,8 @@ class TaskConfig(BaseModel):
     task: TaskDetails
     vm: Optional[TaskVm]
     pool: Optional[TaskPool]
-    containers: List[TaskContainers]
-    tags: Dict[str, str]
+    containers: Optional[List[TaskContainers]]
+    tags: Optional[Dict[str, str]]
     debug: Optional[List[TaskDebugFlag]]
     colocate: Optional[bool]
 

--- a/src/pytypes/onefuzztypes/requests.py
+++ b/src/pytypes/onefuzztypes/requests.py
@@ -20,7 +20,7 @@ from .enums import (
     TaskState,
 )
 from .events import EventType
-from .models import AutoScaleConfig, InstanceConfig, NotificationConfig
+from .models import AutoScaleConfig, InstanceConfig, NotificationConfig, TemplateRenderContext
 from .primitives import Container, PoolName, Region
 from .webhooks import WebhookMessageFormat
 
@@ -251,5 +251,8 @@ class NodeAddSshKey(BaseModel):
 class InstanceConfigUpdate(BaseModel):
     config: InstanceConfig
 
+class TemplateValidationPost(BaseModel):
+    template: str
+    context: Optional[TemplateRenderContext]
 
 _check_hotfix()

--- a/src/pytypes/onefuzztypes/requests.py
+++ b/src/pytypes/onefuzztypes/requests.py
@@ -20,7 +20,12 @@ from .enums import (
     TaskState,
 )
 from .events import EventType
-from .models import AutoScaleConfig, InstanceConfig, NotificationConfig, TemplateRenderContext
+from .models import (
+    AutoScaleConfig,
+    InstanceConfig,
+    NotificationConfig,
+    TemplateRenderContext,
+)
 from .primitives import Container, PoolName, Region
 from .webhooks import WebhookMessageFormat
 
@@ -251,8 +256,10 @@ class NodeAddSshKey(BaseModel):
 class InstanceConfigUpdate(BaseModel):
     config: InstanceConfig
 
+
 class TemplateValidationPost(BaseModel):
     template: str
     context: Optional[TemplateRenderContext]
+
 
 _check_hotfix()

--- a/src/pytypes/onefuzztypes/responses.py
+++ b/src/pytypes/onefuzztypes/responses.py
@@ -85,6 +85,7 @@ class CanSchedule(BaseResponse):
     allowed: bool
     work_stopped: bool
 
+
 class TemplateValidationResponse(BaseResponse):
     rendered_template: str
     available_context: TemplateRenderContext

--- a/src/pytypes/onefuzztypes/responses.py
+++ b/src/pytypes/onefuzztypes/responses.py
@@ -9,7 +9,7 @@ from uuid import UUID
 from pydantic import BaseModel
 
 from .enums import VmState
-from .models import Forward, NodeCommandEnvelope
+from .models import Forward, NodeCommandEnvelope, TemplateRenderContext
 from .primitives import Region
 
 
@@ -84,3 +84,7 @@ class PendingNodeCommand(BaseResponse):
 class CanSchedule(BaseResponse):
     allowed: bool
     work_stopped: bool
+
+class TemplateValidationResponse(BaseResponse):
+    rendered_template: str
+    available_context: TemplateRenderContext


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_

Adds a cli command `onefuzz debug notification template`. You pass a template string and it will attempt to render it for you via scriban.

Help text:
```
$ onefuzz debug notification template -h
usage: onefuzz debug notification template [-h] [-v] [--format {json,raw}] [--query QUERY] [--context TemplateRenderContext] template

positional arguments:
  template

options:
  -h, --help            show this help message and exit
  -v, --verbose         increase output verbosity
  --format {json,raw}   output format
  --query QUERY         JMESPath query string. See http://jmespath.org/ for more information and examples.
  --context TemplateRenderContext
                        JSON for TemplateRenderContext. use @file to read from a file
```

Closes #2501 

## Info on Pull Request

* Adds the new template subcommand
* Adds some new C# types that weren't migrated to pytypes
* Update TaskConfig type to match C#

_What does this include?_

## Validation Steps Performed

_How does someone test & validate?_

I ran the command with some valid and invalid scriban template strings to see if they're rendered correctly.
