### PR TITLE
Fix `{target_harness}` expansion in template

### DIFF
--- a/src/cli/onefuzz/templates/libfuzzer.py
+++ b/src/cli/onefuzz/templates/libfuzzer.py
@@ -624,7 +624,7 @@ class Libfuzzer(Command):
         if target_options is None:
             target_options = []
         target_options = [
-            "--target_path={setup_dir}/" + "{target_harness}"
+            "--target_path={setup_dir}/" + f"{target_harness}"
         ] + target_options
 
         helper = JobHelper(


### PR DESCRIPTION
This seems to have been inadvertently broken by 41f973184ec7653c7048872362e47e2ca9999f89.

The missing variable expansion was exposed by #2789, so tasks using `{target_harness}` (which is not a valid expansion) fail.

