### PR TITLE
Build fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -351,7 +351,10 @@ jobs:
       - uses: actions/checkout@v3
       - uses: azure/CLI@v1
         with:
-          inlineScript: az bicep build --file src/deployment/azuredeploy.bicep --stdout > /dev/null
+          inlineScript: |
+           az config set bicep.use_binary_from_path=false
+           az bicep install
+           az bicep build --file src/deployment/azuredeploy.bicep --stdout > /dev/null
   dotnet-fuzzing-tools-linux:
     runs-on: ubuntu-20.04
     steps:

--- a/src/ci/get-version.sh
+++ b/src/ci/get-version.sh
@@ -12,17 +12,17 @@ GIT_HASH=$(git rev-parse HEAD)
 
 if [ "${GITHUB_REF}" != "" ]; then
     TAG_VERSION=${GITHUB_REF#refs/tags/}
-    
+
     # this isn't a tag
     if [ ${TAG_VERSION} == ${GITHUB_REF} ]; then
-        echo ${BASE_VERSION}-${GIT_HASH}
+        echo ${BASE_VERSION}+${GIT_HASH}
     else
         echo ${BASE_VERSION}
-    fi    
+    fi
 else
     if $(git diff --quiet); then
-        echo ${BASE_VERSION}-${GIT_HASH}
+        echo ${BASE_VERSION}+${GIT_HASH}
     else
-        echo ${BASE_VERSION}-${GIT_HASH}localchanges
-    fi 
+        echo ${BASE_VERSION}+${GIT_HASH}localchanges
+    fi
 fi


### PR DESCRIPTION


### bicep validation fix
The bicep validation tool has a [bug](https://github.com/Azure/azure-cli/issues/25710) that breaks our build. This pr implement one of the mitigation (suggested)[https://github.com/Azure/azure-cli/issues/25710#issuecomment-1464673546]

### update the local version scheme
The latest version of the setup tools has dropped support for [non-conformant versions](https://github.com/pypa/setuptools/issues/3772#issuecomment-1384342813) numbers. This was causing a build break because our local version scheme `<onefuzzversion>-<git id>` was not a valid [pep 440](https://peps.python.org/pep-0440/) version. This PR replaces the version scheme with `<onefuzzversion>+<git id>` (using '+' as the separator)


