### PR TITLE
Shrink published Rust debug info

### DIFF
--- a/src/agent/Cargo.toml
+++ b/src/agent/Cargo.toml
@@ -22,4 +22,9 @@ members = [
 
 [profile.release]
 lto = "thin"
-debug = true
+# Per https://fasterthanli.me/articles/why-is-my-rust-build-so-slow:
+# In Cargo.toml, debug = true actually means debug = 2, and it's usually overkill,
+# unless you're doing the sort of debugging where you need to be able to inspect
+#  the value of local variables for example.
+# If all you're after is a stack trace, debug = 1 is good enough.
+debug = 1

--- a/src/ci/agent.sh
+++ b/src/ci/agent.sh
@@ -49,6 +49,13 @@ echo "Checking dependencies of binaries"
 
 "$script_dir/check-dependencies.sh"
 
+if [ "$(uname)" == 'Linux' ]; then
+    echo "Compressing debug symbols"
+    objcopy --compress-debug-sections target/release/onefuzz-task
+    objcopy --compress-debug-sections target/release/onefuzz-agent
+    objcopy --compress-debug-sections target/release/srcview
+fi
+
 echo "Copying artifacts to $output_dir"
 
 cp target/release/onefuzz-task* "$output_dir"


### PR DESCRIPTION
I noticed these were getting very big and impacting our CI time due to copying huge artifacts. Presumably this would be slowing down copying in the live environment as well.

Two changes have been made:
- Use `debug=1` instead of `debug=true` (equivalent to `debug=2`); this should be sufficient for our needs
- On Linux, compress debug information after building
 
| Binary | Before | with `debug=1` | after compression |
|--|--:|--:|--:|
| onefuzz-agent (Linux) | 170 MB | 83 MB | 30 MB |
| onefuzz-task (Linux) | 284 MB  | 134 MB | 46 MB |
| onefuzz_agent.pdb (Windows) | 89 MB | 42 MB | — |
| onefuzz_task.pdb (Windows) | 150 MB | 63 MB | — |
| onefuzz-deployment.zip | 364 MB | 286 MB | 285 MB |

Overall the compressed `release-artifacts` reduced from 374 → 297 MB.

Build speed improvements (latest build on `main` vs this PR):

| Step | Before | After |
|--|--:|--:|
| agent upload-artifact | 26s/32s/45s | 16s/15s/20s |
| package download-artifact | 1m 57s | 26 s |
| package upload-artifact | 2m 8s | 1m 35s |