### PR TITLE
.NET configuration for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,7 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-patch"]
+  - package-ecosystem: nuget
+    directory: "/src/ApiService"
+    schedule:
+      interval: daily


### PR DESCRIPTION
Allow Dependabot to send PRs for .NET version upgrades.