### PR TITLE
Add command to download the blob content to a file

### DIFF
--- a/src/cli/onefuzz/api.py
+++ b/src/cli/onefuzz/api.py
@@ -218,6 +218,20 @@ class Files(Endpoint):
         downloaded = client.download_blob(filename)
         return downloaded
 
+    def download(
+        self, container: primitives.Container, blob_name: str, file_path: Optional[str]
+    ) -> "None":
+        """download a container file to a local path"""
+        self.logger.debug("getting file from container: %s:%s", container, blob_name)
+        client = self._get_client(container)
+        downloaded = client.download_blob(blob_name)
+        local_file = file_path if file_path else blob_name
+        with open(local_file, "wb") as handle:
+            handle.write(downloaded)
+        self.logger.debug(
+            f"downloaded blob {blob_name} from container {container} to {local_file}"
+        )
+
     def upload_file(
         self,
         container: primitives.Container,


### PR DESCRIPTION
## Summary of the Pull Request

Add command to download the blob content to a file
``` cmd
$> onefuzz containers files  download  --help
usage: onefuzz containers files download [-h] [-v] [--format {json,raw}] [--query QUERY] [--file_path FILE_PATH] container blob_name

positional arguments:
  container
  blob_name

options:
  -h, --help            show this help message and exit
  -v, --verbose         increase output verbosity
  --format {json,raw}   output format
  --query QUERY         JMESPath query string. See http://jmespath.org/ for more information and examples.
```
