### PR TITLE
fix CVE-2023-0286

### DIFF
--- a/src/ApiService/ApiService/onefuzzlib/NodeOperations.cs
+++ b/src/ApiService/ApiService/onefuzzlib/NodeOperations.cs
@@ -463,7 +463,7 @@ public class NodeOperations : StatefulOrm<Node, NodeState, NodeOperations>, INod
 
 
     public async Async.Task SendStopIfFree(Node node) {
-        var ver = new Version(_context.ServiceConfiguration.OneFuzzVersion.Split('-')[0]);
+        var ver = new Version(_context.ServiceConfiguration.OneFuzzVersion.Split('-', '+')[0]);
         if (ver >= Version.Parse("2.16.1")) {
             await SendMessage(node, new NodeCommand(StopIfFree: new NodeCommandStopIfFree()));
         }

--- a/src/cli/requirements.txt
+++ b/src/cli/requirements.txt
@@ -12,16 +12,7 @@ azure-applicationinsights==0.1.0
 tenacity==8.0.1
 docstring_parser==0.8.1
 azure-identity==1.10.0
-azure-cli-core==2.43.0
-# packaging is required but not specified by azure-cli-core
-packaging==21.3
-# urllib3[secure] needs to be specifically stated for azure-cli-core
-urllib3[secure]>=1.26.8
-# iDNA needs to be specifically stated for azure-cli-core
-idna<3,>=2.10
-# cryptography needs to be pinned to the version used by azure-cli-core
-cryptography<3.4,>=3.3.2
-# PyJWT needs to be pinned to the version used by azure-cli-core
+azure-cli-core==2.46.0
 PyJWT>=2.4.0
 # install rsa version >=4.7 to fix CVE-2020-25658
 rsa>=4.7

--- a/src/deployment/requirements.txt
+++ b/src/deployment/requirements.txt
@@ -1,5 +1,5 @@
-azure-cli-core==2.43.0
-azure-cli==2.43.0
+azure-cli-core==2.46.0
+azure-cli==2.46.0
 azure-identity==1.10.0
 azure-cosmosdb-table==1.0.6
 azure-mgmt-eventgrid==10.2.0b2

--- a/src/utils/add-corpus-storage-accounts/requirements.txt
+++ b/src/utils/add-corpus-storage-accounts/requirements.txt
@@ -1,3 +1,3 @@
 azure-mgmt-storage~=19.0.0
-azure-cli-core==2.43.0
+azure-cli-core==2.46.0
 azure-mgmt-eventgrid==3.0.0rc9

--- a/src/utils/check-pr/requirements.txt
+++ b/src/utils/check-pr/requirements.txt
@@ -1,5 +1,5 @@
 azure-common~=1.1.25
 azure-identity==1.10.0
 PyGithub==1.56
-azure-cli-core==2.43.0
+azure-cli-core==2.46.0
 msgraph-core==0.2.2


### PR DESCRIPTION
removing dependency on cryptography==3.3.2

closes #2932