### PR TITLE
Make coverage-recording errors non-fatal

### DIFF
--- a/src/agent/onefuzz-task/src/tasks/coverage/generic.rs
+++ b/src/agent/onefuzz-task/src/tasks/coverage/generic.rs
@@ -373,12 +373,19 @@ impl<'a> TaskContext<'a> {
             match entry {
                 Ok(entry) => {
                     if entry.file_type().await?.is_file() {
-                        self.record_input(&entry.path()).await?;
-                        count += 1;
+                        if let Err(e) = self.record_input(&entry.path()).await {
+                            warn!(
+                                "ignoring error recording coverage for input: {}, error: {}",
+                                entry.path().display(),
+                                e
+                            );
+                        } else {
+                            count += 1;
 
-                        // make sure we save & sync coverage every 10 inputs
-                        if count % 10 == 0 {
-                            self.save_and_sync_coverage().await?;
+                            // make sure we save & sync coverage every 10 inputs
+                            if count % 10 == 0 {
+                                self.save_and_sync_coverage().await?;
+                            }
                         }
                     } else {
                         warn!("skipping non-file dir entry: {}", entry.path().display());

--- a/src/agent/onefuzz-task/src/tasks/coverage/generic.rs
+++ b/src/agent/onefuzz-task/src/tasks/coverage/generic.rs
@@ -21,7 +21,7 @@ use onefuzz_file_format::coverage::{
     binary::{v1::BinaryCoverageJson as BinaryCoverageJsonV1, BinaryCoverageJson},
     source::{v1::SourceCoverageJson as SourceCoverageJsonV1, SourceCoverageJson},
 };
-use onefuzz_telemetry::{warn, Event::coverage_data, EventData};
+use onefuzz_telemetry::{event, warn, Event::coverage_data, Event::coverage_failed, EventData};
 use storage_queue::{Message, QueueClient};
 use tokio::fs;
 use tokio::task::spawn_blocking;
@@ -374,6 +374,7 @@ impl<'a> TaskContext<'a> {
                 Ok(entry) => {
                     if entry.file_type().await?.is_file() {
                         if let Err(e) = self.record_input(&entry.path()).await {
+                            event!(coverage_failed; EventData::Path = entry.path().display().to_string());
                             warn!(
                                 "ignoring error recording coverage for input: {}, error: {}",
                                 entry.path().display(),

--- a/src/agent/onefuzz-telemetry/src/lib.rs
+++ b/src/agent/onefuzz-telemetry/src/lib.rs
@@ -72,6 +72,7 @@ impl Role {
 pub enum Event {
     task_start,
     coverage_data,
+    coverage_failed,
     new_result,
     new_coverage,
     runtime_stats,
@@ -87,6 +88,7 @@ impl Event {
         match self {
             Self::task_start => "task_start",
             Self::coverage_data => "coverage_data",
+            Self::coverage_failed => "coverage_failed",
             Self::new_coverage => "new_coverage",
             Self::new_result => "new_result",
             Self::runtime_stats => "runtime_stats",


### PR DESCRIPTION
When we record coverage, if any of the files fail (e.g. due to timeouts during coverage recording), then we fail the whole process.

Instead, make coverage recording best-effort: if any files fail then we continue to record coverage using the other files. A warning is printed that we can monitor for any ongoing problems.

Closes #3041