### PR TITLE
UniqueReports should be UniqueInputs in LibFuzzer merge task

### DIFF
--- a/src/ApiService/ApiService/onefuzzlib/Defs.cs
+++ b/src/ApiService/ApiService/onefuzzlib/Defs.cs
@@ -416,7 +416,7 @@ public static class Defs {
             Permissions: ContainerPermission.Read | ContainerPermission.List
         ),
         new ContainerDefinition(
-            Type:ContainerType.UniqueReports,
+            Type:ContainerType.UniqueInputs,
             Compare: Compare.Equal,
             Value:1,
             Permissions:


### PR DESCRIPTION
Fixes #2955.

Confirmed that [the Python version had `unique_inputs` here](https://github.com/microsoft/onefuzz/blob/d79e6d9864f0911b8709c52bf21b957a2ba98a48/src/api-service/__app__/onefuzzlib/tasks/defs.py#L343-L352) so this is a bug introduced during the port.