### PR TITLE
Include debug info in the release binaries to improve backtraces and debuggability

### DIFF
--- a/src/agent/Cargo.toml
+++ b/src/agent/Cargo.toml
@@ -22,3 +22,4 @@ members = [
 
 [profile.release]
 lto = "thin"
+debug = true


### PR DESCRIPTION
Include debug info in the release binaries to [improve backtraces and debuggability](https://doc.rust-lang.org/cargo/reference/profiles.html#build-dependencies).
