### PR TITLE
Bump Rust dependency crossbeam-channel to 0.5.8

### DIFF
--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -515,9 +515,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.1"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
+checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",


### PR DESCRIPTION
## Summary of the Pull Request

Current version was yanked, bumping `crossbeam-channel` to the latest version 0.5.8

## PR Checklist
* [ ] Tests passed

## Info on Pull Request

updated:
src/agent/Cargo.lock

