### PR TITLE
Downloading files to locally repro crashes

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
 	"name": "Ubuntu",
 	"build": {
-		"dockerfile": "Dockerfile"
+		"dockerfile": "Dockerfile",
 	},
 	// Set *default* container specific settings.json values on container create.
 	"settings": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
 	"name": "Ubuntu",
 	"build": {
-		"dockerfile": "Dockerfile",
+		"dockerfile": "Dockerfile"
 	},
 	// Set *default* container specific settings.json values on container create.
 	"settings": {

--- a/src/cli/onefuzz/api.py
+++ b/src/cli/onefuzz/api.py
@@ -551,7 +551,7 @@ class Repro(Endpoint):
         report_container: primitives.Container,
         report_name: str,
         include_setup: bool = False,
-        output_dir: primitives.Directory = "."
+        output_dir: primitives.Directory = ".",
     ) -> None:
         """downloads the files necessary to locally repro the crash from a given report"""
         report_bytes = self.onefuzz.containers.files.get(report_container, report_name)
@@ -559,20 +559,19 @@ class Repro(Endpoint):
 
         self.logger.debug(
             "downloading files necessary to locally repro crash %s",
-            report["input_blob"]["name"]
+            report["input_blob"]["name"],
         )
-        
+
         self.onefuzz.containers.files.download(
             report["input_blob"]["container"],
             report["input_blob"]["name"],
-            os.path.join(output_dir, report["input_blob"]["name"])
+            os.path.join(output_dir, report["input_blob"]["name"]),
         )
-        
+
         if include_setup:
             setup_container = list(
                 self.onefuzz.jobs.containers.list(
-                    report["job_id"],
-                    enums.ContainerType.setup
+                    report["job_id"], enums.ContainerType.setup
                 )
             ).pop()
             self.onefuzz.containers.files.download_dir(setup_container, output_dir)

--- a/src/cli/onefuzz/api.py
+++ b/src/cli/onefuzz/api.py
@@ -233,7 +233,11 @@ class Files(Endpoint):
         )
 
     def download_repro(
-            self, container: primitives.Container, crash_name: str, fuzz_target: str, dir_path: primitives.Directory
+        self,
+        container: primitives.Container,
+        crash_name: str,
+        fuzz_target: str,
+        dir_path: primitives.Directory,
     ) -> None:
         """downloads the files necessary to locally repro a crash"""
         self.logger.debug("downloading files necesary to repro crash %s", crash_name)

--- a/src/cli/onefuzz/api.py
+++ b/src/cli/onefuzz/api.py
@@ -557,7 +557,7 @@ class Repro(Endpoint):
         report_bytes = self.onefuzz.containers.files.get(report_container, report_name)
         report = json.loads(report_bytes)
 
-        self.logger.debug(
+        self.logger.info(
             "downloading files necessary to locally repro crash %s",
             report["input_blob"]["name"],
         )
@@ -573,7 +573,7 @@ class Repro(Endpoint):
                 self.onefuzz.jobs.containers.list(
                     report["job_id"], enums.ContainerType.setup
                 )
-            ).pop()
+            )[0]
             self.onefuzz.containers.files.download_dir(
                 primitives.Container(setup_container), output_dir
             )

--- a/src/cli/onefuzz/api.py
+++ b/src/cli/onefuzz/api.py
@@ -551,7 +551,7 @@ class Repro(Endpoint):
         report_container: primitives.Container,
         report_name: str,
         include_setup: bool = False,
-        output_dir: primitives.Directory = ".",
+        output_dir: primitives.Directory = primitives.Directory("."),
     ) -> None:
         """downloads the files necessary to locally repro the crash from a given report"""
         report_bytes = self.onefuzz.containers.files.get(report_container, report_name)
@@ -574,7 +574,7 @@ class Repro(Endpoint):
                     report["job_id"], enums.ContainerType.setup
                 )
             ).pop()
-            self.onefuzz.containers.files.download_dir(setup_container, output_dir)
+            self.onefuzz.containers.files.download_dir(primitives.Container(setup_container), output_dir)
 
     def create(
         self, container: primitives.Container, path: str, duration: int = 24

--- a/src/cli/onefuzz/api.py
+++ b/src/cli/onefuzz/api.py
@@ -232,6 +232,15 @@ class Files(Endpoint):
             f"downloaded blob {blob_name} from container {container} to {local_file}"
         )
 
+    def download_repro(
+            self, container: primitives.Container, crash_name: str, fuzz_target: str, dir_path: primitives.Directory
+    ) -> None:
+        """downloads the files necessary to locally repro a crash"""
+        self.logger.debug("downloading files necesary to repro crash %s", crash_name)
+        self.download_dir(container, dir_path)
+        self.download(container, crash_name, dir_path.join(crash_name))
+        self.download(container, fuzz_target, dir_path.join(fuzz_target))
+
     def upload_file(
         self,
         container: primitives.Container,

--- a/src/cli/onefuzz/api.py
+++ b/src/cli/onefuzz/api.py
@@ -574,7 +574,9 @@ class Repro(Endpoint):
                     report["job_id"], enums.ContainerType.setup
                 )
             ).pop()
-            self.onefuzz.containers.files.download_dir(primitives.Container(setup_container), output_dir)
+            self.onefuzz.containers.files.download_dir(
+                primitives.Container(setup_container), output_dir
+            )
 
     def create(
         self, container: primitives.Container, path: str, duration: int = 24


### PR DESCRIPTION
## Summary of the Pull Request

Add a command to the CLI for downloading the files to locally repro a crash
Command:
`onefuzz repro get_files <report_container> <report_name> [--output_dir <path>] [--include-setup]`

## PR Checklist
* [ ] Applies to work item: #xxx
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/onefuzz) and sign the CLI.
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Validation Steps Performed

Ran the command with correct and invalid arguments.
