### PR TITLE
Fix coverage example build

### DIFF
--- a/src/agent/debugger/Cargo.toml
+++ b/src/agent/debugger/Cargo.toml
@@ -23,6 +23,7 @@ features = [
     "debugapi",
     "handleapi",
     "memoryapi",
+    "namedpipeapi",
     "processthreadsapi",
     "securitybaseapi",
     "shellapi",


### PR DESCRIPTION
The `coverage` crate does not build on its own unless the `namedpipeapi` feature from `winapi` is enabled.

In the larger OneFuzz workspace, this feature is enabled for `winapi` elsewhere, which is why the build generally is not broken.

A note: `winapi` hasn't had a commit since November 2021.