### PR TITLE
Add additional filter check for reports and regressions

### DIFF
--- a/src/ApiService/ApiService/onefuzzlib/Reports.cs
+++ b/src/ApiService/ApiService/onefuzzlib/Reports.cs
@@ -28,7 +28,7 @@ public class Reports : IReports {
 
     public async Async.Task<IReport?> GetReportOrRegression(Container container, string fileName, bool expectReports = false, params string[] args) {
         var filePath = string.Join("/", new[] { container.String, fileName });
-        if (!fileName.EndsWith(".json", StringComparison.Ordinal) || fileName.Contains("source-coverage", StringComparison.Ordinal)) {
+        if (!fileName.EndsWith(".json", StringComparison.Ordinal) || fileName.Contains("source-coverage", StringComparison.InvariantCultureIgnoreCase)) {
             if (expectReports) {
                 _log.Error($"get_report invalid extension or filename: {filePath:Tag:FilePath}");
             }

--- a/src/ApiService/ApiService/onefuzzlib/Reports.cs
+++ b/src/ApiService/ApiService/onefuzzlib/Reports.cs
@@ -28,9 +28,9 @@ public class Reports : IReports {
 
     public async Async.Task<IReport?> GetReportOrRegression(Container container, string fileName, bool expectReports = false, params string[] args) {
         var filePath = string.Join("/", new[] { container.String, fileName });
-        if (!fileName.EndsWith(".json", StringComparison.Ordinal)) {
+        if (!fileName.EndsWith(".json", StringComparison.Ordinal) || fileName.Contains("source-coverage", StringComparison.Ordinal)) {
             if (expectReports) {
-                _log.Error($"get_report invalid extension: {filePath:Tag:FilePath}");
+                _log.Error($"get_report invalid extension or filename: {filePath:Tag:FilePath}");
             }
             return null;
         }


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_
Add additional filter condition to catch `source-coverage.json` files. 

## PR Checklist
* [ ] Applies to work item: #xxx
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/onefuzz) and sign the CLI.
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_

## Validation Steps Performed

_How does someone test & validate?_
