### PR TITLE
Add basic test for `coverage` example and library

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ env:
   CARGO_TERM_COLOR: always
   SCCACHE_DIR: ${{github.workspace}}/sccache/
   SCCACHE_CACHE_SIZE: 1G
-  ACTIONS_CACHE_KEY_DATE: 2022-11-21-02
+  ACTIONS_CACHE_KEY_DATE: 2023-04-19
   CI: true
 
 jobs:

--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -465,17 +465,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "config"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b076e143e1d9538dde65da30f8481c2a6c44040edb8e02b9bf1351edb92ce3"
-dependencies = [
- "lazy_static",
- "nom 5.1.2",
- "serde",
-]
-
-[[package]]
 name = "console"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/src/agent/coverage/examples/coverage.rs
+++ b/src/agent/coverage/examples/coverage.rs
@@ -167,3 +167,19 @@ fn dump_cobertura(binary: &BinaryCoverage) -> Result<()> {
 
     Ok(())
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn can_run_coverage() {
+        let cmd = command(&["ls".to_string()], None);
+        let recorded = CoverageRecorder::new(cmd)
+            .timeout(Duration::from_secs(5))
+            .record()
+            .unwrap();
+
+        assert!(recorded.coverage.modules.len() > 0);
+    }
+}

--- a/src/agent/coverage/examples/coverage.rs
+++ b/src/agent/coverage/examples/coverage.rs
@@ -174,12 +174,21 @@ mod test {
 
     #[test]
     fn can_run_coverage() {
-        let cmd = command(&["ls".to_string()], None);
+        #[cfg(target_os = "linux")]
+        let cmd = command(&["ls"].map(str::to_string), None);
+
+        #[cfg(target_os = "windows")]
+        let cmd = command(&["cmd.exe", "/c", "dir"].map(str::to_string), None);
+
         let recorded = CoverageRecorder::new(cmd)
             .timeout(Duration::from_secs(5))
             .record()
             .unwrap();
 
+        assert_ne!("", recorded.output.stdout);
+
+        // only non-debuggable modules are found on Windows
+        #[cfg(target_os = "linux")]
         assert!(recorded.coverage.modules.len() > 0);
     }
 }

--- a/src/agent/onefuzz-agent/src/agent.rs
+++ b/src/agent/onefuzz-agent/src/agent.rs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 
 #![allow(clippy::too_many_arguments)]
+use std::time::Duration;
+
 use anyhow::{Error, Result};
 use tokio::time;
 
@@ -29,6 +31,7 @@ pub struct Agent {
     last_poll_command: Result<Option<NodeCommand>, PollCommandError>,
     managed: bool,
     machine_id: uuid::Uuid,
+    sleep_duration: Duration,
 }
 
 impl Agent {
@@ -59,6 +62,7 @@ impl Agent {
             last_poll_command,
             managed,
             machine_id,
+            sleep_duration: Duration::from_secs(30),
         }
     }
 
@@ -365,8 +369,7 @@ impl Agent {
     }
 
     async fn sleep(&self) {
-        let delay = time::Duration::from_secs(30);
-        time::sleep(delay).await;
+        time::sleep(self.sleep_duration).await;
     }
 }
 

--- a/src/agent/onefuzz-agent/src/agent/tests.rs
+++ b/src/agent/onefuzz-agent/src/agent/tests.rs
@@ -84,7 +84,8 @@ impl Fixture {
 
 #[tokio::test]
 async fn test_update_free_no_work() {
-    let agent = Fixture.agent();
+    let mut agent = Fixture.agent();
+    agent.sleep_duration = Duration::from_secs(5);
 
     let (agent, done) = agent.update().await.unwrap();
     assert!(!done);

--- a/src/ci/agent.sh
+++ b/src/ci/agent.sh
@@ -61,7 +61,7 @@ export RUST_BACKTRACE=full
 
 # Run tests and collect coverage 
 # https://github.com/taiki-e/cargo-llvm-cov
-cargo llvm-cov --locked --workspace --lcov --output-path "$output_dir/lcov.info"
+cargo llvm-cov nextest --all-targets --locked --workspace --lcov --output-path "$output_dir/lcov.info"
 
 # TODO: re-enable integration tests.
 # cargo test --release --manifest-path ./onefuzz-task/Cargo.toml --features integration_test -- --nocapture

--- a/src/ci/rust-prereqs.sh
+++ b/src/ci/rust-prereqs.sh
@@ -5,7 +5,7 @@
 
 set -ex
 
-cargo install sccache cargo-license@0.4.2 cargo-llvm-cov cargo-deny cargo-insta
+cargo install sccache cargo-license@0.4.2 cargo-llvm-cov cargo-deny cargo-insta cargo-nextest
 
 # sccache --start-server
 # export RUSTC_WRAPPER=$(which sccache)


### PR DESCRIPTION
The coverage code is not currently exercised by any test.

* Add a test to the `coverage` example so that it can run in PR builds.
* Specify `--all-targets` so that example tests are run.
* Install and use [`nextest`](https://nexte.st/) instead of the standard test runner.
  * This will parallelize test runs across binaries so the overall test run is faster.
* Make sleep duration of agent configurable and reduce it in the test run so that it doesn't wait for 30 seconds.