### PR TITLE
Tiny PR: elsa::sync::FrozenMap now implements Default

### DIFF
--- a/src/agent/debuggable-module/src/loader.rs
+++ b/src/agent/debuggable-module/src/loader.rs
@@ -5,17 +5,9 @@ use anyhow::Result;
 
 use crate::path::FilePath;
 
+#[derive(Default)]
 pub struct Loader {
     loaded: elsa::sync::FrozenMap<FilePath, Box<[u8]>>,
-}
-
-impl Default for Loader {
-    fn default() -> Self {
-        Self {
-            // sync version doesn't have a Default impl
-            loaded: elsa::sync::FrozenMap::new(),
-        }
-    }
 }
 
 impl Loader {


### PR DESCRIPTION
Noticed this while looking at the coverage code.

As of: https://github.com/Manishearth/elsa/pull/37