### PR TITLE
Sets `EnableScriban` to false by default at deployment time

### DIFF
--- a/src/deployment/bicep-templates/feature-flags.bicep
+++ b/src/deployment/bicep-templates/feature-flags.bicep
@@ -18,7 +18,7 @@ resource configStoreFeatureflag 'Microsoft.AppConfiguration/configurationStores/
     value: string({
       id: 'EnableScribanOnly'
       description: 'Render notification templates with scriban only'
-      enabled: true
+      enabled: false
     })
     contentType: 'application/vnd.microsoft.appconfig.ff+json;charset=utf-8'
   }


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_

The scriban migration cli trigger wasn't shipped in 6.4. If EnableScriban is enabled at deployment time, we would need to run the migration **before** the deployment.

This way, we can run the migration after deploying 7.0, and then flip the feature flag afterwards.