### PR TITLE
Update the error truncating logic to retrieve the last messages

### DIFF
--- a/src/ApiService/ApiService/Functions/AgentEvents.cs
+++ b/src/ApiService/ApiService/Functions/AgentEvents.cs
@@ -309,6 +309,6 @@ public class AgentEvents {
             return str;
         }
 
-        return str[..MAX_OUTPUT_SIZE];
+        return str[(str.Length - MAX_OUTPUT_SIZE) ..];
     }
 }

--- a/src/ApiService/ApiService/Functions/AgentEvents.cs
+++ b/src/ApiService/ApiService/Functions/AgentEvents.cs
@@ -309,6 +309,6 @@ public class AgentEvents {
             return str;
         }
 
-        return str[(str.Length - MAX_OUTPUT_SIZE) ..];
+        return str[(str.Length - MAX_OUTPUT_SIZE)..];
     }
 }


### PR DESCRIPTION
Update the error truncating logic to retrieve the last messages.
This makes it easier to identify the cause of the failure of a task