### PR TITLE
Add option to specify a  known crash container

### DIFF
--- a/src/cli/onefuzz/templates/libfuzzer.py
+++ b/src/cli/onefuzz/templates/libfuzzer.py
@@ -357,7 +357,7 @@ class Libfuzzer(Command):
         analyzer_env: Optional[Dict[str, str]] = None,
         tools: Optional[Container] = None,
         extra_container: Optional[Container] = None,
-        crashes: Optional[Directory] = None,
+        crashes: Optional[Container] = None,
     ) -> Optional[Job]:
         """
         Basic libfuzzer job
@@ -372,6 +372,9 @@ class Libfuzzer(Command):
 
         if readonly_inputs:
             self.onefuzz.containers.get(readonly_inputs)
+
+        if crashes:
+            self.onefuzz.containers.get(crashes)
 
         if dryrun:
             return None
@@ -412,6 +415,9 @@ class Libfuzzer(Command):
 
         if readonly_inputs:
             helper.containers[ContainerType.readonly_inputs] = readonly_inputs
+
+        if crashes:
+            helper.containers[ContainerType.crashes] = crashes
 
         if analyzer_exe is not None:
             helper.define_containers(ContainerType.analysis)
@@ -643,7 +649,7 @@ class Libfuzzer(Command):
         expect_crash_on_failure: bool = False,
         notification_config: Optional[NotificationConfig] = None,
         extra_container: Optional[Container] = None,
-        crashes: Optional[Directory] = None,
+        crashes: Optional[Container] = None,
     ) -> Optional[Job]:
         pool = self.onefuzz.pools.get(pool_name)
 
@@ -653,6 +659,9 @@ class Libfuzzer(Command):
 
         if readonly_inputs:
             self.onefuzz.containers.get(readonly_inputs)
+
+        if crashes:
+            self.onefuzz.containers.get(crashes)
 
         # We _must_ proactively specify the OS based on pool.
         #
@@ -706,6 +715,9 @@ class Libfuzzer(Command):
 
         if readonly_inputs:
             helper.containers[ContainerType.readonly_inputs] = readonly_inputs
+
+        if crashes:
+            helper.containers[ContainerType.crashes] = crashes
 
         # Assumes that `libfuzzer-dotnet` and supporting tools were uploaded upon deployment.
         fuzzer_tools_container = Container(
@@ -871,7 +883,7 @@ class Libfuzzer(Command):
         check_retry_count: Optional[int] = 300,
         check_fuzzer_help: bool = True,
         extra_container: Optional[Container] = None,
-        crashes: Optional[Directory] = None,
+        crashes: Optional[Container] = None,
     ) -> Optional[Job]:
         """
         libfuzzer tasks, wrapped via qemu-user (PREVIEW FEATURE)
@@ -923,6 +935,10 @@ class Libfuzzer(Command):
             helper.containers[ContainerType.inputs] = existing_inputs
         else:
             helper.define_containers(ContainerType.inputs)
+
+        if crashes:
+            self.onefuzz.containers.get(crashes)
+            helper.containers[ContainerType.crashes] = crashes
 
         fuzzer_containers = [
             (ContainerType.setup, helper.containers[ContainerType.setup]),

--- a/src/cli/onefuzz/templates/libfuzzer.py
+++ b/src/cli/onefuzz/templates/libfuzzer.py
@@ -425,13 +425,6 @@ class Libfuzzer(Command):
         helper.create_containers()
         helper.setup_notifications(notification_config)
 
-        if crashes:
-            self.logger.info("uploading crash directory")
-            self.onefuzz.containers.files.upload_dir(
-                helper.containers[ContainerType.crashes], crashes
-            )
-            self.logger.info("uploading crash directory complete")
-
         helper.upload_setup(setup_dir, target_exe, extra_files)
         if inputs:
             helper.upload_inputs(inputs)
@@ -737,13 +730,6 @@ class Libfuzzer(Command):
         helper.create_containers()
         helper.setup_notifications(notification_config)
 
-        if crashes:
-            self.logger.info("uploading crash directory")
-            self.onefuzz.containers.files.upload_dir(
-                helper.containers[ContainerType.crashes], crashes
-            )
-            self.logger.info("uploading crash directory complete")
-
         helper.upload_setup(setup_dir, target_dll)
 
         if inputs:
@@ -950,13 +936,6 @@ class Libfuzzer(Command):
             fuzzer_containers.append((ContainerType.extra, extra_container))
 
         helper.create_containers()
-
-        if crashes:
-            self.logger.info("uploading crash directory")
-            self.onefuzz.containers.files.upload_dir(
-                helper.containers[ContainerType.crashes], crashes
-            )
-            self.logger.info("uploading crash directory complete")
 
         target_exe_blob_name = helper.setup_relative_blob_name(target_exe, None)
 

--- a/src/cli/onefuzz/templates/libfuzzer.py
+++ b/src/cli/onefuzz/templates/libfuzzer.py
@@ -357,6 +357,7 @@ class Libfuzzer(Command):
         analyzer_env: Optional[Dict[str, str]] = None,
         tools: Optional[Container] = None,
         extra_container: Optional[Container] = None,
+        crashes: Optional[Directory] = None,
     ) -> Optional[Job]:
         """
         Basic libfuzzer job
@@ -417,6 +418,13 @@ class Libfuzzer(Command):
 
         helper.create_containers()
         helper.setup_notifications(notification_config)
+
+        if crashes:
+            self.logger.info("uploading crash directory")
+            self.onefuzz.containers.files.upload_dir(
+                helper.containers[ContainerType.crashes], crashes
+            )
+            self.logger.info("uploading crash directory complete")
 
         helper.upload_setup(setup_dir, target_exe, extra_files)
         if inputs:
@@ -635,6 +643,7 @@ class Libfuzzer(Command):
         expect_crash_on_failure: bool = False,
         notification_config: Optional[NotificationConfig] = None,
         extra_container: Optional[Container] = None,
+        crashes: Optional[Directory] = None,
     ) -> Optional[Job]:
         pool = self.onefuzz.pools.get(pool_name)
 
@@ -715,6 +724,13 @@ class Libfuzzer(Command):
 
         helper.create_containers()
         helper.setup_notifications(notification_config)
+
+        if crashes:
+            self.logger.info("uploading crash directory")
+            self.onefuzz.containers.files.upload_dir(
+                helper.containers[ContainerType.crashes], crashes
+            )
+            self.logger.info("uploading crash directory complete")
 
         helper.upload_setup(setup_dir, target_dll)
 
@@ -855,6 +871,7 @@ class Libfuzzer(Command):
         check_retry_count: Optional[int] = 300,
         check_fuzzer_help: bool = True,
         extra_container: Optional[Container] = None,
+        crashes: Optional[Directory] = None,
     ) -> Optional[Job]:
         """
         libfuzzer tasks, wrapped via qemu-user (PREVIEW FEATURE)
@@ -917,6 +934,13 @@ class Libfuzzer(Command):
             fuzzer_containers.append((ContainerType.extra, extra_container))
 
         helper.create_containers()
+
+        if crashes:
+            self.logger.info("uploading crash directory")
+            self.onefuzz.containers.files.upload_dir(
+                helper.containers[ContainerType.crashes], crashes
+            )
+            self.logger.info("uploading crash directory complete")
 
         target_exe_blob_name = helper.setup_relative_blob_name(target_exe, None)
 


### PR DESCRIPTION
## Summary of the Pull Request

Update the libfuzzer templates to add option to specify a known crash container.
This is useful when the user wants to include some known crashes to the job submission.

