### PR TITLE
Include coverage percentage in Cobertura reports

### DIFF
--- a/src/agent/coverage/examples/cobertura.rs
+++ b/src/agent/coverage/examples/cobertura.rs
@@ -49,6 +49,8 @@ mod test {
     use pretty_assertions::assert_eq;
 
     #[test]
+    // On Windows this produces different output due to filename parsing.
+    #[cfg(target_os = "linux")]
     pub fn check_output() {
         let result = generate_output().unwrap();
 

--- a/src/agent/coverage/examples/cobertura.rs
+++ b/src/agent/coverage/examples/cobertura.rs
@@ -8,6 +8,11 @@ use coverage::source::{Count, FileCoverage, Line, SourceCoverage};
 use debuggable_module::path::FilePath;
 
 fn main() -> Result<()> {
+    println!("{}", generate_output()?);
+    Ok(())
+}
+
+fn generate_output() -> Result<String> {
     let modoff = vec![
         (r"/missing/lib.c", vec![1, 2, 3, 5, 8]),
         (
@@ -35,10 +40,185 @@ fn main() -> Result<()> {
         coverage.files.insert(file_path, file);
     }
 
-    let cobertura = CoberturaCoverage::from(coverage);
+    CoberturaCoverage::from(coverage).to_string()
+}
 
-    let text = cobertura.to_string()?;
-    println!("{text}");
+#[cfg(test)]
+mod test {
+    use super::*;
+    use pretty_assertions::assert_eq;
 
-    Ok(())
+    #[test]
+    pub fn check_output() {
+        let result = generate_output().unwrap();
+
+        let expected = r#"<coverage line-rate="0.30" branch-rate="0.00" lines-covered="9" lines-valid="30" branches-covered="0" branches-valid="0" complexity="0" version="" timestamp="0">
+  <sources>
+    <source path="test-data\fuzz.h"/>
+    <source path="test-data\lib\explode.h"/>
+    <source path="/missing/lib.c"/>
+    <source path="test-data/fuzz.c"/>
+  </sources>
+  <packages>
+    <package name="" line-rate="0.33" branch-rate="0.00" complexity="0">
+      <classes>
+        <class name="test-data\fuzz.h" filename="test-data\fuzz.h" line-rate="0.33" branch-rate="0.00" complexity="0">
+          <methods>
+          </methods>
+          <lines>
+            <line number="3" hits="1" branch="false" condition-coverage="100%">
+              <conditions>
+              </conditions>
+            </line>
+            <line number="4" hits="0" branch="false" condition-coverage="100%">
+              <conditions>
+              </conditions>
+            </line>
+            <line number="5" hits="0" branch="false" condition-coverage="100%">
+              <conditions>
+              </conditions>
+            </line>
+          </lines>
+        </class>
+        <class name="test-data\lib\explode.h" filename="test-data\lib\explode.h" line-rate="0.33" branch-rate="0.00" complexity="0">
+          <methods>
+          </methods>
+          <lines>
+            <line number="1" hits="0" branch="false" condition-coverage="100%">
+              <conditions>
+              </conditions>
+            </line>
+            <line number="2" hits="0" branch="false" condition-coverage="100%">
+              <conditions>
+              </conditions>
+            </line>
+            <line number="3" hits="1" branch="false" condition-coverage="100%">
+              <conditions>
+              </conditions>
+            </line>
+          </lines>
+        </class>
+      </classes>
+    </package>
+    <package name="/missing" line-rate="0.20" branch-rate="0.00" complexity="0">
+      <classes>
+        <class name="lib.c" filename="/missing/lib.c" line-rate="0.20" branch-rate="0.00" complexity="0">
+          <methods>
+          </methods>
+          <lines>
+            <line number="1" hits="0" branch="false" condition-coverage="100%">
+              <conditions>
+              </conditions>
+            </line>
+            <line number="2" hits="0" branch="false" condition-coverage="100%">
+              <conditions>
+              </conditions>
+            </line>
+            <line number="3" hits="1" branch="false" condition-coverage="100%">
+              <conditions>
+              </conditions>
+            </line>
+            <line number="5" hits="0" branch="false" condition-coverage="100%">
+              <conditions>
+              </conditions>
+            </line>
+            <line number="8" hits="0" branch="false" condition-coverage="100%">
+              <conditions>
+              </conditions>
+            </line>
+          </lines>
+        </class>
+      </classes>
+    </package>
+    <package name="test-data" line-rate="0.32" branch-rate="0.00" complexity="0">
+      <classes>
+        <class name="fuzz.c" filename="test-data/fuzz.c" line-rate="0.32" branch-rate="0.00" complexity="0">
+          <methods>
+          </methods>
+          <lines>
+            <line number="7" hits="0" branch="false" condition-coverage="100%">
+              <conditions>
+              </conditions>
+            </line>
+            <line number="8" hits="0" branch="false" condition-coverage="100%">
+              <conditions>
+              </conditions>
+            </line>
+            <line number="10" hits="0" branch="false" condition-coverage="100%">
+              <conditions>
+              </conditions>
+            </line>
+            <line number="13" hits="0" branch="false" condition-coverage="100%">
+              <conditions>
+              </conditions>
+            </line>
+            <line number="16" hits="0" branch="false" condition-coverage="100%">
+              <conditions>
+              </conditions>
+            </line>
+            <line number="17" hits="0" branch="false" condition-coverage="100%">
+              <conditions>
+              </conditions>
+            </line>
+            <line number="21" hits="1" branch="false" condition-coverage="100%">
+              <conditions>
+              </conditions>
+            </line>
+            <line number="22" hits="0" branch="false" condition-coverage="100%">
+              <conditions>
+              </conditions>
+            </line>
+            <line number="23" hits="0" branch="false" condition-coverage="100%">
+              <conditions>
+              </conditions>
+            </line>
+            <line number="27" hits="1" branch="false" condition-coverage="100%">
+              <conditions>
+              </conditions>
+            </line>
+            <line number="28" hits="0" branch="false" condition-coverage="100%">
+              <conditions>
+              </conditions>
+            </line>
+            <line number="29" hits="0" branch="false" condition-coverage="100%">
+              <conditions>
+              </conditions>
+            </line>
+            <line number="30" hits="1" branch="false" condition-coverage="100%">
+              <conditions>
+              </conditions>
+            </line>
+            <line number="32" hits="0" branch="false" condition-coverage="100%">
+              <conditions>
+              </conditions>
+            </line>
+            <line number="33" hits="1" branch="false" condition-coverage="100%">
+              <conditions>
+              </conditions>
+            </line>
+            <line number="37" hits="0" branch="false" condition-coverage="100%">
+              <conditions>
+              </conditions>
+            </line>
+            <line number="39" hits="1" branch="false" condition-coverage="100%">
+              <conditions>
+              </conditions>
+            </line>
+            <line number="42" hits="1" branch="false" condition-coverage="100%">
+              <conditions>
+              </conditions>
+            </line>
+            <line number="44" hits="0" branch="false" condition-coverage="100%">
+              <conditions>
+              </conditions>
+            </line>
+          </lines>
+        </class>
+      </classes>
+    </package>
+  </packages>
+</coverage>"#;
+
+        assert_eq!(expected, result);
+    }
 }


### PR DESCRIPTION
Closes #2824. ReportGenerator (apparently) does not use this information, but I noticed that it was missing when using PyCobertura to generate a report. 

