### PR TITLE
Fix error reporting for creating a Scaleset under a missing Pool

### DIFF
--- a/src/ApiService/ApiService/Functions/AgentCommands.cs
+++ b/src/ApiService/ApiService/Functions/AgentCommands.cs
@@ -44,7 +44,7 @@ public class AgentCommands {
 
     private async Async.Task<HttpResponseData> Delete(HttpRequestData req) {
         var request = await RequestHandling.ParseRequest<NodeCommandDelete>(req);
-        if (!request.IsOk || request.OkV == null) {
+        if (!request.IsOk) {
             return await _context.RequestHandling.NotOk(req, request.ErrorV, typeof(NodeCommandDelete).ToString());
         }
         var nodeCommand = request.OkV;

--- a/src/ApiService/ApiService/Functions/Scaleset.cs
+++ b/src/ApiService/ApiService/Functions/Scaleset.cs
@@ -63,7 +63,7 @@ public class Scaleset {
         // verify the pool exists
         var poolResult = await _context.PoolOperations.GetByName(create.PoolName);
         if (!poolResult.IsOk) {
-            return await _context.RequestHandling.NotOk(req, answer.ErrorV, "ScalesetCreate");
+            return await _context.RequestHandling.NotOk(req, poolResult.ErrorV, "ScalesetCreate");
         }
 
         var pool = poolResult.OkV;

--- a/src/ApiService/ApiService/OneFuzzTypes/ReturnTypes.cs
+++ b/src/ApiService/ApiService/OneFuzzTypes/ReturnTypes.cs
@@ -2,7 +2,7 @@
 
 namespace Microsoft.OneFuzz.Service {
 
-    public struct ResultVoid<T_Error> {
+    public readonly struct ResultVoid<T_Error> {
         public static ResultVoid<T_Error> Ok() => new();
         public static ResultVoid<T_Error> Error(T_Error err) => new(err);
 
@@ -16,7 +16,7 @@ namespace Microsoft.OneFuzz.Service {
     }
 
 
-    public struct Result<T_Ok, T_Error> {
+    public readonly struct Result<T_Ok, T_Error> {
         public static Result<T_Ok, T_Error> Ok(T_Ok ok) => new(ok);
         public static Result<T_Ok, T_Error> Error(T_Error err) => new(err);
 
@@ -37,17 +37,17 @@ namespace Microsoft.OneFuzz.Service {
         public static OneFuzzResult<T> Ok<T>(T val) => OneFuzzResult<T>.Ok(val);
     }
 
-    public struct OneFuzzResult<T_Ok> {
-        static Error NoError = new(0);
+    public readonly struct OneFuzzResult<T_Ok> {
 
         [MemberNotNullWhen(returnValue: true, member: nameof(OkV))]
+        [MemberNotNullWhen(returnValue: false, member: nameof(ErrorV))]
         public bool IsOk { get; }
 
         public T_Ok? OkV { get; }
 
-        public Error ErrorV { get; }
+        public Error? ErrorV { get; }
 
-        private OneFuzzResult(T_Ok ok) => (OkV, ErrorV, IsOk) = (ok, NoError, true);
+        private OneFuzzResult(T_Ok ok) => (OkV, ErrorV, IsOk) = (ok, null, true);
 
         private OneFuzzResult(ErrorCode errorCode, string[] errors) => (OkV, ErrorV, IsOk) = (default, new Error(errorCode, errors), false);
 
@@ -63,14 +63,14 @@ namespace Microsoft.OneFuzz.Service {
         public static implicit operator OneFuzzResult<T_Ok>(Error err) => new(err);
     }
 
-    public struct OneFuzzResultVoid {
-        static Error NoError = new(0);
+    public readonly struct OneFuzzResultVoid {
 
+        [MemberNotNullWhen(returnValue: false, member: nameof(ErrorV))]
         public bool IsOk { get; }
 
-        public Error ErrorV { get; }
+        public Error? ErrorV { get; }
 
-        public OneFuzzResultVoid() => (ErrorV, IsOk) = (NoError, true);
+        public OneFuzzResultVoid() => (ErrorV, IsOk) = (null, true);
 
         private OneFuzzResultVoid(ErrorCode errorCode, string[] errors) => (ErrorV, IsOk) = (new Error(errorCode, errors), false);
 

--- a/src/ApiService/ApiService/onefuzzlib/ReproOperations.cs
+++ b/src/ApiService/ApiService/onefuzzlib/ReproOperations.cs
@@ -181,11 +181,9 @@ public class ReproOperations : StatefulOrm<Repro, VmState, ReproOperations>, IRe
         if (vmData == null) {
             return await _context.ReproOperations.SetError(
                 repro,
-                OneFuzzResultVoid.Error(
+                new Error(
                     ErrorCode.VM_CREATE_FAILED,
-                    "failed before launching extensions"
-                ).ErrorV
-            );
+                    new string[] { "failed before launching extensions" }));
         }
 
         if (vmData.ProvisioningState == "Failed") {
@@ -232,10 +230,11 @@ public class ReproOperations : StatefulOrm<Repro, VmState, ReproOperations>, IRe
             .Select(status => $"{status.Code} {status.DisplayStatus} {status.Message}")
             .ToArray();
 
-        return await SetError(repro, OneFuzzResultVoid.Error(
-            ErrorCode.VM_CREATE_FAILED,
-            errors
-        ).ErrorV);
+        return await SetError(
+            repro,
+            new Error(
+                ErrorCode.VM_CREATE_FAILED,
+                errors));
     }
 
     public async Task<OneFuzzResultVoid> BuildReproScript(Repro repro) {


### PR DESCRIPTION
Closes #2805.

Also change the Result types so that this kind of mistake would be statically detected by the compiler (no other instances of the problem found at the moment, but did fix some other code to comply with static analysis changes).