### PR TITLE
Use --locked when installing Rust pre-reqs

### DIFF
--- a/src/ci/rust-prereqs.sh
+++ b/src/ci/rust-prereqs.sh
@@ -5,7 +5,7 @@
 
 set -ex
 
-cargo install sccache cargo-license@0.4.2 cargo-llvm-cov cargo-deny cargo-insta cargo-nextest
+cargo install --locked sccache cargo-license@0.4.2 cargo-llvm-cov cargo-deny cargo-insta cargo-nextest
 
 # sccache --start-server
 # export RUSTC_WRAPPER=$(which sccache)


### PR DESCRIPTION
CI builds have been broken by https://github.com/bluejekyll/enum-as-inner/issues/98. Try using `--locked` when setting up our pre-reqs so that we get the versions of the dependencies which the executables have been released (and presumably built) with.