### PR TITLE
Handle the case where the secret is not serialized as json

### DIFF
--- a/src/ApiService/ApiService/onefuzzlib/Secrets.cs
+++ b/src/ApiService/ApiService/onefuzzlib/Secrets.cs
@@ -15,7 +15,7 @@ public interface ISecretsOperations {
         return new SecretData<T>(new SecretAddress<T>(address));
     }
 
-    public Task<T?> GetSecretValue<T>(ISecret<T> data);
+    public Task<T?> GetSecretValue<T>(ISecret<T> data) where T : class;
 
     Task<Uri> StoreSecret(ISecret secret);
 
@@ -52,13 +52,19 @@ public class SecretsOperations : ISecretsOperations {
         };
     }
 
-    public async Task<T?> GetSecretValue<T>(ISecret<T> data) {
+    public async Task<T?> GetSecretValue<T>(ISecret<T> data) where T : class {
         switch ((data)) {
             case SecretAddress<T> secretAddress:
                 var secretValue = (await GetSecret(secretAddress.Url))?.Value;
                 if (secretValue is null)
                     return default;
+
+                if (typeof(T) == typeof(string)) {
+                    return secretValue as T;
+                }
+
                 return JsonSerializer.Deserialize<T>(secretValue, EntityConverter.GetJsonSerializerOptions());
+
 
             case SecretValue<T> sValue:
                 return sValue.Value;

--- a/src/ApiService/Tests/OrmTest.cs
+++ b/src/ApiService/Tests/OrmTest.cs
@@ -20,7 +20,7 @@ namespace Tests {
 
         private readonly ConcurrentDictionary<Guid, string> _secrets = new();
 
-        public Task<T?> GetSecretValue<T>(ISecret<T> data) {
+        public Task<T?> GetSecretValue<T>(ISecret<T> data) where T : class {
             switch (data) {
                 case SecretAddress<T> secretAddress:
                     var key = Guid.Parse(secretAddress.Url.Authority);


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_

We were assuming the data stored in keyvault is json but we sometimes store strings as well. When we would attempt to deserialize the string, we'd get an error that it's invalid json.
