### PR TITLE
Include a reason when a task has never started

### DIFF
--- a/docs/webhook_events.md
+++ b/docs/webhook_events.md
@@ -1183,7 +1183,8 @@ If webhook is set to have Event Grid message format then the payload will look a
                 481,
                 482,
                 483,
-                484
+                484,
+                485
             ],
             "title": "ErrorCode"
         },
@@ -1829,7 +1830,8 @@ If webhook is set to have Event Grid message format then the payload will look a
                 481,
                 482,
                 483,
-                484
+                484,
+                485
             ],
             "title": "ErrorCode"
         }
@@ -2774,7 +2776,8 @@ If webhook is set to have Event Grid message format then the payload will look a
                 481,
                 482,
                 483,
-                484
+                484,
+                485
             ],
             "title": "ErrorCode"
         }
@@ -3501,7 +3504,8 @@ If webhook is set to have Event Grid message format then the payload will look a
                 481,
                 482,
                 483,
-                484
+                484,
+                485
             ],
             "title": "ErrorCode"
         },
@@ -5579,7 +5583,8 @@ If webhook is set to have Event Grid message format then the payload will look a
                 481,
                 482,
                 483,
-                484
+                484,
+                485
             ],
             "title": "ErrorCode"
         },

--- a/src/ApiService/ApiService/Functions/AgentEvents.cs
+++ b/src/ApiService/ApiService/Functions/AgentEvents.cs
@@ -250,7 +250,7 @@ public class AgentEvents {
 
         if (done.ExitStatus.Success) {
             _log.Info($"task done. {task.JobId:Tag:JobId}:{task.TaskId:Tag:TaskId} {done.ExitStatus:Tag:Status}");
-            await _context.TaskOperations.MarkStopping(task);
+            await _context.TaskOperations.MarkStopping(task, "task is done");
 
             // keep node if keep-on-completion is set
             if (task.Config.Debug?.Contains(TaskDebugFlag.KeepNodeOnCompletion) == true) {

--- a/src/ApiService/ApiService/Functions/Tasks.cs
+++ b/src/ApiService/ApiService/Functions/Tasks.cs
@@ -170,7 +170,7 @@ public class Tasks {
 
         }
 
-        await _context.TaskOperations.MarkStopping(task);
+        await _context.TaskOperations.MarkStopping(task, "task is deleted");
 
         var response = req.CreateResponse(HttpStatusCode.OK);
         await response.WriteAsJsonAsync(task);

--- a/src/ApiService/ApiService/Functions/TimerTasks.cs
+++ b/src/ApiService/ApiService/Functions/TimerTasks.cs
@@ -26,7 +26,7 @@ public class TimerTasks {
         var expriredTasks = _taskOperations.SearchExpired();
         await foreach (var task in expriredTasks) {
             _logger.Info($"stopping expired task. job_id:{task.JobId:Tag:JobId} task_id:{task.TaskId:Tag:TaskId}");
-            await _taskOperations.MarkStopping(task);
+            await _taskOperations.MarkStopping(task, "task is expired");
         }
 
 

--- a/src/ApiService/ApiService/OneFuzzTypes/Enums.cs
+++ b/src/ApiService/ApiService/OneFuzzTypes/Enums.cs
@@ -39,6 +39,7 @@ public enum ErrorCode {
     UNEXPECTED_DATA_SHAPE = 482,
     UNABLE_TO_SEND = 483,
     NODE_DELETED = 484,
+    TASK_CANCELLED = 485,
     // NB: if you update this enum, also update enums.py
 }
 

--- a/src/ApiService/ApiService/onefuzzlib/JobOperations.cs
+++ b/src/ApiService/ApiService/onefuzzlib/JobOperations.cs
@@ -111,7 +111,7 @@ public class JobOperations : StatefulOrm<Job, JobState, JobOperations>, IJobOper
 
         if (notStopped.Any()) {
             foreach (var task in notStopped) {
-                await _context.TaskOperations.MarkStopping(task);
+                await _context.TaskOperations.MarkStopping(task, "job is stopping");
             }
         } else {
             job = job with { State = JobState.Stopped };

--- a/src/ApiService/IntegrationTests/AgentEventsTests.cs
+++ b/src/ApiService/IntegrationTests/AgentEventsTests.cs
@@ -123,7 +123,7 @@ public abstract class AgentEventsTestsBase : FunctionTestBase {
     }
 
     [Fact]
-    public async Async.Task WorkerDone_ForNonStartedTask_MarksTaskAsFailed() {
+    public async Async.Task WorkerDone_ForNonStartedTask_MarksTaskAsCancelled() {
         await Context.InsertAll(
             new Node(_poolName, _machineId, _poolId, _poolVersion),
             // task state is scheduled, not running
@@ -148,7 +148,7 @@ public abstract class AgentEventsTestsBase : FunctionTestBase {
 
         // should be failed - it never started running
         Assert.Equal(TaskState.Stopping, task.State);
-        Assert.Equal(ErrorCode.TASK_FAILED, task.Error?.Code);
+        Assert.Equal(ErrorCode.TASK_CANCELLED, task.Error?.Code);
     }
 
     [Fact]

--- a/src/pytypes/onefuzztypes/enums.py
+++ b/src/pytypes/onefuzztypes/enums.py
@@ -291,6 +291,7 @@ class ErrorCode(Enum):
     UNEXPECTED_DATA_SHAPE = 482
     UNABLE_TO_SEND = 483
     NODE_DELETED = 484
+    TASK_CANCELLED = 485
     # NB: if you update this enum, also update Enums.cs
 
 


### PR DESCRIPTION
## Summary of the Pull Request

- Added a reason field to MarkStopping
- Added a new ErrorCode `TASK_CANCELLED` to differentiate cancellation from failure.
- If a task is cancelled all dependent task are cancelled


closes #3147