### PR TITLE
Increase lock wait timeout for `qemu_user` setup script

### DIFF
--- a/src/cli/onefuzz/templates/libfuzzer.py
+++ b/src/cli/onefuzz/templates/libfuzzer.py
@@ -982,7 +982,7 @@ class Libfuzzer(Command):
                     handle.write(
                         "#!/bin/bash\n"
                         "set -ex\n"
-                        "sudo apt-get install -y qemu-user g++-aarch64-linux-gnu libasan5-arm64-cross\n"
+                        "sudo apt-get -o DPkg::Lock::Timeout=600 install -y qemu-user g++-aarch64-linux-gnu libasan5-arm64-cross\n"
                         'cd $(dirname "$(readlink -f "$0")")\n'
                         "mkdir -p sysroot\n"
                         "tar -C sysroot -zxvf %s\n" % sysroot_filename


### PR DESCRIPTION
Address this error when running the setup script:

```
sudo apt-get install -y qemu-user g++-aarch64-linux-gnu libasan5-arm64-cross
E: Could not get lock /var/lib/dpkg/lock-frontend. It is held by process 9364 (dpkg)
E: Unable to acquire the dpkg frontend lock (/var/lib/dpkg/lock-frontend), is another process using it?
```

Solution from [here](https://askubuntu.com/a/1371734/216901); this option is present in Ubuntu 20.04 and later, which we use.