### PR TITLE
Bump azure_* crates to 0.12

### DIFF
--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -203,9 +203,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "azure_core"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32568c56fda7f2f1173430298bddeb507ed44e99bd989ba1156a25534bff5d98"
+checksum = "8145944236fd41c52140108c98b7e46da0f64be494bce7340b03a84c166e059d"
 dependencies = [
  "async-trait",
  "base64 0.21.0",
@@ -230,9 +230,9 @@ dependencies = [
 
 [[package]]
 name = "azure_storage"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29747ca7da0f81ea199d1c957bae737bc5bc54502e0f7c00ca7be1894306944a"
+checksum = "ac51cec052458f949d230895144f25cb325e61e79f4b6a47f750502888e54b7b"
 dependencies = [
  "RustyXML",
  "async-trait",
@@ -253,9 +253,9 @@ dependencies = [
 
 [[package]]
 name = "azure_storage_blobs"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b56de7a67648a7a434db81f11264df2a07e33468e751da379bddbfd7c25d5117"
+checksum = "faf2a451fefb055410fbc9e26e54a1863d1e930125a4346487e2d2d5f64081cb"
 dependencies = [
  "RustyXML",
  "azure_core",

--- a/src/agent/onefuzz-agent/Cargo.toml
+++ b/src/agent/onefuzz-agent/Cargo.toml
@@ -31,13 +31,13 @@ onefuzz-telemetry = { path = "../onefuzz-telemetry" }
 backtrace = "0.3"
 ipc-channel = { git = "https://github.com/servo/ipc-channel", rev = "7f432aa" }
 dynamic-library = { path = "../dynamic-library" }
-azure_core = { version = "0.11", default-features = false, features = [
+azure_core = { version = "0.12", default-features = false, features = [
     "enable_reqwest",
 ] }
-azure_storage = { version = "0.11", default-features = false, features = [
+azure_storage = { version = "0.12", default-features = false, features = [
     "enable_reqwest",
 ] }
-azure_storage_blobs = { version = "0.11", default-features = false, features = [
+azure_storage_blobs = { version = "0.12", default-features = false, features = [
     "enable_reqwest",
 ] }
 

--- a/src/agent/onefuzz-task/Cargo.toml
+++ b/src/agent/onefuzz-task/Cargo.toml
@@ -57,13 +57,13 @@ chrono = { version = "0.4", default-features = false, features = [
 ] }
 ipc-channel = { git = "https://github.com/servo/ipc-channel", rev = "7f432aa" }
 
-azure_core = { version = "0.11", default-features = false, features = [
+azure_core = { version = "0.12", default-features = false, features = [
     "enable_reqwest",
 ] }
-azure_storage = { version = "0.11", default-features = false, features = [
+azure_storage = { version = "0.12", default-features = false, features = [
     "enable_reqwest",
 ] }
-azure_storage_blobs = { version = "0.11", default-features = false, features = [
+azure_storage_blobs = { version = "0.12", default-features = false, features = [
     "enable_reqwest",
 ] }
 
@@ -71,4 +71,3 @@ flexi_logger = "0.25"
 
 [dev-dependencies]
 pretty_assertions = "1.3"
-


### PR DESCRIPTION
Dependabot is trying to do this in #3121 #3122 #3124 but failing since they all need to be updated at the same time.