### PR TITLE
Port 'missing field' error fix to C#

### DIFF
--- a/src/ApiService/ApiService/OneFuzzTypes/Model.cs
+++ b/src/ApiService/ApiService/OneFuzzTypes/Model.cs
@@ -1002,7 +1002,6 @@ public record TaskUnitConfig(
     // Deprecated. Retained for processing old table data.
     public string? CoverageFilter { get; set; }
 
-
     public bool? PreserveExistingOutputs { get; set; }
     public string? ModuleAllowlist { get; set; }
     public string? SourceAllowlist { get; set; }

--- a/src/ApiService/ApiService/OneFuzzTypes/Model.cs
+++ b/src/ApiService/ApiService/OneFuzzTypes/Model.cs
@@ -1002,6 +1002,8 @@ public record TaskUnitConfig(
     // Deprecated. Retained for processing old table data.
     public string? CoverageFilter { get; set; }
 
+
+    public bool? PreserveExistingOutputs { get; set; }
     public string? ModuleAllowlist { get; set; }
     public string? SourceAllowlist { get; set; }
     public string? TargetAssembly { get; set; }

--- a/src/ApiService/ApiService/onefuzzlib/Config.cs
+++ b/src/ApiService/ApiService/onefuzzlib/Config.cs
@@ -248,7 +248,7 @@ public class Config : IConfig {
         }
 
         if (definition.Features.Contains(TaskFeature.PreserveExistingOutputs)) {
-            config.PreserveExistingOutputs = task.Config.Task.PreserveExistingOutputs;
+            config.PreserveExistingOutputs = task.Config.Task.PreserveExistingOutputs ?? false;
         }
 
         if (definition.Features.Contains(TaskFeature.ReportList)) {

--- a/src/ApiService/ApiService/onefuzzlib/Config.cs
+++ b/src/ApiService/ApiService/onefuzzlib/Config.cs
@@ -247,6 +247,10 @@ public class Config : IConfig {
             config.CheckFuzzerHelp = task.Config.Task.CheckFuzzerHelp ?? true;
         }
 
+        if (definition.Features.Contains(TaskFeature.PreserveExistingOutputs)) {
+            config.PreserveExistingOutputs = task.Config.Task.PreserveExistingOutputs;
+        }
+
         if (definition.Features.Contains(TaskFeature.ReportList)) {
             config.ReportList = task.Config.Task.ReportList;
         }

--- a/src/ApiService/ApiService/onefuzzlib/Defs.cs
+++ b/src/ApiService/ApiService/onefuzzlib/Defs.cs
@@ -405,6 +405,7 @@ public static class Defs {
         TaskFeature.TargetEnv,
         TaskFeature.TargetOptions,
         TaskFeature.CheckFuzzerHelp,
+        TaskFeature.PreserveExistingOutputs,
      },
      Vm: new VmDefinition(Compare: Compare.Equal, Value: 1),
      Containers: new[] {


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_
A 'missing field' error affecting libfuzzer was previously addressed in #1739. This fix addressed #1672. 

This PR ports the fix to the C# code. 

## PR Checklist
* [ ] Applies to work item: #1672
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/onefuzz) and sign the CLI.
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_

## Validation Steps Performed

_How does someone test & validate?_
