### PR TITLE
Use global.json to specify .NET version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,6 @@ env:
   SCCACHE_CACHE_SIZE: 1G
   ACTIONS_CACHE_KEY_DATE: 2022-11-21-02
   CI: true
-  DOTNET_VERSION: 7.0.x
 
 jobs:
   agent:
@@ -268,9 +267,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Setup .NET Core SDK
         uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: ${{env.DOTNET_VERSION}}
-          dotnet-quality: "ga"
+        # this will use global.json to install the correct version
       - name: Install dependencies
         run: |
           cd src/ApiService/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -363,8 +363,8 @@ jobs:
       - name: Setup .NET Core SDK
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: ${{env.DOTNET_VERSION}}
-          dotnet-quality: "ga"
+          # use global.json to install the correct version
+          global-json-file: global.json
       - run: src/ci/dotnet-fuzzing-tools.sh
         shell: bash
       - uses: actions/upload-artifact@v3
@@ -378,8 +378,8 @@ jobs:
       - name: Setup .NET Core SDK
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: ${{env.DOTNET_VERSION}}
-          dotnet-quality: "ga"
+          # use global.json to install the correct version
+          global-json-file: global.json
       - run: src/ci/dotnet-fuzzing-tools.ps1
         shell: pwsh
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,7 +267,9 @@ jobs:
       - uses: actions/checkout@v3
       - name: Setup .NET Core SDK
         uses: actions/setup-dotnet@v3
-        # this will use global.json to install the correct version
+        with:
+          # use global.json to install the correct version
+          global-json-file: global.json
       - name: Install dependencies
         run: |
           cd src/ApiService/

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+    "sdk": {
+        "version": "7.0.100",
+        // allows 7.0.xxx
+        "rollForward": "latestFeature"
+    }
+}

--- a/global.json
+++ b/global.json
@@ -1,7 +1,6 @@
 {
     "sdk": {
         "version": "7.0.100",
-        // allows 7.0.xxx
         "rollForward": "latestFeature"
     }
 }


### PR DESCRIPTION
Rather than specifying this in `ci.yml`, specify it in the `global.json` file. This allows us to share the version amongst several workflows (and ADO pipelines) without needing to synchronize them.