### PR TITLE
Update "Needs Triage" label to the one we use.

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -23,7 +23,7 @@
           {
             "name": "addLabel",
             "parameters": {
-              "label": "Needs: Triage :mag:"
+              "label": "Needs: triage"
             }
           }
         ],


### PR DESCRIPTION
## Summary of the Pull Request
The default fabricbot needs triage label was different from what we use.