### PR TITLE
Don't consume `S_LABEL` symbols from PDBs

### DIFF
--- a/src/agent/debuggable-module/src/windows.rs
+++ b/src/agent/debuggable-module/src/windows.rs
@@ -153,13 +153,6 @@ impl<'data> WindowsModule<'data> {
                                 extra.noreturns.insert(offset);
                             }
                         }
-                        Ok(SymbolData::Label(label)) => {
-                            let internal = label.offset;
-                            let offset = self
-                                .translator
-                                .internal_section_offset_to_virtual_offset(internal)?;
-                            extra.labels.insert(offset);
-                        }
                         _ => {}
                     }
                 }

--- a/src/agent/debuggable-module/src/windows.rs
+++ b/src/agent/debuggable-module/src/windows.rs
@@ -141,6 +141,7 @@ impl<'data> WindowsModule<'data> {
                 let mut symbols = mi.symbols()?;
 
                 while let Some(symbol) = symbols.next()? {
+                    #[allow(clippy::single_match)]
                     match symbol.parse() {
                         Ok(SymbolData::Procedure(proc)) => {
                             let noreturn = proc.flags.never;


### PR DESCRIPTION
On Windows, label symbols (see [here](https://docs.rs/pdb/latest/pdb/struct.LabelSymbol.html), [here](https://github.com/microsoft/microsoft-pdb/blob/0fe89a942f9a0f8e061213313e438884f4c9b876/include/cvinfo.h#L2859)) are used to extend the initial set of basic block entrypoint offsets, augmenting function entrypoints. We expect these labels to describe instruction locations, and never procedure-local data or tables.

In practice, this doesn't always hold. We may be able to re-enable this feature in the future, but we'll need a reliable procedure for identifying true code labels (dereferencing to an x86 instruction is insufficient), so disable this hinting for now.