### PR TITLE
Fix bug for scale-in protection

### DIFF
--- a/src/ApiService/ApiService/Functions/AgentCanSchedule.cs
+++ b/src/ApiService/ApiService/Functions/AgentCanSchedule.cs
@@ -62,6 +62,14 @@ public class AgentCanSchedule {
         }
         _ = scp.OkV; // node could be updated but we don't use it after this
         allowed = scp.IsOk;
+
+        if (allowed) {
+            _log.Metric($"WorkScheduled", 1, new Dictionary<string, string> {
+                {"MachineId", node.MachineId.ToString()},
+                {"TaskId", task is not null ? task.TaskId.ToString() : string.Empty}
+            });
+        }
+
         return await RequestHandling.Ok(req, new CanSchedule(Allowed: allowed, WorkStopped: workStopped, Reason: reason));
     }
 }

--- a/src/ApiService/ApiService/Functions/AgentCanSchedule.cs
+++ b/src/ApiService/ApiService/Functions/AgentCanSchedule.cs
@@ -64,7 +64,7 @@ public class AgentCanSchedule {
         allowed = scp.IsOk;
 
         if (allowed) {
-            _log.Metric($"WorkScheduled", 1, new Dictionary<string, string> {
+            _log.Metric($"TaskAllowedToSchedule", 1, new Dictionary<string, string> {
                 {"MachineId", node.MachineId.ToString()},
                 {"TaskId", task is not null ? task.TaskId.ToString() : string.Empty}
             });


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_

Fixes a bug where we return `OneFuzzResult.Ok` even if applying scale in protection wasn't OK.

## PR Checklist
* [ ] Applies to work item: #xxx
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/onefuzz) and sign the CLI.
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_

* Only return OK if acquiring scale-in protection was successful
* Add metrics

## Validation Steps Performed

_How does someone test & validate?_

Will be validating in check-pr