### PR TITLE
Deserialize user info when pulling from blob

### DIFF
--- a/src/ApiService/ApiService/onefuzzlib/Events.cs
+++ b/src/ApiService/ApiService/onefuzzlib/Events.cs
@@ -33,6 +33,7 @@ namespace Microsoft.OneFuzz.Service {
         private readonly IContainers _containers;
         private readonly ICreds _creds;
         private readonly JsonSerializerOptions _options;
+        private readonly JsonSerializerOptions _deserializingFromBlobOptions;
 
         public Events(ILogTracer log, IOnefuzzContext context) {
             _queue = context.Queue;
@@ -44,6 +45,9 @@ namespace Microsoft.OneFuzz.Service {
                 DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
             };
             _options.Converters.Add(new RemoveUserInfo());
+            _deserializingFromBlobOptions = new JsonSerializerOptions(EntityConverter.GetJsonSerializerOptions()) {
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+            };
         }
 
         public virtual async Async.Task QueueSignalrEvent(DownloadableEventMessage message) {
@@ -83,7 +87,7 @@ namespace Microsoft.OneFuzz.Service {
                 return OneFuzzResult<EventMessage>.Error(ErrorCode.UNABLE_TO_FIND, $"Could not find container for event with id {eventId}");
             }
 
-            var eventMessage = JsonSerializer.Deserialize<EventMessage>(blob, _options);
+            var eventMessage = JsonSerializer.Deserialize<EventMessage>(blob, _deserializingFromBlobOptions);
             if (eventMessage == null) {
                 return OneFuzzResult<EventMessage>.Error(ErrorCode.UNEXPECTED_DATA_SHAPE, $"Could not deserialize event with id {eventId}");
             }

--- a/src/ApiService/ApiService/onefuzzlib/WebhookOperations.cs
+++ b/src/ApiService/ApiService/onefuzzlib/WebhookOperations.cs
@@ -14,6 +14,8 @@ public interface IWebhookOperations : IOrm<Webhook> {
     Async.Task<Webhook?> GetByWebhookId(Guid webhookId);
     Async.Task<OneFuzzResultVoid> Send(WebhookMessageLog messageLog);
     Task<EventPing> Ping(Webhook webhook);
+    Task<OneFuzzResult<Tuple<string, string?>>> BuildMessage(Guid webhookId, Guid eventId, EventType eventType, BaseEvent webhookEvent, String? secretToken, WebhookMessageFormat? messageFormat);
+
 }
 
 public class WebhookOperations : Orm<Webhook>, IWebhookOperations {


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_

Our user info serializer fails when reading. We know though, that reading from the events container (which is controlled by onefuzz and only written to by onefuzz_ is safe. So this PR adds a special case when deserializing events from the events container.

## Validation Steps Performed

_How does someone test & validate?_

Added integration test that specifically exercises the failing code path.