### PR TITLE
Interact with migrations via cli

### DIFF
--- a/src/cli/onefuzz/api.py
+++ b/src/cli/onefuzz/api.py
@@ -13,7 +13,7 @@ import time
 import uuid
 from enum import Enum
 from shutil import which
-from typing import Callable, Dict, List, Optional, Tuple, Type, TypeVar
+from typing import Callable, Dict, List, Optional, Tuple, Type, TypeVar, Union
 from urllib.parse import urlparse
 from uuid import UUID
 
@@ -1731,6 +1731,34 @@ class ValidateScriban(Endpoint):
         return self._req_model("POST", responses.TemplateValidationResponse, data=req)
 
 
+class Migration(Endpoint):
+    """Execute migrations"""
+
+    endpoint = "migrations"
+
+    def jinja_to_scriban(
+        self, dry_run: bool = False
+    ) -> Union[
+        responses.JinjaToScribanMigrationResponse,
+        responses.JinjaToScribanMigrationDryRunResponse,
+    ]:
+        migration_endpoint = self.endpoint + "/jinja_to_scriban"
+        if dry_run:
+            return self._req_model(
+                "POST",
+                responses.JinjaToScribanMigrationDryRunResponse,
+                data=requests.JinjaToScribanMigrationPost(dry_run=dry_run),
+                alternate_endpoint=migration_endpoint,
+            )
+        else:
+            return self._req_model(
+                "POST",
+                responses.JinjaToScribanMigrationResponse,
+                data=requests.JinjaToScribanMigrationPost(dry_run=dry_run),
+                alternate_endpoint=migration_endpoint,
+            )
+
+
 class Command:
     def __init__(self, onefuzz: "Onefuzz", logger: logging.Logger):
         self.onefuzz = onefuzz
@@ -1822,6 +1850,7 @@ class Onefuzz:
         self.tools = Tools(self)
         self.instance_config = InstanceConfigCmd(self)
         self.validate_scriban = ValidateScriban(self)
+        self.migrations = Migration(self)
 
         if self._backend.is_feature_enabled(PreviewFeature.job_templates.name):
             self.job_templates = JobTemplates(self)

--- a/src/cli/onefuzz/api.py
+++ b/src/cli/onefuzz/api.py
@@ -888,6 +888,30 @@ class Notifications(Endpoint):
             data=requests.NotificationSearch(container=container),
         )
 
+    def migrate_jinja_to_scriban(
+        self, dry_run: bool = False
+    ) -> Union[
+        responses.JinjaToScribanMigrationResponse,
+        responses.JinjaToScribanMigrationDryRunResponse,
+    ]:
+        """Migrates all notification templates from jinja to scriban"""
+
+        migration_endpoint = "migrations/jinja_to_scriban"
+        if dry_run:
+            return self._req_model(
+                "POST",
+                responses.JinjaToScribanMigrationDryRunResponse,
+                data=requests.JinjaToScribanMigrationPost(dry_run=dry_run),
+                alternate_endpoint=migration_endpoint,
+            )
+        else:
+            return self._req_model(
+                "POST",
+                responses.JinjaToScribanMigrationResponse,
+                data=requests.JinjaToScribanMigrationPost(dry_run=dry_run),
+                alternate_endpoint=migration_endpoint,
+            )
+
 
 class Tasks(Endpoint):
     """Interact with tasks"""
@@ -1731,34 +1755,6 @@ class ValidateScriban(Endpoint):
         return self._req_model("POST", responses.TemplateValidationResponse, data=req)
 
 
-class Migration(Endpoint):
-    """Execute migrations"""
-
-    endpoint = "migrations"
-
-    def jinja_to_scriban(
-        self, dry_run: bool = False
-    ) -> Union[
-        responses.JinjaToScribanMigrationResponse,
-        responses.JinjaToScribanMigrationDryRunResponse,
-    ]:
-        migration_endpoint = self.endpoint + "/jinja_to_scriban"
-        if dry_run:
-            return self._req_model(
-                "POST",
-                responses.JinjaToScribanMigrationDryRunResponse,
-                data=requests.JinjaToScribanMigrationPost(dry_run=dry_run),
-                alternate_endpoint=migration_endpoint,
-            )
-        else:
-            return self._req_model(
-                "POST",
-                responses.JinjaToScribanMigrationResponse,
-                data=requests.JinjaToScribanMigrationPost(dry_run=dry_run),
-                alternate_endpoint=migration_endpoint,
-            )
-
-
 class Command:
     def __init__(self, onefuzz: "Onefuzz", logger: logging.Logger):
         self.onefuzz = onefuzz
@@ -1850,7 +1846,6 @@ class Onefuzz:
         self.tools = Tools(self)
         self.instance_config = InstanceConfigCmd(self)
         self.validate_scriban = ValidateScriban(self)
-        self.migrations = Migration(self)
 
         if self._backend.is_feature_enabled(PreviewFeature.job_templates.name):
             self.job_templates = JobTemplates(self)

--- a/src/pytypes/onefuzztypes/requests.py
+++ b/src/pytypes/onefuzztypes/requests.py
@@ -262,4 +262,8 @@ class TemplateValidationPost(BaseModel):
     context: Optional[TemplateRenderContext]
 
 
+class JinjaToScribanMigrationPost(BaseModel):
+    dry_run: bool = Field(default=False)
+
+
 _check_hotfix()

--- a/src/pytypes/onefuzztypes/responses.py
+++ b/src/pytypes/onefuzztypes/responses.py
@@ -89,3 +89,12 @@ class CanSchedule(BaseResponse):
 class TemplateValidationResponse(BaseResponse):
     rendered_template: str
     available_context: TemplateRenderContext
+
+
+class JinjaToScribanMigrationResponse(BaseResponse):
+    updated_notification_ids: List[UUID]
+    failed_notification_ids: List[UUID]
+
+
+class JinjaToScribanMigrationDryRunResponse(BaseResponse):
+    notification_ids_to_update: List[UUID]


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_

Closes #2810. This adds the ability to run `onefuzz notifications migrate_jinja_to_scriban`

## Info on Pull Request

_What does this include?_

* New CLI command for jinja to scriban migration endpoint
* New request/response types needed for the endpoint

## Validation Steps Performed

_How does someone test & validate?_

Target a dev deployment and run with and without `--dry_run` argument.
