### PR TITLE
Fix install of dotnet in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,7 +2,7 @@
 
 ARG VARIANT="ubuntu-22.04"
 
-FROM mcr.microsoft.com/vscode/devcontainers/base:0-${VARIANT}
+FROM mcr.microsoft.com/devcontainers/base:${VARIANT}
 
 # note: keep this in sync with .github/workflows/ci.yml
 ARG RUSTVERSION="1.69"

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,19 +7,13 @@ FROM mcr.microsoft.com/vscode/devcontainers/base:0-${VARIANT}
 # note: keep this in sync with .github/workflows/ci.yml
 ARG RUSTVERSION="1.69"
 
-# Needed for dotnet7; remove when available in Ubuntu
-RUN wget https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb \
-    && sudo dpkg -i packages-microsoft-prod.deb \
-    && rm packages-microsoft-prod.deb
-
 # Install packages required for build:
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends \
     libunwind-dev clang build-essential libssl-dev pkg-config lldb \
     bash-completion npm \
     python-is-python3 direnv uuid-runtime python3-distutils python3-pip python3-venv \
-    dotnet-sdk-7.0 gh
-    # TODO replace with dotnet7 when available in Ubuntu
+    dotnet7 gh
 
 # Install Rust:
 USER vscode

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,51 +3,49 @@
 {
 	"name": "Ubuntu",
 	"build": {
-		"dockerfile": "Dockerfile",
+		"dockerfile": "Dockerfile"
 	},
-	// Set *default* container specific settings.json values on container create.
-	"settings": {
-		"lldb.executable": "/usr/bin/lldb",
-		"files.watcherExclude": {
-			"**/target/**": true
-		},
-		"rust-analyzer.checkOnSave.command": "clippy",
-		"rust-analyzer.linkedProjects": [
-			"/workspaces/onefuzz/src/agent/Cargo.toml",
-			"/workspaces/onefuzz/src/proxy-manager/Cargo.toml"
-		],
-		"python.defaultInterpreterPath": "/workspaces/onefuzz/src/venv/bin/python",
-		"python.formatting.provider": "black",
-		"python.linting.flake8Enabled": true,
-		"python.linting.mypyEnabled": true,
-		"omnisharp.enableRoslynAnalyzers": true,
-		"omnisharp.enableEditorConfigSupport": true,
-		"editor.formatOnSave": true
+	"customizations": {
+		"vscode": {
+			"settings": {
+				"editor.formatOnSave": true,
+				"files.watcherExclude": {
+					"**/target/**": true
+				},
+				"lldb.executable": "/usr/bin/lldb",
+				"omnisharp.enableEditorConfigSupport": true,
+				"omnisharp.enableRoslynAnalyzers": true,
+				"python.defaultInterpreterPath": "/workspaces/onefuzz/src/venv/bin/python",
+				"python.formatting.provider": "black",
+				"python.linting.flake8Enabled": true,
+				"python.linting.mypyEnabled": true,
+				"rust-analyzer.checkOnSave.command": "clippy",
+				"rust-analyzer.linkedProjects": [
+					"/workspaces/onefuzz/src/agent/Cargo.toml",
+					"/workspaces/onefuzz/src/proxy-manager/Cargo.toml"
+				]
+			},
+			"extensions": [
+				"formulahendry.dotnet-test-explorer",
+				"ms-azuretools.vscode-azurefunctions",
+				"ms-azuretools.vscode-bicep",
+				"ms-dotnettools.csharp",
+				"ms-python.python",
+				"mutantdino.resourcemonitor",
+				"redhat.vscode-yaml",
+				"rust-lang.rust-analyzer",
+				"serayuzgur.crates",
+				"tamasfe.even-better-toml",
+				"vadimcn.vscode-lldb"
+			]
+		}
 	},
-	// Add the IDs of extensions you want installed when the container is created.
-	"extensions": [
-		"vadimcn.vscode-lldb",
-		"mutantdino.resourcemonitor",
-		"rust-lang.rust-analyzer",
-		"tamasfe.even-better-toml",
-		"serayuzgur.crates",
-		"ms-dotnettools.csharp",
-		"ms-python.python",
-		"ms-azuretools.vscode-bicep",
-		"formulahendry.dotnet-test-explorer",
-		"ms-azuretools.vscode-azurefunctions",
-		"redhat.vscode-yaml"
-	],
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// Run as interactive bash shell to pick up .bashrc so that direnv is set up:
 	"postCreateCommand": "bash -i .devcontainer/post-create-script.sh",
-	// - ensure all nuget packages are present
-	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode",
-	// Note: available features are listed in: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/container-features/src/devcontainer-features.json
+	// Note: available features are found in: https://github.com/devcontainers/features/blob/main/README.md
 	"features": {
-		"azure-cli": "latest"
+		"ghcr.io/devcontainers/features/azure-cli:1": {}
 	}
 }


### PR DESCRIPTION
Somehow using the Microsoft package we are ending up with a broken install of `dotnet`. Change to use the Ubuntu-supplied version instead.

Also go ahead and update the devcontainer config to conform to the new standard.