### PR TITLE
Change how Git hash is appended to .NET version string for pre-release builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,7 +292,7 @@ jobs:
           # NB: ensure this stays in sync with get-version.sh
           if [[ "$version" =~ '+' ]]; then
             # if it has a suffix, split it into two parts
-            dotnet build -warnaserror --configuration Release /p:VersionPrefix=${version%+*} /p:VersionSuffix=${version#*+}
+            dotnet build -warnaserror --configuration Release /p:VersionPrefix=${version%+*} /p:SourceRevisionId=${version#*+}
           else
             dotnet build -warnaserror --configuration Release /p:VersionPrefix=${version}
           fi


### PR DESCRIPTION
When .NET appends `VersionSuffix` to the `InformationalVersion` string, it appends it with a `-` separator. For consistency with the other version strings (and semver), we want it appended with a `+` separator. This is now supported by using the explicit `SourceRevisionId` property instead of `VersionSuffix`.