### PR TITLE
Allow libfuzzer verification to retry

### DIFF
--- a/src/agent/onefuzz-agent/src/validations.rs
+++ b/src/agent/onefuzz-agent/src/validations.rs
@@ -79,7 +79,7 @@ async fn validate_libfuzzer(config: ValidationConfig) -> Result<()> {
     );
 
     if let Some(seeds) = config.seeds {
-        libfuzzer.verify(true, Some(vec![seeds])).await?;
+        libfuzzer.verify(true, Some(&[&seeds])).await?;
     }
 
     Ok(())

--- a/src/agent/onefuzz-task/src/tasks/fuzz/libfuzzer/common.rs
+++ b/src/agent/onefuzz-task/src/tasks/fuzz/libfuzzer/common.rs
@@ -17,7 +17,11 @@ use onefuzz_telemetry::{
     EventData,
 };
 use serde::Deserialize;
-use std::{collections::HashMap, path::PathBuf, sync::Arc};
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 use tempfile::{tempdir_in, TempDir};
 use tokio::{
     io::{AsyncBufReadExt, BufReader},
@@ -132,19 +136,14 @@ where
     }
 
     pub async fn verify(&self) -> Result<()> {
-        let mut directories = vec![self.config.inputs.local_path.clone()];
+        let mut directories: Vec<&Path> = vec![&self.config.inputs.local_path];
         if let Some(readonly_inputs) = &self.config.readonly_inputs {
-            let mut dirs = readonly_inputs
-                .iter()
-                .map(|x| x.local_path.clone())
-                .collect();
-            directories.append(&mut dirs);
+            directories.extend(readonly_inputs.iter().map(|x| -> &Path { &x.local_path }));
         }
 
         let fuzzer = L::from_config(&self.config).await?;
-
         fuzzer
-            .verify(self.config.check_fuzzer_help, Some(directories))
+            .verify(self.config.check_fuzzer_help, Some(&directories))
             .await
     }
 
@@ -220,7 +219,7 @@ where
     // While it runs, parse stderr for progress metrics, and report them.
     async fn run_fuzzer(
         &self,
-        local_inputs: impl AsRef<std::path::Path>,
+        local_inputs: impl AsRef<Path>,
         worker_id: usize,
         stats_sender: Option<&StatsSender>,
     ) -> Result<()> {

--- a/src/agent/onefuzz/src/libfuzzer.rs
+++ b/src/agent/onefuzz/src/libfuzzer.rs
@@ -226,6 +226,7 @@ impl LibFuzzer {
                 Ok(()) => return Ok(()),
                 Err(e) => {
                     if (Instant::now() + sleep_time) <= (started_at + max_verification_time) {
+                        warn!("libfuzzer verification failed, will retry: {e:?}");
                         tokio::time::sleep(sleep_time).await;
                     } else {
                         return Err(e.context(format!(

--- a/src/agent/onefuzz/src/libfuzzer.rs
+++ b/src/agent/onefuzz/src/libfuzzer.rs
@@ -16,6 +16,7 @@ use std::{
     ffi::{OsStr, OsString},
     path::{Path, PathBuf},
     process::Stdio,
+    time::{Duration, Instant},
 };
 use tempfile::tempdir;
 use tokio::process::{Child, Command};
@@ -168,35 +169,30 @@ impl LibFuzzer {
         Ok(cmd)
     }
 
-    pub async fn verify(
-        &self,
-        check_fuzzer_help: bool,
-        inputs: Option<Vec<PathBuf>>,
-    ) -> Result<()> {
+    async fn verify_inner(&self, check_fuzzer_help: bool, inputs: &[&Path]) -> Result<()> {
         if check_fuzzer_help {
             self.check_help().await?;
         }
 
         let mut seen_inputs = false;
 
-        if let Some(inputs) = inputs {
-            // check the 5 files at random from the input directories
-            for input_dir in inputs {
-                if tokio::fs::metadata(&input_dir).await.is_ok() {
-                    let mut files = list_files(&input_dir).await?;
-                    {
-                        let mut rng = thread_rng();
-                        files.shuffle(&mut rng);
-                    }
-                    for file in files.iter().take(5) {
-                        self.check_input(file).await.with_context(|| {
-                            format!("checking input corpus: {}", file.display())
-                        })?;
-                        seen_inputs = true;
-                    }
-                } else {
-                    println!("input dir doesn't exist: {input_dir:?}");
+        // check 5 files at random from each input directory
+        for input_dir in inputs {
+            if tokio::fs::metadata(&input_dir).await.is_ok() {
+                let mut files = list_files(&input_dir).await?;
+                {
+                    let mut rng = thread_rng();
+                    files.shuffle(&mut rng);
                 }
+
+                for file in files.iter().take(5) {
+                    self.check_input(file)
+                        .await
+                        .with_context(|| format!("checking input corpus: {}", file.display()))?;
+                    seen_inputs = true;
+                }
+            } else {
+                println!("input dir doesn't exist: {input_dir:?}");
             }
         }
 
@@ -210,6 +206,37 @@ impl LibFuzzer {
         }
 
         Ok(())
+    }
+
+    pub async fn verify(&self, check_fuzzer_help: bool, inputs: Option<&[&Path]>) -> Result<()> {
+        // we’ve seen issues where executables cannot run on the first attempt;
+        // for example, executables that depend upon an override in KnownDlls from taking effect
+        //
+        // so, we let the verification step fail for a while before we commit to its total failure
+        let sleep_time = Duration::from_secs(5);
+        let max_verification_time = Duration::from_secs(60);
+        let started_at = Instant::now();
+        let mut attempts = 0;
+        loop {
+            let result = self
+                .verify_inner(check_fuzzer_help, inputs.unwrap_or_default())
+                .await;
+
+            match result {
+                Ok(()) => return Ok(()),
+                Err(e) => {
+                    if (Instant::now() + sleep_time) <= (started_at + max_verification_time) {
+                        tokio::time::sleep(sleep_time).await;
+                    } else {
+                        return Err(e.context(format!(
+                            "libfuzzer verification still failing after {attempts} attempts"
+                        )));
+                    }
+                }
+            }
+
+            attempts += 1;
+        }
     }
 
     // Verify that the libfuzzer exits with a zero return code with a known
@@ -494,7 +521,7 @@ mod tests {
         // verify catching bad exits with inputs
         assert!(
             fuzzer
-                .verify(false, Some(vec!(temp_setup_dir.path().to_path_buf())))
+                .verify(false, Some(&[temp_setup_dir.path()]))
                 .await
                 .is_err(),
             "checking false with basic input"
@@ -527,7 +554,7 @@ mod tests {
         // verify good exits with inputs
         assert!(
             fuzzer
-                .verify(false, Some(vec!(temp_setup_dir.path().to_path_buf())))
+                .verify(false, Some(&[temp_setup_dir.path()]))
                 .await
                 .is_ok(),
             "checking true with basic inputs"

--- a/src/agent/onefuzz/src/libfuzzer.rs
+++ b/src/agent/onefuzz/src/libfuzzer.rs
@@ -216,7 +216,7 @@ impl LibFuzzer {
         let sleep_time = Duration::from_secs(5);
         let max_verification_time = Duration::from_secs(60);
         let started_at = Instant::now();
-        let mut attempts = 0;
+        let mut attempts = 1;
         loop {
             let result = self
                 .verify_inner(check_fuzzer_help, inputs.unwrap_or_default())

--- a/src/agent/onefuzz/src/libfuzzer.rs
+++ b/src/agent/onefuzz/src/libfuzzer.rs
@@ -192,7 +192,7 @@ impl LibFuzzer {
                     seen_inputs = true;
                 }
             } else {
-                println!("input dir doesn't exist: {input_dir:?}");
+                debug!("input dir doesn't exist: {input_dir:?}");
             }
         }
 


### PR DESCRIPTION
Closes #2862 by brute force.

We’ve seen cases where it takes some time for an executable with a KnownDlls override to actually work after the node is restarted; thus, we now allow verification to take some time (currently up to a minute) to validate that a libfuzzer-based fuzzer actually works.