### PR TITLE
Accept optional dir of coverage test inputs

### DIFF
--- a/src/agent/coverage/examples/coverage.rs
+++ b/src/agent/coverage/examples/coverage.rs
@@ -94,8 +94,8 @@ fn main() -> Result<()> {
     } else {
         let cmd = command(&args.command, None);
         let recorded = CoverageRecorder::new(cmd)
-            .allowlist(allowlist.clone())
-            .loader(loader.clone())
+            .allowlist(allowlist)
+            .loader(loader)
             .timeout(timeout)
             .record()?;
 

--- a/src/agent/coverage/examples/coverage.rs
+++ b/src/agent/coverage/examples/coverage.rs
@@ -135,13 +135,9 @@ fn dump_stdio(recorded: &Recorded) {
     } else {
         println!("status = <unavailable>");
     }
-    println!(
-        "stderr ========================================================================="
-    );
+    println!("stderr =========================================================================");
     println!("{}", recorded.output.stderr);
-    println!(
-        "stdout ========================================================================="
-    );
+    println!("stdout =========================================================================");
     println!("{}", recorded.output.stdout);
     println!();
 }

--- a/src/agent/coverage/examples/coverage.rs
+++ b/src/agent/coverage/examples/coverage.rs
@@ -1,4 +1,5 @@
 use std::process::Command;
+use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Result;
@@ -6,7 +7,7 @@ use clap::Parser;
 use cobertura::CoberturaCoverage;
 use coverage::allowlist::{AllowList, TargetAllowList};
 use coverage::binary::BinaryCoverage;
-use coverage::record::CoverageRecorder;
+use coverage::record::{CoverageRecorder, Recorded};
 use debuggable_module::loader::Loader;
 
 #[derive(Parser, Debug)]
@@ -29,6 +30,10 @@ struct Args {
     #[arg(long)]
     dump_stdio: bool,
 
+    #[arg(short = 'd', long)]
+    input_dir: Option<String>,
+
+    #[arg(required = true, num_args = 1..)]
     command: Vec<String>,
 }
 
@@ -40,6 +45,7 @@ enum OutputFormat {
 }
 
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(5);
+const INPUT_MARKER: &str = "@@";
 
 fn main() -> Result<()> {
     let args = Args::parse();
@@ -50,11 +56,6 @@ fn main() -> Result<()> {
         .timeout
         .map(Duration::from_millis)
         .unwrap_or(DEFAULT_TIMEOUT);
-
-    let mut cmd = Command::new(&args.command[0]);
-    if args.command.len() > 1 {
-        cmd.args(&args.command[1..]);
-    }
 
     let mut allowlist = TargetAllowList::default();
 
@@ -70,37 +71,79 @@ fn main() -> Result<()> {
         allowlist.source_files = AllowList::load(path)?;
     }
 
-    let loader = Loader::new();
-    let recorded = CoverageRecorder::new(cmd)
-        .allowlist(allowlist)
-        .loader(loader)
-        .timeout(timeout)
-        .record()?;
+    let mut coverage = BinaryCoverage::default();
+    let loader = Arc::new(Loader::new());
 
-    if args.dump_stdio {
-        if let Some(status) = &recorded.output.status {
-            println!("status = {status}");
-        } else {
-            println!("status = <unavailable>");
+    if let Some(dir) = args.input_dir {
+        for input in std::fs::read_dir(dir)? {
+            let input = input?.path();
+            let cmd = command(&args.command, Some(&input.to_string_lossy()));
+
+            let recorded = CoverageRecorder::new(cmd)
+                .allowlist(allowlist.clone())
+                .loader(loader.clone())
+                .timeout(timeout)
+                .record()?;
+
+            if args.dump_stdio {
+                dump_stdio(&recorded);
+            }
+
+            coverage.merge(&recorded.coverage);
         }
-        println!(
-            "stderr ========================================================================="
-        );
-        println!("{}", recorded.output.stderr);
-        println!(
-            "stdout ========================================================================="
-        );
-        println!("{}", recorded.output.stdout);
-        println!();
+    } else {
+        let cmd = command(&args.command, None);
+        let recorded = CoverageRecorder::new(cmd)
+            .allowlist(allowlist.clone())
+            .loader(loader.clone())
+            .timeout(timeout)
+            .record()?;
+
+        if args.dump_stdio {
+            dump_stdio(&recorded);
+        }
+
+        coverage.merge(&recorded.coverage);
     }
 
     match args.output {
-        OutputFormat::ModOff => dump_modoff(&recorded.coverage)?,
-        OutputFormat::Source => dump_source_line(&recorded.coverage)?,
-        OutputFormat::Cobertura => dump_cobertura(&recorded.coverage)?,
+        OutputFormat::ModOff => dump_modoff(&coverage)?,
+        OutputFormat::Source => dump_source_line(&coverage)?,
+        OutputFormat::Cobertura => dump_cobertura(&coverage)?,
     }
 
     Ok(())
+}
+
+fn command(argv: &[String], input: Option<&str>) -> Command {
+    let mut cmd = Command::new(&argv[0]);
+
+    let args = argv.iter().skip(1);
+
+    if let Some(input) = input {
+        cmd.args(args.map(|a| a.replace(INPUT_MARKER, input)));
+    } else {
+        cmd.args(args);
+    }
+
+    cmd
+}
+
+fn dump_stdio(recorded: &Recorded) {
+    if let Some(status) = recorded.output.status {
+        println!("status = {status}");
+    } else {
+        println!("status = <unavailable>");
+    }
+    println!(
+        "stderr ========================================================================="
+    );
+    println!("{}", recorded.output.stderr);
+    println!(
+        "stdout ========================================================================="
+    );
+    println!("{}", recorded.output.stdout);
+    println!();
 }
 
 fn dump_modoff(coverage: &BinaryCoverage) -> Result<()> {


### PR DESCRIPTION
Add a new `--input-dir`/`-d` argument to the coverage recording example exe. When provided, the exe will record the combined coverage of every file found in `input_dir`, substituting the file path for the special marker `@@`. When not provided, the target command will be executed exactly as-is (the previous behavior).