### PR TITLE
Install v17 redistributables

### DIFF
--- a/src/runtime-tools/win64/onefuzz.ps1
+++ b/src/runtime-tools/win64/onefuzz.ps1
@@ -165,8 +165,8 @@ function Set-Restart {
 
 function Install-VCRedist {
   log "installing VC Redist"
-  $x64Release = 'https://aka.ms/vs/15/release/VC_redist.x64.exe'
-  $x86Release = 'https://aka.ms/vs/15/release/VC_redist.x86.exe'
+  $x64Release = 'https://aka.ms/vs/17/release/VC_redist.x64.exe'
+  $x86Release = 'https://aka.ms/vs/17/release/VC_redist.x86.exe'
   $ProgressPreference = 'SilentlyContinue'
   Invoke-WebRequest -Uri $x64Release -OutFile "C:\onefuzz\vcredist_x64.exe"
   Invoke-WebRequest -Uri $x86Release -OutFile "C:\onefuzz\vcredist_x86.exe"


### PR DESCRIPTION
The latest VC redistributables [support VS2015 through VS2022](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170#visual-studio-2015-2017-2019-and-2022), so we only need to install one version.

