### PR TITLE
Improve agent perf at the cost of compile time

### DIFF
--- a/src/agent/Cargo.toml
+++ b/src/agent/Cargo.toml
@@ -22,3 +22,4 @@ members = [
 
 [profile.release]
 lto = "thin"
+codegen-units = 1


### PR DESCRIPTION
Setting codegen units to 1 may improve performance. It _will_ increase compile times so I'm opening this PR to see how much.

https://doc.rust-lang.org/rustc/codegen-options/index.html#codegen-units