### PR TITLE
Defer coverage breakpoints

### DIFF
--- a/src/agent/coverage/src/record/windows.rs
+++ b/src/agent/coverage/src/record/windows.rs
@@ -83,7 +83,7 @@ impl<'data> WindowsRecorder<'data> {
                     let thread_id = dbg.get_current_thread_id();
                     let state = DeferralState::PendingReturn { thread_id };
                     self.deferred_breakpoints.insert(id, (trigger, state));
-                },
+                }
                 DeferralState::PendingReturn { thread_id } => {
                     if dbg.get_current_thread_id() == thread_id {
                         // We've returned from the trigger function, and on the same thread.
@@ -99,15 +99,13 @@ impl<'data> WindowsRecorder<'data> {
                         let id = trigger.set(dbg)?;
                         self.deferred_breakpoints.insert(id, (trigger, state));
                     }
-                },
+                }
             }
 
             return Ok(());
         }
 
-        let breakpoint = self
-            .breakpoints
-            .remove(id);
+        let breakpoint = self.breakpoints.remove(id);
 
         let Some(breakpoint) = breakpoint else {
             let stack = dbg.get_current_stack()?;
@@ -153,7 +151,11 @@ impl<'data> WindowsRecorder<'data> {
         Ok(())
     }
 
-    fn set_or_defer_module_breakpoints(&mut self, dbg: &mut Debugger, path: FilePath) -> Result<()> {
+    fn set_or_defer_module_breakpoints(
+        &mut self,
+        dbg: &mut Debugger,
+        path: FilePath,
+    ) -> Result<()> {
         let (_module, debuginfo) = &self.modules[&path];
 
         // For borrowck.
@@ -177,7 +179,10 @@ impl<'data> WindowsRecorder<'data> {
             debug!("deferring coverage breakpoints for module {}", path);
             self.defer_module_breakpoints(dbg, path, trigger)
         } else {
-            debug!("immediately setting coverage breakpoints for module {}", path);
+            debug!(
+                "immediately setting coverage breakpoints for module {}",
+                path
+            );
             self.set_module_breakpoints(dbg, path)
         }
     }
@@ -192,7 +197,8 @@ impl<'data> WindowsRecorder<'data> {
         let entry_breakpoint = Breakpoint::new(path, trigger.offset);
         let id = entry_breakpoint.set(dbg)?;
 
-        self.deferred_breakpoints.insert(id, (entry_breakpoint, state));
+        self.deferred_breakpoints
+            .insert(id, (entry_breakpoint, state));
 
         Ok(())
     }

--- a/src/agent/coverage/src/record/windows.rs
+++ b/src/agent/coverage/src/record/windows.rs
@@ -174,6 +174,12 @@ impl Breakpoint {
     pub fn new(module: FilePath, offset: Offset) -> Self {
         Self { module, offset }
     }
+
+    pub fn set(&self, dbg: &mut Debugger) -> Result<BreakpointId> {
+        let name = Path::new(self.module.base_name());
+        let id = dbg.new_rva_breakpoint(name, self.offset.0, BreakpointType::OneTime)?;
+        Ok(id)
+    }
 }
 
 impl<'data> DebugEventHandler for WindowsRecorder<'data> {

--- a/src/agent/coverage/src/record/windows.rs
+++ b/src/agent/coverage/src/record/windows.rs
@@ -166,8 +166,8 @@ impl Breakpoints {
 
 #[derive(Clone, Debug)]
 struct Breakpoint {
-    module: FilePath,
-    offset: Offset,
+    pub module: FilePath,
+    pub offset: Offset,
 }
 
 impl Breakpoint {

--- a/src/agent/coverage/src/record/windows.rs
+++ b/src/agent/coverage/src/record/windows.rs
@@ -110,7 +110,8 @@ impl<'data> WindowsRecorder<'data> {
             self.breakpoints.set(dbg, breakpoint)?;
         }
 
-        self.coverage.modules.insert(path.clone(), coverage);
+        let count = coverage.offsets.len();
+        debug!("set {} breakpoints for module {}", count, path);
 
         self.modules.insert(path, module);
 

--- a/src/agent/coverage/src/record/windows.rs
+++ b/src/agent/coverage/src/record/windows.rs
@@ -83,7 +83,6 @@ impl<'data> WindowsRecorder<'data> {
                     let thread_id = dbg.get_current_thread_id();
                     let state = DeferralState::PendingReturn { thread_id };
                     self.deferred_breakpoints.insert(id, (trigger, state));
-                    // return Ok(());
                 },
                 DeferralState::PendingReturn { thread_id } => {
                     if dbg.get_current_thread_id() == thread_id {
@@ -99,7 +98,6 @@ impl<'data> WindowsRecorder<'data> {
                         // expect to reach this code in practice.
                         let id = trigger.set(dbg)?;
                         self.deferred_breakpoints.insert(id, (trigger, state));
-                        // return Ok(());
                     }
                 },
             }

--- a/src/agent/coverage/src/record/windows.rs
+++ b/src/agent/coverage/src/record/windows.rs
@@ -69,8 +69,12 @@ impl<'data> WindowsRecorder<'data> {
     fn try_on_breakpoint(&mut self, _dbg: &mut Debugger, id: BreakpointId) -> Result<()> {
         let breakpoint = self
             .breakpoints
-            .remove(id)
-            .ok_or_else(|| anyhow!("stopped on dangling breakpoint"))?;
+            .remove(id);
+
+        let Some(breakpoint) = breakpoint else {
+            let stack = dbg.get_current_stack()?;
+            bail!("stopped on dangling breakpoint, debuggee stack:\n{}", stack);
+        };
 
         let coverage = self
             .coverage

--- a/src/agent/coverage/src/record/windows.rs
+++ b/src/agent/coverage/src/record/windows.rs
@@ -71,9 +71,6 @@ impl<'data> WindowsRecorder<'data> {
     }
 
     fn try_on_breakpoint(&mut self, dbg: &mut Debugger, id: BreakpointId) -> Result<()> {
-        let pc = dbg.read_program_counter()?;
-        let tid = dbg.get_current_thread_id();
-
         if let Some((trigger, state)) = self.deferred_breakpoints.remove(&id) {
             match state {
                 DeferralState::NotEntered => {
@@ -196,7 +193,6 @@ impl<'data> WindowsRecorder<'data> {
         let state = DeferralState::NotEntered;
         let entry_breakpoint = Breakpoint::new(path, trigger.offset);
         let id = entry_breakpoint.set(dbg)?;
-        let thread_id = dbg.get_current_thread_id();
 
         self.deferred_breakpoints.insert(id, (entry_breakpoint, state));
 

--- a/src/agent/coverage/src/record/windows.rs
+++ b/src/agent/coverage/src/record/windows.rs
@@ -152,6 +152,11 @@ impl<'data> WindowsRecorder<'data> {
     fn insert_module(&mut self, dbg: &mut Debugger, module: &ModuleLoadInfo) -> Result<()> {
         let path = FilePath::new(module.path().to_string_lossy())?;
 
+        if self.modules.contains_key(&path) {
+            warn!("module coverage already initialized, skipping");
+            return Ok(());
+        }
+
         if !self.allowlist.modules.is_allowed(&path) {
             debug!("not inserting denylisted module: {path}");
             return Ok(());

--- a/src/agent/coverage/src/record/windows.rs
+++ b/src/agent/coverage/src/record/windows.rs
@@ -179,10 +179,10 @@ impl<'data> WindowsRecorder<'data> {
         }
 
         if let Some(trigger) = trigger {
-            debug!("deferring module breakpoints for {}", path);
+            debug!("deferring coverage breakpoints for module {}", path);
             self.defer_module_breakpoints(dbg, path, trigger)
         } else {
-            debug!("immediately setting module breakpoints for {}", path);
+            debug!("immediately setting coverage breakpoints for module {}", path);
             self.set_module_breakpoints(dbg, path)
         }
     }

--- a/src/agent/coverage/src/record/windows.rs
+++ b/src/agent/coverage/src/record/windows.rs
@@ -161,7 +161,7 @@ impl<'data> WindowsRecorder<'data> {
     fn set_or_defer_module_breakpoints(&mut self, dbg: &mut Debugger, path: FilePath) -> Result<()> {
         let (_module, debuginfo) = &self.modules[&path];
 
-        // For borrocwk.
+        // For borrowck.
         let mut trigger = None;
 
         for function in debuginfo.functions() {

--- a/src/agent/coverage/src/record/windows.rs
+++ b/src/agent/coverage/src/record/windows.rs
@@ -275,6 +275,8 @@ impl Breakpoint {
     }
 
     pub fn set(&self, dbg: &mut Debugger) -> Result<BreakpointId> {
+        // The `debugger` crates tracks loaded modules by base name. If a path or file
+        // name is used, software breakpoints will not be written.
         let name = Path::new(self.module.base_name());
         let id = dbg.new_rva_breakpoint(name, self.offset.0, BreakpointType::OneTime)?;
         Ok(id)

--- a/src/agent/debuggable-module/src/debuginfo.rs
+++ b/src/agent/debuggable-module/src/debuginfo.rs
@@ -40,6 +40,7 @@ impl DebugInfo {
     }
 }
 
+#[derive(Clone, Debug)]
 pub struct Function {
     pub name: String,
     pub offset: Offset,


### PR DESCRIPTION
For each loaded module, defer setting coverage breakpoints until exit from certain known initialization functions (when present). Crucially, this lets us avoid breaking Address Sanitizer interceptor initialization, which will otherwise divergently fail execution by [raising its own debug break exception](https://github.com/llvm/llvm-project/blob/llvmorg-14.0.6/compiler-rt/lib/interception/interception_win.cpp#L655-L660).

With this PR, neither OneFuzz itself nor locally-debugging end users will need to use an allowlist to exclude ASan-intercepted functions from coverage recording.

This PR also fixes a bug in breakpoint setting, which would would prevent setting breakpoints whose offset collided with any other breakpoint's offset (_ignoring_ base module). This would manifest in false negative coverage counts for colliding breakpoints.