### PR TITLE
Add an event for Repro VM creation

### DIFF
--- a/src/ApiService/ApiService/Functions/ReproVmss.cs
+++ b/src/ApiService/ApiService/Functions/ReproVmss.cs
@@ -1,4 +1,6 @@
 ﻿using System.Net;
+using System.Security.Cryptography;
+using System.Text;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 
@@ -79,6 +81,14 @@ public class ReproVmss {
                 req,
                 vm.ErrorV,
                 "repro_vm create");
+        }
+
+        // we’d like to track the usage of this feature; 
+        // anonymize the user ID so we can distinguish multiple requests
+        {
+            var data = userInfo.OkV.UserInfo.ToString(); // rely on record ToString
+            var hash = Convert.ToBase64String(SHA256.HashData(Encoding.UTF8.GetBytes(data)));
+            _log.Event($"created repro VM, user distinguisher: {hash:Tag:UserHash}");
         }
 
         var response = req.CreateResponse(HttpStatusCode.OK);

--- a/src/ApiService/ApiService/Log.cs
+++ b/src/ApiService/ApiService/Log.cs
@@ -12,7 +12,7 @@ namespace Microsoft.OneFuzz.Service;
 [InterpolatedStringHandler]
 public struct LogStringHandler {
 
-    private StringBuilder _builder;
+    private readonly StringBuilder _builder;
     private Dictionary<string, string>? _tags;
 
     public LogStringHandler(int literalLength, int formattedCount) {


### PR DESCRIPTION
Closes #3062 by adding an event to track this information; we can see from Application Insights logs how often the Function is invoked but at the moment do not have a way to distinguish between multiple users.

This (obviously) does not do anything about general feature usage tracking, as we are addressing a shorter-term need.