### PR TITLE
Remove xml-rs dependency

### DIFF
--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -121,12 +121,12 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "azure_core"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8904f5c2ee4f5a172542700a42708706ef8591a16a5c6226bcf6b7f21ead9a6"
+checksum = "32568c56fda7f2f1173430298bddeb507ed44e99bd989ba1156a25534bff5d98"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.21.0",
  "bytes",
  "dyn-clone",
  "futures",
@@ -135,11 +135,11 @@ dependencies = [
  "log",
  "paste",
  "pin-project",
+ "quick-xml",
  "rand 0.8.4",
  "reqwest",
  "rustc_version",
  "serde",
- "serde-xml-rs",
  "serde_json",
  "time",
  "url",
@@ -148,21 +148,19 @@ dependencies = [
 
 [[package]]
 name = "azure_storage"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b5940f60d0cdfe6312e9feb6528c975ba9de061026843b0ded723585b540338"
+checksum = "29747ca7da0f81ea199d1c957bae737bc5bc54502e0f7c00ca7be1894306944a"
 dependencies = [
  "RustyXML",
  "async-trait",
  "azure_core",
- "base64",
  "bytes",
  "futures",
  "hmac",
  "log",
  "once_cell",
  "serde",
- "serde-xml-rs",
  "serde_derive",
  "serde_json",
  "sha2",
@@ -173,20 +171,18 @@ dependencies = [
 
 [[package]]
 name = "azure_storage_blobs"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf7e8d719a89c6079ba6298fc3969acf53a24d590e1f5c1faab6f732e3ddf56b"
+checksum = "b56de7a67648a7a434db81f11264df2a07e33468e751da379bddbfd7c25d5117"
 dependencies = [
  "RustyXML",
  "azure_core",
  "azure_storage",
- "base64",
  "bytes",
  "futures",
  "log",
  "md5",
  "serde",
- "serde-xml-rs",
  "serde_derive",
  "serde_json",
  "time",
@@ -228,6 +224,12 @@ name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
+name = "base64"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
 name = "binary-merge"
@@ -1244,7 +1246,7 @@ checksum = "6e9b187a72d63adbfba487f48095306ac823049cb504ee195541e91c7775f5ad"
 dependencies = [
  "anyhow",
  "async-channel",
- "base64",
+ "base64 0.13.0",
  "futures-lite",
  "http",
  "infer",
@@ -1925,7 +1927,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "backoff",
- "base64",
+ "base64 0.13.0",
  "bytes",
  "clap",
  "cpp_demangle",
@@ -2045,7 +2047,6 @@ dependencies = [
  "reqwest",
  "reqwest-retry",
  "serde",
- "serde-xml-rs",
  "serde_json",
  "stacktrace-parser",
  "storage-queue",
@@ -2451,11 +2452,12 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.27.1"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffc053f057dd768a56f62cd7e434c42c831d296968997e9ac1f76ea7c2d14c41"
+checksum = "e5c1a97b1bc42b1d550bfb48d4262153fe400a12bab1511821736f7eac76d7e2"
 dependencies = [
  "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -2637,7 +2639,7 @@ version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87f242f1488a539a79bac6dbe7c8609ae43b7914b7736210f239a37cccb32525"
 dependencies = [
- "base64",
+ "base64 0.13.0",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -2823,18 +2825,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
 dependencies = [
  "serde_derive",
-]
-
-[[package]]
-name = "serde-xml-rs"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb3aa78ecda1ebc9ec9847d5d3aba7d618823446a049ba2491940506da6e2782"
-dependencies = [
- "log",
- "serde",
- "thiserror",
- "xml-rs",
 ]
 
 [[package]]
@@ -3057,18 +3047,18 @@ dependencies = [
  "anyhow",
  "async-trait",
  "backoff",
- "base64",
+ "base64 0.13.0",
  "bincode",
  "bytes",
  "derivative",
  "flume",
  "num_cpus",
  "queue-file",
+ "quick-xml",
  "regex",
  "reqwest",
  "reqwest-retry",
  "serde",
- "serde-xml-rs",
  "serde_derive",
  "serde_json",
  "tokio",
@@ -3971,12 +3961,6 @@ checksum = "30b31594f29d27036c383b53b59ed3476874d518f0efb151b27a4c275141390e"
 dependencies = [
  "tap",
 ]
-
-[[package]]
-name = "xml-rs"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
 
 [[package]]
 name = "yansi"

--- a/src/agent/cobertura/Cargo.toml
+++ b/src/agent/cobertura/Cargo.toml
@@ -6,4 +6,4 @@ license = "MIT"
 
 [dependencies]
 anyhow = "1.0"
-quick-xml = "0.27.1"
+quick-xml = "0.28"

--- a/src/agent/onefuzz-file-format/Cargo.toml
+++ b/src/agent/onefuzz-file-format/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 anyhow = "1.0"
 coverage = { path = "../coverage" }
 debuggable-module = { path = "../debuggable-module" }
-quick-xml = "0.27.1"
+quick-xml = "0.28"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 

--- a/src/agent/onefuzz-task/Cargo.toml
+++ b/src/agent/onefuzz-task/Cargo.toml
@@ -35,7 +35,6 @@ reqwest = { version = "0.11", features = [
 ], default-features = false }
 serde = "1.0"
 serde_json = "1.0"
-serde-xml-rs = "0.6"
 onefuzz = { path = "../onefuzz" }
 onefuzz-telemetry = { path = "../onefuzz-telemetry" }
 path-absolutize = "3.0"
@@ -58,13 +57,13 @@ chrono = { version = "0.4", default-features = false, features = [
 ] }
 ipc-channel = { git = "https://github.com/servo/ipc-channel", rev = "7f432aa" }
 
-azure_core = { version = "0.10", default-features = false, features = [
+azure_core = { version = "0.11", default-features = false, features = [
     "enable_reqwest",
 ] }
-azure_storage = { version = "0.10", default-features = false, features = [
+azure_storage = { version = "0.11", default-features = false, features = [
     "enable_reqwest",
 ] }
-azure_storage_blobs = { version = "0.10", default-features = false, features = [
+azure_storage_blobs = { version = "0.11", default-features = false, features = [
     "enable_reqwest",
 ] }
 

--- a/src/agent/srcview/Cargo.toml
+++ b/src/agent/srcview/Cargo.toml
@@ -15,7 +15,7 @@ nom = "7"
 pdb = "0.8"
 regex = "1"
 serde = { version = "1", features = ["derive"] }
-quick-xml = "0.27"
+quick-xml = "0.28"
 anyhow = "1.0"
 env_logger = "0.10"
 clap = { version = "4.1.6", features = ["derive"] }

--- a/src/agent/storage-queue/Cargo.toml
+++ b/src/agent/storage-queue/Cargo.toml
@@ -14,14 +14,18 @@ bytes = { version = "1.2", features = ["serde"] }
 derivative = "2.2"
 flume = "0.10"
 num_cpus = "1.15"
+quick-xml = { version = "0.28", features = ["serialize", "serde-types"] }
 regex = "1.7.1"
-reqwest = { version = "0.11", features = ["json", "stream", "native-tls-vendored"], default-features=false }
+reqwest = { version = "0.11", features = [
+    "json",
+    "stream",
+    "native-tls-vendored",
+], default-features = false }
 reqwest-retry = { path = "../reqwest-retry" }
-serde = { version = "1.0", features = ["derive"]}
+serde = { version = "1.0", features = ["derive"] }
 serde_derive = "1.0"
 serde_json = "1.0"
-serde-xml-rs = "0.6"
 bincode = "1.3"
-tokio = { version = "1.24" , features=["full"] }
+tokio = { version = "1.24", features = ["full"] }
 queue-file = "1.4"
 uuid = { version = "0.8", features = ["serde", "v4"] }

--- a/src/agent/storage-queue/src/local_queue.rs
+++ b/src/agent/storage-queue/src/local_queue.rs
@@ -62,15 +62,15 @@ impl FileQueueClient {
 
     pub async fn enqueue(&self, data: impl Serialize) -> Result<()> {
         let send_data = || async {
-            let mut buffer = Vec::new();
-            serde_xml_rs::to_writer(&mut buffer, &data)
+            let mut buffer = String::new();
+            quick_xml::se::to_writer(&mut buffer, &data)
                 .map_err(|_| anyhow::anyhow!("unable to deserialize"))?;
             let mut locked_q = self
                 .queue
                 .lock()
                 .map_err(|_| anyhow::anyhow!("unable to acquire lock"))?;
             locked_q
-                .add(buffer.as_slice())
+                .add(buffer.as_bytes())
                 .map_err(|_| anyhow::anyhow!("unable to queue message"))?;
             Ok(())
         };

--- a/src/deny.toml
+++ b/src/deny.toml
@@ -15,7 +15,6 @@ unmaintained = "deny"
 unsound = "deny"
 yanked = "deny"
 ignore = [
-    "RUSTSEC-2022-0048", # xml-rs is unmaintained
     "RUSTSEC-2023-0018",
     "RUSTSEC-2020-0016", # There is a PR currently open to stop using the unmaintained crate: https://github.com/servo/ipc-channel/pull/302
 ]

--- a/src/proxy-manager/Cargo.lock
+++ b/src/proxy-manager/Cargo.lock
@@ -931,6 +931,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5c1a97b1bc42b1d550bfb48d4262153fe400a12bab1511821736f7eac76d7e2"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "quote"
 version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -999,9 +1009,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
+checksum = "cce168fea28d3e05f158bda4576cf0c844d5045bc2cc3620fa0292ed5bb5814c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1010,9 +1020,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.27"
+version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "remove_dir_all"
@@ -1139,18 +1149,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
 dependencies = [
  "serde_derive",
-]
-
-[[package]]
-name = "serde-xml-rs"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb3aa78ecda1ebc9ec9847d5d3aba7d618823446a049ba2491940506da6e2782"
-dependencies = [
- "log",
- "serde",
- "thiserror",
- "xml-rs",
 ]
 
 [[package]]
@@ -1283,11 +1281,11 @@ dependencies = [
  "flume",
  "num_cpus",
  "queue-file",
+ "quick-xml",
  "regex",
  "reqwest",
  "reqwest-retry",
  "serde",
- "serde-xml-rs",
  "serde_derive",
  "serde_json",
  "tokio",
@@ -1794,9 +1792,3 @@ checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
 ]
-
-[[package]]
-name = "xml-rs"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"


### PR DESCRIPTION
Update the Azure crates and switch from `serde-xml-rs` to `quick-xml`, which removes a warning suppression from `deny.toml`.