### PR TITLE
Remove function allowlist

### DIFF
--- a/src/ApiService/ApiService/OneFuzzTypes/Enums.cs
+++ b/src/ApiService/ApiService/OneFuzzTypes/Enums.cs
@@ -274,7 +274,6 @@ public enum TaskFeature {
     ReportList,
     MinimizedStackDepth,
     CoverageFilter,
-    FunctionAllowlist,
     ModuleAllowlist,
     SourceAllowlist,
     TargetMustUseInput,

--- a/src/ApiService/ApiService/OneFuzzTypes/Model.cs
+++ b/src/ApiService/ApiService/OneFuzzTypes/Model.cs
@@ -213,7 +213,6 @@ public record TaskDetails(
     // Deprecated. Retained for processing old table data.
     string? CoverageFilter = null,
 
-    string? FunctionAllowlist = null,
     string? ModuleAllowlist = null,
     string? SourceAllowlist = null,
     string? TargetAssembly = null,
@@ -1002,7 +1001,6 @@ public record TaskUnitConfig(
     // Deprecated. Retained for processing old table data.
     public string? CoverageFilter { get; set; }
 
-    public string? FunctionAllowlist { get; set; }
     public string? ModuleAllowlist { get; set; }
     public string? SourceAllowlist { get; set; }
     public string? TargetAssembly { get; set; }

--- a/src/ApiService/ApiService/onefuzzlib/Config.cs
+++ b/src/ApiService/ApiService/onefuzzlib/Config.cs
@@ -262,12 +262,6 @@ public class Config : IConfig {
             }
         }
 
-        if (definition.Features.Contains(TaskFeature.FunctionAllowlist)) {
-            if (task.Config.Task.FunctionAllowlist != null) {
-                config.FunctionAllowlist = task.Config.Task.FunctionAllowlist;
-            }
-        }
-
         if (definition.Features.Contains(TaskFeature.ModuleAllowlist)) {
             if (task.Config.Task.ModuleAllowlist != null) {
                 config.ModuleAllowlist = task.Config.Task.ModuleAllowlist;

--- a/src/ApiService/ApiService/onefuzzlib/Defs.cs
+++ b/src/ApiService/ApiService/onefuzzlib/Defs.cs
@@ -15,7 +15,6 @@ public static class Defs {
                     // Deprecated. Retained for processing old table data.
                     TaskFeature.CoverageFilter,
 
-                    TaskFeature.FunctionAllowlist,
                     TaskFeature.ModuleAllowlist,
                     TaskFeature.SourceAllowlist,
                 },

--- a/src/agent/coverage/examples/coverage.rs
+++ b/src/agent/coverage/examples/coverage.rs
@@ -16,9 +16,6 @@ struct Args {
     module_allowlist: Option<String>,
 
     #[arg(long)]
-    function_allowlist: Option<String>,
-
-    #[arg(long)]
     source_allowlist: Option<String>,
 
     #[arg(short, long)]
@@ -61,10 +58,6 @@ fn main() -> Result<()> {
 
     if let Some(path) = &args.module_allowlist {
         allowlist.modules = AllowList::load(path)?;
-    }
-
-    if let Some(path) = &args.function_allowlist {
-        allowlist.functions = AllowList::load(path)?;
     }
 
     if let Some(path) = &args.source_allowlist {

--- a/src/agent/coverage/src/allowlist.rs
+++ b/src/agent/coverage/src/allowlist.rs
@@ -7,18 +7,13 @@ use std::path::Path;
 
 #[derive(Clone, Debug, Default)]
 pub struct TargetAllowList {
-    pub functions: AllowList,
     pub modules: AllowList,
     pub source_files: AllowList,
 }
 
 impl TargetAllowList {
     pub fn new(modules: AllowList, source_files: AllowList) -> Self {
-        // Allow all.
-        let functions = AllowList::default();
-
         Self {
-            functions,
             modules,
             source_files,
         }
@@ -28,7 +23,6 @@ impl TargetAllowList {
     pub fn extend(&self, other: &Self) -> Self {
         let mut new = Self::default();
 
-        new.functions = self.functions.extend(&other.functions);
         new.modules = self.modules.extend(&other.modules);
         new.source_files = self.source_files.extend(&other.source_files);
 

--- a/src/agent/coverage/src/binary.rs
+++ b/src/agent/coverage/src/binary.rs
@@ -120,10 +120,6 @@ pub fn find_coverage_sites(
     let mut offsets = BTreeSet::new();
 
     for function in debuginfo.functions() {
-        if !allowlist.functions.is_allowed(&function.name) {
-            continue;
-        }
-
         let blocks = block::sweep_region(module, &debuginfo, function.offset, function.size)?;
 
         for block in &blocks {
@@ -133,10 +129,6 @@ pub fn find_coverage_sites(
 
                     // Apply allowlists per block, to account for inlining. The `location` values
                     // here describe the top of the inline-inclusive call stack.
-                    if !allowlist.functions.is_allowed(&path) {
-                        continue;
-                    }
-
                     if !allowlist.source_files.is_allowed(&path) {
                         continue;
                     }

--- a/src/cli/onefuzz/api.py
+++ b/src/cli/onefuzz/api.py
@@ -979,7 +979,6 @@ class Tasks(Endpoint):
         colocate: bool = False,
         report_list: Optional[List[str]] = None,
         minimized_stack_depth: Optional[int] = None,
-        function_allowlist: Optional[str] = None,
         module_allowlist: Optional[str] = None,
         source_allowlist: Optional[str] = None,
     ) -> models.Task:
@@ -1057,7 +1056,6 @@ class Tasks(Endpoint):
                 report_list=report_list,
                 preserve_existing_outputs=preserve_existing_outputs,
                 minimized_stack_depth=minimized_stack_depth,
-                function_allowlist=function_allowlist,
                 module_allowlist=module_allowlist,
                 source_allowlist=source_allowlist,
             ),

--- a/src/cli/onefuzz/templates/libfuzzer.py
+++ b/src/cli/onefuzz/templates/libfuzzer.py
@@ -68,7 +68,6 @@ class Libfuzzer(Command):
         check_fuzzer_help: bool = True,
         expect_crash_on_failure: bool = False,
         minimized_stack_depth: Optional[int] = None,
-        function_allowlist: Optional[str] = None,
         module_allowlist: Optional[str] = None,
         source_allowlist: Optional[str] = None,
         analyzer_exe: Optional[str] = None,
@@ -220,7 +219,6 @@ class Libfuzzer(Command):
             debug=debug,
             colocate=colocate_all_tasks or colocate_secondary_tasks,
             check_fuzzer_help=check_fuzzer_help,
-            function_allowlist=function_allowlist,
             module_allowlist=module_allowlist,
             source_allowlist=source_allowlist,
         )
@@ -327,7 +325,6 @@ class Libfuzzer(Command):
         check_fuzzer_help: bool = True,
         expect_crash_on_failure: bool = False,
         minimized_stack_depth: Optional[int] = None,
-        function_allowlist: Optional[File] = None,
         module_allowlist: Optional[File] = None,
         source_allowlist: Optional[File] = None,
         analyzer_exe: Optional[str] = None,
@@ -402,13 +399,6 @@ class Libfuzzer(Command):
 
         target_exe_blob_name = helper.setup_relative_blob_name(target_exe, setup_dir)
 
-        if function_allowlist:
-            function_allowlist_blob_name: Optional[
-                str
-            ] = helper.setup_relative_blob_name(function_allowlist, setup_dir)
-        else:
-            function_allowlist_blob_name = None
-
         if module_allowlist:
             module_allowlist_blob_name: Optional[str] = helper.setup_relative_blob_name(
                 module_allowlist, setup_dir
@@ -445,7 +435,6 @@ class Libfuzzer(Command):
             check_fuzzer_help=check_fuzzer_help,
             expect_crash_on_failure=expect_crash_on_failure,
             minimized_stack_depth=minimized_stack_depth,
-            function_allowlist=function_allowlist_blob_name,
             module_allowlist=module_allowlist_blob_name,
             source_allowlist=source_allowlist_blob_name,
             analyzer_exe=analyzer_exe,


### PR DESCRIPTION
Remove the standalone function allowlist from both OneFuzz and the `coverage` crate. This will let us avoid either a breaking version change or having to maintain tedious back-compat code when we implement #2854.