### PR TITLE
switch to default HttpCompletion, which is ResponseRead

### DIFF
--- a/src/ApiService/ApiService/HttpClient.cs
+++ b/src/ApiService/ApiService/HttpClient.cs
@@ -34,7 +34,7 @@ public class Request {
             }
         }
 
-        return await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
+        return await _httpClient.SendAsync(request);
     }
 
     public async Task<HttpResponseMessage> Get(Uri url, string? json = null) {


### PR DESCRIPTION
Try this out as an experiment to see if it helps with Webhooks occasionally failing to send messages