### PR TITLE
Match the agent version to the server

### DIFF
--- a/src/ApiService/ApiService/Functions/AgentEvents.cs
+++ b/src/ApiService/ApiService/Functions/AgentEvents.cs
@@ -71,11 +71,10 @@ public class AgentEvents {
         }
 
         if (ev.State == NodeState.Free) {
-            if (!node.Managed) {
-                return null;
-            }
-
             if (node.ReimageRequested || node.DeleteRequested) {
+                if (!node.Managed) {
+                    return null;
+                }
                 _log.Info($"stopping free node with reset flags: {machineId:Tag:MachineId}");
                 // discard result: node not used after this point
                 _ = await _context.NodeOperations.Stop(node);

--- a/src/agent/onefuzz-agent/build.rs
+++ b/src/agent/onefuzz-agent/build.rs
@@ -37,7 +37,7 @@ fn print_version(include_sha: bool, include_local: bool, sha: &str) -> Result<()
     let mut version = read_file("../../../CURRENT_VERSION")?;
 
     if include_sha {
-        version.push('-');
+        version.push('+');
         version.push_str(sha);
 
         // if we're a non-release build, check to see if git has

--- a/src/agent/onefuzz-task/build.rs
+++ b/src/agent/onefuzz-task/build.rs
@@ -37,7 +37,7 @@ fn print_version(include_sha: bool, include_local: bool, sha: &str) -> Result<()
     let mut version = read_file("../../../CURRENT_VERSION")?;
 
     if include_sha {
-        version.push('-');
+        version.push('+');
         version.push_str(sha);
 
         // if we're a non-release build, check to see if git has

--- a/src/proxy-manager/build.rs
+++ b/src/proxy-manager/build.rs
@@ -30,7 +30,7 @@ fn print_version(include_sha: bool, include_local: bool) -> Result<(), Box<dyn E
     let sha = run_cmd(&["git", "rev-parse", "HEAD"])?;
 
     if include_sha {
-        version.push('-');
+        version.push('+');
         version.push_str(&sha);
 
         // if we're a non-release build, check to see if git has


### PR DESCRIPTION
## Summary of the Pull Request

This PR updates the onefuzz agent version to generate a version that matches the service side. The version format was changed in #2925

closes #3092 