### PR TITLE
Tweaking some of the parameter for the logging

### DIFF
--- a/src/agent/onefuzz-task/src/tasks/task_logger.rs
+++ b/src/agent/onefuzz-task/src/tasks/task_logger.rs
@@ -16,10 +16,10 @@ use uuid::Uuid;
 
 use tokio::sync::broadcast::{error::TryRecvError, Receiver};
 
-const LOGS_BUFFER_SIZE: usize = 100;
+const LOGS_BUFFER_SIZE: usize = 1000;
 const MAX_LOG_SIZE: u64 = 100000000; // 100 MB
-const DEFAULT_LOGGING_INTERVAL: Duration = Duration::from_secs(60);
-const DEFAULT_POLLING_INTERVAL: Duration = Duration::from_secs(5);
+const DEFAULT_LOGGING_INTERVAL: Duration = Duration::from_secs(20);
+const DEFAULT_POLLING_INTERVAL: Duration = Duration::from_secs(3);
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]

--- a/src/agent/onefuzz-telemetry/src/lib.rs
+++ b/src/agent/onefuzz-telemetry/src/lib.rs
@@ -254,7 +254,7 @@ mod global {
 
     lazy_static! {
         pub static ref EVENT_SOURCE: RwLock<Option<Sender<LoggingEvent>>> = {
-            let (telemetry_event_source, _) = broadcast::channel::<_>(100);
+            let (telemetry_event_source, _) = broadcast::channel::<_>(5000);
             RwLock::new(Some(telemetry_event_source))
         };
     }


### PR DESCRIPTION
## Summary of the Pull Request

Tweaking some of the parameter in the `task_logger` to alleviate the issue #3065

- Increase the size of the broadcast queue from 100 to 5000
- Increase the number of messages consumed by the task_logger from 100 to 10000
- decrease the period between logging from 1 min to 20s
- decrease the polling interval from 5s to 3s

closes #3065