### PR TITLE
Rename EventGrid subscription

### DIFF
--- a/src/deployment/bicep-templates/event-grid.bicep
+++ b/src/deployment/bicep-templates/event-grid.bicep
@@ -16,7 +16,7 @@ resource eventGridSystemTopics 'Microsoft.EventGrid/systemTopics@2021-12-01' = {
 }
 
 resource eventSubscriptions 'Microsoft.EventGrid/systemTopics/eventSubscriptions@2021-12-01' = {
-  name: 'onefuzz1_subscription'
+  name: 'onefuzz1-subscription'
   parent: eventGridSystemTopics
   properties: {
     destination: {

--- a/src/deployment/deploy.py
+++ b/src/deployment/deploy.py
@@ -877,16 +877,18 @@ class Client:
         )
 
         # Event subscription for version up to 5.1.0
-        old_subscription_name = "onefuzz1"
-        old_subscription_exists = Client.event_subscription_exists(
-            event_grid_client, src_resource_id, old_subscription_name
-        )
+        # or 7.1.0
+        old_subscription_names = ["onefuzz1", "onefuzz1_subscription"]
+        for old_subscription_name in old_subscription_names:
+            old_subscription_exists = Client.event_subscription_exists(
+                event_grid_client, src_resource_id, old_subscription_name
+            )
 
-        if old_subscription_exists:
-            logger.info("removing deprecated event subscription")
-            event_grid_client.event_subscriptions.begin_delete(
-                src_resource_id, old_subscription_name
-            ).wait()
+            if old_subscription_exists:
+                logger.info("removing deprecated event subscription")
+                event_grid_client.event_subscriptions.begin_delete(
+                    src_resource_id, old_subscription_name
+                ).wait()
 
     def add_instance_id(self) -> None:
         logger.info("setting instance_id log export")

--- a/src/utils/add-corpus-storage-accounts/add-corpus-storage-account.py
+++ b/src/utils/add-corpus-storage-accounts/add-corpus-storage-account.py
@@ -31,7 +31,7 @@ def get_base_event(
         resource_group, location
     ):
         if (
-            entry.name == "onefuzz1_subscription"
+            entry.name == "onefuzz1-subscription"
             and entry.type == "Microsoft.EventGrid/eventSubscriptions"
             and entry.event_delivery_schema == "EventGridSchema"
             and entry.destination.endpoint_type == "StorageQueue"


### PR DESCRIPTION


The EventGrid subscription name is invalid according to the published schema. Rename it, and add a deployment step to delete any old instances of this subscription.