### PR TITLE
Use minimized stack for crash site if no ASAN logs available

### DIFF
--- a/src/ApiService/ApiService/onefuzzlib/notifications/NotificationsBase.cs
+++ b/src/ApiService/ApiService/onefuzzlib/notifications/NotificationsBase.cs
@@ -138,7 +138,7 @@ public abstract class NotificationsBase {
                 true => new TemplateContext {
                     EnableRelaxedFunctionAccess = false,
                     EnableRelaxedIndexerAccess = false,
-                    EnableRelaxedMemberAccess = false,
+                    EnableRelaxedMemberAccess = true,
                     EnableRelaxedTargetAccess = false
                 },
                 _ => new TemplateContext()

--- a/src/ApiService/IntegrationTests/JinjaToScribanMigrationTests.cs
+++ b/src/ApiService/IntegrationTests/JinjaToScribanMigrationTests.cs
@@ -362,6 +362,12 @@ public abstract class JinjaToScribanMigrationTestBase : FunctionTestBase {
         result.StatusCode.Should().Be(System.Net.HttpStatusCode.BadRequest);
     }
 
+    [Fact]
+    public async Async.Task Do_Not_Enforce_Key_Exists_In_Strict_Validation() {
+        (await JinjaTemplateAdapter.IsValidScribanNotificationTemplate(Context, Logger, ValidScribanAdoTemplate()))
+            .Should().BeTrue();
+    }
+
     private async Async.Task ConfigureAuth() {
         await Context.InsertAll(
             new InstanceConfig(Context.ServiceConfiguration.OneFuzzInstanceName!) { Admins = new[] { _userObjectId } } // needed for admin check
@@ -411,5 +417,20 @@ public abstract class JinjaToScribanMigrationTestBase : FunctionTestBase {
 
     private static TeamsTemplate GetTeamsTemplate() {
         return new TeamsTemplate(new SecretData<string>(new SecretValue<string>("https://example.com")));
+    }
+
+    private static AdoTemplate ValidScribanAdoTemplate() {
+        return new AdoTemplate(
+            new Uri("http://example.com"),
+            new SecretData<string>(new SecretValue<string>("some secret")),
+            "{{ if task.tags.project }} blah {{ end }}",
+            string.Empty,
+            Array.Empty<string>().ToList(),
+            new Dictionary<string, string>(),
+            new ADODuplicateTemplate(
+                Array.Empty<string>().ToList(),
+                new Dictionary<string, string>(),
+                new Dictionary<string, string>()
+        ));
     }
 }

--- a/src/agent/onefuzz-task/src/tasks/report/dotnet/generic.rs
+++ b/src/agent/onefuzz-task/src/tasks/report/dotnet/generic.rs
@@ -208,7 +208,7 @@ impl AsanProcessor {
                     input_blob,
                     executable,
                     crash_type: exception.exception,
-                    crash_site: exception.call_stack[0].clone(),
+                    crash_site: exception.call_stack.first().cloned().unwrap_or_default(),
                     call_stack: exception.call_stack,
                     call_stack_sha256,
                     minimized_stack: None,


### PR DESCRIPTION
Closes #841. 

If all we have is a call stack, use the top of the "minimized stack" as the crash site, not the top of the full stack.

This only happens if we don't have ASAN logs available for the crash.