### PR TITLE
Remove .debug_pubnames and .debug_pubtypes sections from agent binaries

### DIFF
--- a/src/ci/agent.sh
+++ b/src/ci/agent.sh
@@ -50,6 +50,12 @@ echo "Checking dependencies of binaries"
 "$script_dir/check-dependencies.sh"
 
 if [ "$(uname)" == 'Linux' ]; then
+    echo "Stripping unneeded debug info"
+    # see: https://github.com/benesch/materialize/blob/02cc34cb7c7d9f1b775fe95e1697b797d8fa9b6d/misc/python/mzbuild.py#L166-L183
+    objcopy -R .debug_pubnames -R .debug_pubtypes target/release/onefuzz-task
+    objcopy -R .debug_pubnames -R .debug_pubtypes target/release/onefuzz-agent
+    objcopy -R .debug_pubnames -R .debug_pubtypes target/release/srcview
+
     echo "Compressing debug symbols"
     objcopy --compress-debug-sections target/release/onefuzz-task
     objcopy --compress-debug-sections target/release/onefuzz-agent


### PR DESCRIPTION
This further shaves off the sizes from #3247:

- `onefuzz-agent`: 30 MB → 28 MB
- `onefuzz-task`: 46 MB → 42 MB