### PR TITLE
Increase test timeout

### DIFF
--- a/src/agent/onefuzz/src/monitor/tests.rs
+++ b/src/agent/onefuzz/src/monitor/tests.rs
@@ -9,7 +9,7 @@ use tokio::fs;
 
 use crate::monitor::DirectoryMonitor;
 
-const TEST_TIMEOUT: Duration = Duration::from_millis(200);
+const TEST_TIMEOUT: Duration = Duration::from_millis(1000);
 
 macro_rules! timed_test {
     ($test_name: ident, $future: expr) => {


### PR DESCRIPTION
Increase the test timeout for directory monitor tests as we are seeing this fail fairly often with the ARM64 builds ([see, e.g.](https://github.com/microsoft/onefuzz/actions/runs/5416711609/jobs/9846801082)).