### PR TITLE
UPN changes/fixes

### DIFF
--- a/src/ApiService/ApiService/Functions/Node.cs
+++ b/src/ApiService/ApiService/Functions/Node.cs
@@ -59,7 +59,7 @@ public class Node {
                 _context.NodeMessageOperations.GetMessages(machineId).ToListAsync().AsTask());
 
             var commands = messages.Select(m => m.Message).ToList();
-            return await RequestHandling.Ok(req, NodeToNodeSearchResult(node with { Tasks = tasks, Messages = commands }));
+            return await RequestHandling.Ok(req, NodeToNodeSearchResult(node, tasks, commands));
         }
 
         var nodes = await _context.NodeOperations.SearchStates(
@@ -67,10 +67,10 @@ public class Node {
             poolName: search.PoolName,
             scalesetId: search.ScalesetId).ToListAsync();
 
-        return await RequestHandling.Ok(req, nodes.Select(NodeToNodeSearchResult));
+        return await RequestHandling.Ok(req, nodes.Select(x => NodeToNodeSearchResult(x, null, null)));
     }
 
-    private static NodeSearchResult NodeToNodeSearchResult(Service.Node node) {
+    private static NodeSearchResult NodeToNodeSearchResult(Service.Node node, List<NodeTasks>? tasks, List<NodeCommand>? messages) {
         return new NodeSearchResult(
             PoolId: node.PoolId,
             PoolName: node.PoolName,
@@ -82,7 +82,9 @@ public class Node {
             ScalesetId: node.ScalesetId,
             ReimageRequested: node.ReimageRequested,
             DeleteRequested: node.DeleteRequested,
-            DebugKeepNode: node.DebugKeepNode);
+            DebugKeepNode: node.DebugKeepNode,
+            Tasks: tasks,
+            Messages: messages);
     }
 
     private async Async.Task<HttpResponseData> Patch(HttpRequestData req) {

--- a/src/ApiService/ApiService/OneFuzzTypes/Events.cs
+++ b/src/ApiService/ApiService/OneFuzzTypes/Events.cs
@@ -106,7 +106,7 @@ public class EventTypeProvider : ITypeProvider {
 public record EventTaskStopped(
     Guid JobId,
     Guid TaskId,
-    UserInfo? UserInfo,
+    StoredUserInfo? UserInfo,
     TaskConfig Config
 ) : BaseEvent();
 
@@ -115,7 +115,7 @@ public record EventTaskFailed(
     Guid JobId,
     Guid TaskId,
     Error Error,
-    UserInfo? UserInfo,
+    StoredUserInfo? UserInfo,
     TaskConfig Config
     ) : BaseEvent();
 
@@ -124,7 +124,7 @@ public record EventTaskFailed(
 public record EventJobCreated(
    Guid JobId,
    JobConfig Config,
-   UserInfo? UserInfo
+   StoredUserInfo? UserInfo
    ) : BaseEvent();
 
 
@@ -139,7 +139,7 @@ public record JobTaskStopped(
 public record EventJobStopped(
     Guid JobId,
     JobConfig Config,
-    UserInfo? UserInfo,
+    StoredUserInfo? UserInfo,
     List<JobTaskStopped> TaskInfo
 ) : BaseEvent(), ITruncatable<BaseEvent> {
     public BaseEvent Truncate(int maxLength) {
@@ -155,7 +155,7 @@ public record EventTaskCreated(
     Guid JobId,
     Guid TaskId,
     TaskConfig Config,
-    UserInfo? UserInfo
+    StoredUserInfo? UserInfo
     ) : BaseEvent();
 
 [EventType(EventType.TaskStateUpdated)]
@@ -375,7 +375,7 @@ public record DownloadableEventMessage : EventMessage, ITruncatable<Downloadable
 public record EventMessage(
     Guid EventId,
     EventType EventType,
-    [property: TypeDiscrimnatorAttribute("EventType", typeof(EventTypeProvider))]
+    [property: TypeDiscrimnator("EventType", typeof(EventTypeProvider))]
     [property: JsonConverter(typeof(BaseEventConverter))]
     BaseEvent Event,
     Guid InstanceId,
@@ -401,7 +401,7 @@ public record EventMessage(
 
 public class BaseEventConverter : JsonConverter<BaseEvent> {
     public override BaseEvent? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) {
-        return null;
+        throw new NotSupportedException("BaseEvent cannot be read");
     }
 
     public override void Write(Utf8JsonWriter writer, BaseEvent value, JsonSerializerOptions options) {

--- a/src/ApiService/ApiService/OneFuzzTypes/Model.cs
+++ b/src/ApiService/ApiService/OneFuzzTypes/Model.cs
@@ -39,8 +39,8 @@ public record TaskHeartbeatEntry(
     Guid TaskId,
     Guid? JobId,
     Guid MachineId,
-    HeartbeatData[] Data
-    );
+    HeartbeatData[] Data);
+
 public record NodeHeartbeatEntry(Guid NodeId, HeartbeatData[] Data);
 
 public record NodeCommandStopIfFree();
@@ -50,7 +50,6 @@ public record StopNodeCommand();
 public record StopTaskNodeCommand(Guid TaskId);
 
 public record NodeCommandAddSshKey(string PublicKey);
-
 
 public record NodeCommand
 (
@@ -114,11 +113,7 @@ public record Node
     bool DeleteRequested = false,
     bool DebugKeepNode = false,
     bool Managed = true
-) : StatefulEntityBase<NodeState>(State) {
-
-    public List<NodeTasks>? Tasks { get; set; }
-    public List<NodeCommand>? Messages { get; set; }
-}
+) : StatefulEntityBase<NodeState>(State) { }
 
 
 public record Forward
@@ -286,7 +281,7 @@ public record Task(
     ISecret<Authentication>? Auth = null,
     DateTimeOffset? Heartbeat = null,
     DateTimeOffset? EndTime = null,
-    UserInfo? UserInfo = null) : StatefulEntityBase<TaskState>(State) {
+    StoredUserInfo? UserInfo = null) : StatefulEntityBase<TaskState>(State) {
 }
 
 public record TaskEvent(
@@ -726,7 +721,7 @@ public record Repro(
     Error? Error = null,
     string? Ip = null,
     DateTimeOffset? EndTime = null,
-    UserInfo? UserInfo = null
+    StoredUserInfo? UserInfo = null
 ) : StatefulEntityBase<VmState>(State);
 
 // TODO: Make this >1 and < 7*24 (more than one hour, less than seven days)
@@ -907,12 +902,13 @@ public record Job(
     [PartitionKey][RowKey] Guid JobId,
     JobState State,
     JobConfig Config,
+    StoredUserInfo? UserInfo,
     string? Error = null,
     DateTimeOffset? EndTime = null
-) : StatefulEntityBase<JobState>(State) {
-    public List<JobTaskInfo>? TaskInfo { get; set; }
-    public UserInfo? UserInfo { get; set; }
-}
+) : StatefulEntityBase<JobState>(State) { }
+
+// This is like UserInfo but lacks the UPN:
+public record StoredUserInfo(Guid? ApplicationId, Guid? ObjectId);
 
 public record Nsg(string Name, Region Region) {
     public static Nsg ForRegion(Region region)

--- a/src/ApiService/ApiService/OneFuzzTypes/Responses.cs
+++ b/src/ApiService/ApiService/OneFuzzTypes/Responses.cs
@@ -33,8 +33,9 @@ public record NodeSearchResult(
     ScalesetId? ScalesetId,
     bool ReimageRequested,
     bool DeleteRequested,
-    bool DebugKeepNode
-) : BaseResponse();
+    bool DebugKeepNode,
+    List<NodeTasks>? Tasks,
+    List<NodeCommand>? Messages) : BaseResponse();
 
 public record TaskSearchResult(
      Guid JobId,
@@ -46,7 +47,7 @@ public record TaskSearchResult(
     Authentication? Auth,
     DateTimeOffset? Heartbeat,
     DateTimeOffset? EndTime,
-    UserInfo? UserInfo,
+    StoredUserInfo? UserInfo,
     List<TaskEventSummary> Events,
     List<NodeAssignment> Nodes,
     [property: JsonPropertyName("Timestamp")] // must retain capital T for backcompat
@@ -96,18 +97,20 @@ public record JobResponse(
     string? Error,
     DateTimeOffset? EndTime,
     List<JobTaskInfo>? TaskInfo,
+    StoredUserInfo? UserInfo,
     [property: JsonPropertyName("Timestamp")] // must retain capital T for backcompat
     DateTimeOffset? Timestamp
 // not including UserInfo from Job model
 ) : BaseResponse() {
-    public static JobResponse ForJob(Job j)
+    public static JobResponse ForJob(Job j, List<JobTaskInfo>? taskInfo)
         => new(
             JobId: j.JobId,
             State: j.State,
             Config: j.Config,
             Error: j.Error,
             EndTime: j.EndTime,
-            TaskInfo: j.TaskInfo,
+            TaskInfo: taskInfo,
+            UserInfo: j.UserInfo,
             Timestamp: j.Timestamp
         );
 }
@@ -237,7 +240,7 @@ public record ReproVmResponse(
     Error? Error = null,
     string? Ip = null,
     DateTimeOffset? EndTime = null,
-    UserInfo? UserInfo = null
+    StoredUserInfo? UserInfo = null
 ) : BaseResponse() {
 
     public static ReproVmResponse FromRepro(Repro repro, Authentication? auth) {

--- a/src/ApiService/ApiService/OneFuzzTypes/Webhooks.cs
+++ b/src/ApiService/ApiService/OneFuzzTypes/Webhooks.cs
@@ -39,7 +39,7 @@ public record WebhookMessageEventGrid(
 public record WebhookMessageLog(
     [RowKey] Guid EventId,
     EventType EventType,
-    [property: TypeDiscrimnatorAttribute("EventType", typeof(EventTypeProvider))]
+    [property: TypeDiscrimnator("EventType", typeof(EventTypeProvider))]
     [property: JsonConverter(typeof(BaseEventConverter))]
     BaseEvent Event,
     Guid InstanceId,

--- a/src/ApiService/ApiService/onefuzzlib/ReproOperations.cs
+++ b/src/ApiService/ApiService/onefuzzlib/ReproOperations.cs
@@ -351,7 +351,7 @@ public class ReproOperations : StatefulOrm<Repro, VmState, ReproOperations>, IRe
             Os: task.Os,
             Auth: new SecretAddress<Authentication>(auth),
             EndTime: DateTimeOffset.UtcNow + TimeSpan.FromHours(config.Duration),
-            UserInfo: userInfo);
+            UserInfo: new(ObjectId: userInfo.ObjectId, ApplicationId: userInfo.ApplicationId));
 
         var r = await _context.ReproOperations.Insert(vm);
         if (!r.IsOk) {

--- a/src/ApiService/ApiService/onefuzzlib/notifications/JinjaTemplateAdapter.cs
+++ b/src/ApiService/ApiService/onefuzzlib/notifications/JinjaTemplateAdapter.cs
@@ -194,7 +194,7 @@ public class JinjaTemplateAdapter {
                 new SecretValue<Authentication>(new Authentication("password", "public key", "private key")),
                 DateTimeOffset.UtcNow,
                 DateTimeOffset.UtcNow,
-                new UserInfo(Guid.NewGuid(), Guid.NewGuid(), "upn")
+                new(Guid.NewGuid(), Guid.NewGuid())
             );
 
         var job = new Job(
@@ -207,6 +207,7 @@ public class JinjaTemplateAdapter {
                     duration,
                     "logs"
                 ),
+                null,
                 "some error",
                 DateTimeOffset.UtcNow
             );

--- a/src/ApiService/ApiService/onefuzzlib/orm/EntityConverter.cs
+++ b/src/ApiService/ApiService/onefuzzlib/orm/EntityConverter.cs
@@ -3,6 +3,7 @@ using System.Linq.Expressions;
 using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Threading.Tasks;
 using Azure;
 using Azure.Data.Tables;
 
@@ -12,8 +13,7 @@ public abstract record EntityBase {
     [JsonIgnore]
     public ETag? ETag { get; set; }
 
-    [JsonPropertyName("Timestamp")]
-    // this needs to be serialized with a capital T for backwards compat
+    [JsonIgnore]
     public DateTimeOffset? Timestamp { get; set; }
 
     // https://docs.microsoft.com/en-us/rest/api/storageservices/designing-a-scalable-partitioning-strategy-for-azure-table-storage#yyy
@@ -49,6 +49,7 @@ public class SkipRenameAttribute : Attribute { }
 public class RowKeyAttribute : Attribute { }
 [AttributeUsage(AttributeTargets.Parameter)]
 public class PartitionKeyAttribute : Attribute { }
+
 [AttributeUsage(AttributeTargets.Property)]
 public class TypeDiscrimnatorAttribute : Attribute {
     public string FieldName { get; }
@@ -166,8 +167,7 @@ public class EntityConverter {
         return _cache.GetOrAdd(typeof(T), type => {
             var constructor = type.GetConstructors()[0];
             var parameterInfos = constructor.GetParameters();
-            var parameters =
-            parameterInfos.SelectMany(GetEntityProperties<T>).ToArray();
+            var parameters = parameterInfos.SelectMany(GetEntityProperties<T>).ToArray();
 
             return new EntityInfo(typeof(T), parameters.ToLookup(x => x.name), BuildConstructerFrom(constructor));
         });
@@ -177,6 +177,48 @@ public class EntityConverter {
 
     public static T? FromJsonString<T>(string value) => JsonSerializer.Deserialize<T>(value, _options);
 
+    private async ValueTask<(string, object?)> PropertyToColumnValue(EntityProperty prop, object? value) {
+        if (value == null) {
+            return (prop.columnName, null);
+        }
+
+        if (prop.kind == EntityPropertyKind.PartitionKey || prop.kind == EntityPropertyKind.RowKey) {
+            return (prop.columnName, value?.ToString());
+        }
+
+        if (prop.type == typeof(Guid) || prop.type == typeof(Guid?) || prop.type == typeof(Uri)) {
+            return (prop.columnName, value?.ToString());
+        }
+
+        if (prop.type == typeof(bool)
+             || prop.type == typeof(bool?)
+             || prop.type == typeof(string)
+             || prop.type == typeof(DateTime)
+             || prop.type == typeof(DateTime?)
+             || prop.type == typeof(DateTimeOffset)
+             || prop.type == typeof(DateTimeOffset?)
+             || prop.type == typeof(int)
+             || prop.type == typeof(int?)
+             || prop.type == typeof(long)
+             || prop.type == typeof(long?)
+             || prop.type == typeof(double)
+             || prop.type == typeof(double?)) {
+            return (prop.columnName, value);
+        }
+
+        // if prop.type is a SecretData
+        if (typeof(ISecret).IsAssignableFrom(prop.type)) {
+            var secret = (ISecret)value;
+            if (!secret.IsHIddden) {
+                var kv = await _secretsOperations.StoreSecret(secret);
+                value = new SecretAddress<object>(kv);
+            }
+        }
+
+        var serialized = JsonSerializer.Serialize(value, _options);
+        return (prop.columnName, serialized.Trim('"'));
+    }
+
     public async Async.Task<TableEntity> ToTableEntity<T>(T typedEntity) where T : EntityBase {
         if (typedEntity == null) {
             throw new ArgumentNullException(nameof(typedEntity));
@@ -185,51 +227,15 @@ public class EntityConverter {
         var type = typeof(T);
 
         var entityInfo = GetEntityInfo<T>();
-        Dictionary<string, object?> columnValues = await entityInfo.properties.SelectMany(x => x).ToAsyncEnumerable().SelectAwait(async prop => {
+
+        var columnValues = new Dictionary<string, object?>();
+        foreach (var prop in entityInfo.properties.SelectMany(x => x)) {
             var value = entityInfo.type.GetProperty(prop.name)?.GetValue(typedEntity);
-            if (value == null) {
-                return (prop.columnName, value: (object?)null);
-            }
-            if (prop.kind == EntityPropertyKind.PartitionKey || prop.kind == EntityPropertyKind.RowKey) {
-                return (prop.columnName, value?.ToString());
-            }
-            if (prop.type == typeof(Guid) || prop.type == typeof(Guid?) || prop.type == typeof(Uri)) {
-                return (prop.columnName, value?.ToString());
-            }
-            if (prop.type == typeof(bool)
-                 || prop.type == typeof(bool?)
-                 || prop.type == typeof(string)
-                 || prop.type == typeof(DateTime)
-                 || prop.type == typeof(DateTime?)
-                 || prop.type == typeof(DateTimeOffset)
-                 || prop.type == typeof(DateTimeOffset?)
-                 || prop.type == typeof(int)
-                 || prop.type == typeof(int?)
-                 || prop.type == typeof(long)
-                 || prop.type == typeof(long?)
-                 || prop.type == typeof(double)
-                 || prop.type == typeof(double?)
-
-             ) {
-                return (prop.columnName, value);
-            }
-
-            // if prop.type is a SecretData
-            if (typeof(ISecret).IsAssignableFrom(prop.type)) {
-                var secret = (ISecret)value;
-                if (!secret.IsHIddden) {
-                    var kv = await _secretsOperations.StoreSecret(secret);
-                    value = new SecretAddress<object>(kv);
-                }
-            }
-
-            var serialized = JsonSerializer.Serialize(value, _options);
-            return (prop.columnName, serialized.Trim('"'));
-
-        }).ToDictionaryAsync(x => x.columnName, x => x.value);
+            var (columnName, columnValue) = await PropertyToColumnValue(prop, value);
+            columnValues.Add(columnName, columnValue);
+        }
 
         var tableEntity = new TableEntity(columnValues);
-
         if (typedEntity.ETag.HasValue) {
             tableEntity.ETag = typedEntity.ETag.Value;
         }

--- a/src/ApiService/FunctionalTests/1f-api/ApiClient.cs
+++ b/src/ApiService/FunctionalTests/1f-api/ApiClient.cs
@@ -1,7 +1,5 @@
 ﻿namespace FunctionalTests {
     sealed class ApiClient {
-        static Uri endpoint = new Uri(System.Environment.GetEnvironmentVariable("ONEFUZZ_ENDPOINT") ?? "http://localhost:7071");
-
         static Microsoft.Morse.AuthenticationConfig authConfig =
                 new Microsoft.Morse.AuthenticationConfig(
                     ClientId: System.Environment.GetEnvironmentVariable("ONEFUZZ_CLIENT_ID")!,
@@ -14,6 +12,6 @@
 
         public static Microsoft.OneFuzz.Service.Request Request => request;
 
-        public static Uri Endpoint => endpoint;
+        public static Uri Endpoint { get; } = new(Environment.GetEnvironmentVariable("ONEFUZZ_ENDPOINT") ?? "http://localhost:7071");
     }
 }

--- a/src/ApiService/FunctionalTests/FunctionalTests.csproj
+++ b/src/ApiService/FunctionalTests/FunctionalTests.csproj
@@ -19,12 +19,12 @@
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Security.Cryptography.Pkcs" Version="7.0.2" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.2.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/ApiService/FunctionalTests/packages.lock.json
+++ b/src/ApiService/FunctionalTests/packages.lock.json
@@ -4,9 +4,9 @@
     "net7.0": {
       "coverlet.collector": {
         "type": "Direct",
-        "requested": "[3.2.0, )",
-        "resolved": "3.2.0",
-        "contentHash": "xjY8xBigSeWIYs4I7DgUHqSNoGqnHi7Fv7/7RZD02rvZyG3hlsjnQKiVKVWKgr9kRKgmV+dEfu8KScvysiC0Wg=="
+        "requested": "[6.0.0, )",
+        "resolved": "6.0.0",
+        "contentHash": "tW3lsNS+dAEII6YGUX/VMoJjBS1QvsxqJeqLaJXub08y1FSjasFPtQ4UBUsudE9PNrzLjooClMsPtY2cZLdXpQ=="
       },
       "FluentAssertions": {
         "type": "Direct",
@@ -90,20 +90,20 @@
       },
       "xunit": {
         "type": "Direct",
-        "requested": "[2.4.2, )",
-        "resolved": "2.4.2",
-        "contentHash": "6Mj73Ont3zj2CJuoykVJfE0ZmRwn7C+pTuRP8c4bnaaTFjwNG6tGe0prJ1yIbMe9AHrpDys63ctWacSsFJWK/w==",
+        "requested": "[2.5.0, )",
+        "resolved": "2.5.0",
+        "contentHash": "f2V5wuAdoaq0mRTt9UBmPbVex9HcwFYn+y7WaKUz5Xpakcrv7lhtQWBJUWNY4N3Z+o+atDBLyAALM1QWx04C6Q==",
         "dependencies": {
-          "xunit.analyzers": "1.0.0",
-          "xunit.assert": "2.4.2",
-          "xunit.core": "[2.4.2]"
+          "xunit.analyzers": "1.2.0",
+          "xunit.assert": "2.5.0",
+          "xunit.core": "[2.5.0]"
         }
       },
       "xunit.runner.visualstudio": {
         "type": "Direct",
-        "requested": "[2.4.5, )",
-        "resolved": "2.4.5",
-        "contentHash": "OwHamvBdUKgqsXfBzWiCW/O98BTx81UKzx2bieIOQI7CZFE5NEQZGi8PBQGIKawDW96xeRffiNf20SjfC0x9hw=="
+        "requested": "[2.5.0, )",
+        "resolved": "2.5.0",
+        "contentHash": "+Gp9vuC2431yPyKB15YrOTxCuEAErBQUTIs6CquumX1F073UaPHGW0VE/XVJLMh9W4sXdz3TBkcHdFWZrRn2Hw=="
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
@@ -1030,30 +1030,30 @@
       },
       "xunit.analyzers": {
         "type": "Transitive",
-        "resolved": "1.0.0",
-        "contentHash": "BeO8hEgs/c8Ls2647fPfieMngncvf0D0xYNDfIO59MolxtCtVjFRd6SRc+7tj8VMqkVOuJcnc9eh4ngI2cAmLQ=="
+        "resolved": "1.2.0",
+        "contentHash": "d3dehV/DASLRlR8stWQmbPPjfYC2tct50Evav+OlsJMkfFqkhYvzO1k0s81lk0px8O0knZU/FqC8SqbXOtn+hw=="
       },
       "xunit.assert": {
         "type": "Transitive",
-        "resolved": "2.4.2",
-        "contentHash": "pxJISOFjn2XTTi1mcDCkRZrTFb9OtRRCtx2kZFNF51GdReLr1ls2rnyxvAS4JO247K3aNtflvh5Q0346K5BROA==",
+        "resolved": "2.5.0",
+        "contentHash": "wN84pKX5jzfpgJ0bB6arrCA/oelBeYLCpnQ9Wj5xGEVPydKzVSDY5tEatFLHE/rO0+0RC+I4H5igGE118jRh1w==",
         "dependencies": {
           "NETStandard.Library": "1.6.1"
         }
       },
       "xunit.core": {
         "type": "Transitive",
-        "resolved": "2.4.2",
-        "contentHash": "KB4yGCxNqIVyekhJLXtKSEq6BaXVp/JO3mbGVE1hxypZTLEe7h+sTbAhpA+yZW2dPtXTuiW+C1B2oxxHEkrmOw==",
+        "resolved": "2.5.0",
+        "contentHash": "dnV0Mn2s1C0y2m33AylQyMkEyhBQsL4R0302kwSGiEGuY3JwzEmhTa9pnghyMRPliYSs4fXfkEAP+5bKXryGFg==",
         "dependencies": {
-          "xunit.extensibility.core": "[2.4.2]",
-          "xunit.extensibility.execution": "[2.4.2]"
+          "xunit.extensibility.core": "[2.5.0]",
+          "xunit.extensibility.execution": "[2.5.0]"
         }
       },
       "xunit.extensibility.core": {
         "type": "Transitive",
-        "resolved": "2.4.2",
-        "contentHash": "W1BoXTIN1C6kpVSMw25huSet25ky6IAQUNovu3zGOGN/jWnbgSoTyCrlIhmXSg0tH5nEf8q7h3OjNHOjyu5PfA==",
+        "resolved": "2.5.0",
+        "contentHash": "xRm6NIV3i7I+LkjsAJ91Xz2fxJm/oMEi2CYq1G5HlGTgcK1Zo2wNbLO6nKX1VG5FZzXibSdoLwr/MofVvh3mFA==",
         "dependencies": {
           "NETStandard.Library": "1.6.1",
           "xunit.abstractions": "2.0.3"
@@ -1061,11 +1061,11 @@
       },
       "xunit.extensibility.execution": {
         "type": "Transitive",
-        "resolved": "2.4.2",
-        "contentHash": "CZmgcKkwpyo8FlupZdWpJCryrAOWLh1FBPG6gmVZuPQkGQsim/oL4PcP4nfrC2hHgXUFtluvaJ0Sp9PQKUMNpg==",
+        "resolved": "2.5.0",
+        "contentHash": "7+v2Bvp+1ew1iMGQVb1glICi8jcNdHbRUX6Ru0dmJBViGdjiS7kyqcX2VxleQhFbKNi+WF0an7/TeTXD283RlQ==",
         "dependencies": {
           "NETStandard.Library": "1.6.1",
-          "xunit.extensibility.core": "[2.4.2]"
+          "xunit.extensibility.core": "[2.5.0]"
         }
       }
     }

--- a/src/ApiService/IntegrationTests/AdoTests.cs
+++ b/src/ApiService/IntegrationTests/AdoTests.cs
@@ -60,7 +60,7 @@ public abstract class AdoTestBase : FunctionTestBase {
                 string.Empty,
                 new Report(null, null, string.Empty, string.Empty, string.Empty, new(), string.Empty, string.Empty, null, Guid.Empty, Guid.Empty, null, null, null, null, null, null, null, null, null, null, null, null),
                 new Task(Guid.Empty, Guid.Empty, TaskState.Init, Os.Windows, new TaskConfig(Guid.Empty, null, new TaskDetails(TaskType.LibfuzzerFuzz, 1))),
-                new Job(Guid.Empty, JobState.Init, new JobConfig(string.Empty, string.Empty, string.Empty, 1, null)),
+                new Job(Guid.Empty, JobState.Init, new JobConfig(string.Empty, string.Empty, string.Empty, 1, null), null),
                 new Uri("https://example.com"),
                 new Uri("https://example.com"),
                 new Uri("https://example.com"),

--- a/src/ApiService/IntegrationTests/EventsTests.cs
+++ b/src/ApiService/IntegrationTests/EventsTests.cs
@@ -89,11 +89,9 @@ public abstract class EventsTestBase : FunctionTestBase {
         await Context.Events.SendEvent(new EventTaskStopped(
             jobId,
             taskId,
-            new UserInfo(
+            new StoredUserInfo(
                 appId,
-                objectId,
-                upn
-            ),
+                objectId),
             taskConfig
         ));
 

--- a/src/ApiService/IntegrationTests/IntegrationTests.csproj
+++ b/src/ApiService/IntegrationTests/IntegrationTests.csproj
@@ -9,12 +9,12 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="System.Security.Cryptography.Pkcs" Version="7.0.2" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.2.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/ApiService/IntegrationTests/JobsTests.cs
+++ b/src/ApiService/IntegrationTests/JobsTests.cs
@@ -44,7 +44,7 @@ public abstract class JobsTestBase : FunctionTestBase {
     [Fact]
     public async Async.Task Delete_ExistingJob_SetsStoppingState() {
         await Context.InsertAll(
-            new Job(_jobId, JobState.Enabled, _config));
+            new Job(_jobId, JobState.Enabled, _config, null));
 
         var func = new Jobs(Context, LoggerProvider.CreateLogger<Jobs>());
 
@@ -63,7 +63,7 @@ public abstract class JobsTestBase : FunctionTestBase {
     [Fact]
     public async Async.Task Delete_ExistingStoppedJob_DoesNotSetStoppingState() {
         await Context.InsertAll(
-            new Job(_jobId, JobState.Stopped, _config));
+            new Job(_jobId, JobState.Stopped, _config, null));
 
         var func = new Jobs(Context, LoggerProvider.CreateLogger<Jobs>());
 
@@ -83,7 +83,7 @@ public abstract class JobsTestBase : FunctionTestBase {
     [Fact]
     public async Async.Task Get_CanFindSpecificJob() {
         await Context.InsertAll(
-            new Job(_jobId, JobState.Stopped, _config));
+            new Job(_jobId, JobState.Stopped, _config, null));
 
         var func = new Jobs(Context, LoggerProvider.CreateLogger<Jobs>());
 
@@ -96,13 +96,32 @@ public abstract class JobsTestBase : FunctionTestBase {
         Assert.Equal(JobState.Stopped, response.State);
     }
 
+
+    [Fact]
+    public async Async.Task Get_ReturnsUserData() {
+        var userInfo = new StoredUserInfo(Guid.NewGuid(), Guid.NewGuid());
+
+        await Context.InsertAll(
+            new Job(_jobId, JobState.Stopped, _config, userInfo));
+
+        var func = new Jobs(Context, LoggerProvider.CreateLogger<Jobs>());
+
+        var ctx = new TestFunctionContext();
+        var result = await func.Run(TestHttpRequestData.FromJson("GET", new JobSearch(JobId: _jobId)), ctx);
+        Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+
+        var response = BodyAs<JobResponse>(result);
+        Assert.Equal(_jobId, response.JobId);
+        Assert.Equal(userInfo, response.UserInfo);
+    }
+
     [Fact]
     public async Async.Task Get_CanFindJobsInState() {
         await Context.InsertAll(
-            new Job(Guid.NewGuid(), JobState.Init, _config),
-            new Job(Guid.NewGuid(), JobState.Stopping, _config),
-            new Job(Guid.NewGuid(), JobState.Enabled, _config),
-            new Job(Guid.NewGuid(), JobState.Stopped, _config));
+            new Job(Guid.NewGuid(), JobState.Init, _config, null),
+            new Job(Guid.NewGuid(), JobState.Stopping, _config, null),
+            new Job(Guid.NewGuid(), JobState.Enabled, _config, null),
+            new Job(Guid.NewGuid(), JobState.Stopped, _config, null));
 
         var func = new Jobs(Context, LoggerProvider.CreateLogger<Jobs>());
 
@@ -118,10 +137,10 @@ public abstract class JobsTestBase : FunctionTestBase {
     [Fact]
     public async Async.Task Get_CanFindMultipleJobsInState() {
         await Context.InsertAll(
-            new Job(Guid.NewGuid(), JobState.Init, _config),
-            new Job(Guid.NewGuid(), JobState.Stopping, _config),
-            new Job(Guid.NewGuid(), JobState.Enabled, _config),
-            new Job(Guid.NewGuid(), JobState.Stopped, _config));
+            new Job(Guid.NewGuid(), JobState.Init, _config, null),
+            new Job(Guid.NewGuid(), JobState.Stopping, _config, null),
+            new Job(Guid.NewGuid(), JobState.Enabled, _config, null),
+            new Job(Guid.NewGuid(), JobState.Stopped, _config, null));
 
         var func = new Jobs(Context, LoggerProvider.CreateLogger<Jobs>());
 

--- a/src/ApiService/IntegrationTests/packages.lock.json
+++ b/src/ApiService/IntegrationTests/packages.lock.json
@@ -4,9 +4,9 @@
     "net7.0": {
       "coverlet.collector": {
         "type": "Direct",
-        "requested": "[3.2.0, )",
-        "resolved": "3.2.0",
-        "contentHash": "xjY8xBigSeWIYs4I7DgUHqSNoGqnHi7Fv7/7RZD02rvZyG3hlsjnQKiVKVWKgr9kRKgmV+dEfu8KScvysiC0Wg=="
+        "requested": "[6.0.0, )",
+        "resolved": "6.0.0",
+        "contentHash": "tW3lsNS+dAEII6YGUX/VMoJjBS1QvsxqJeqLaJXub08y1FSjasFPtQ4UBUsudE9PNrzLjooClMsPtY2cZLdXpQ=="
       },
       "FluentAssertions": {
         "type": "Direct",
@@ -47,20 +47,20 @@
       },
       "xunit": {
         "type": "Direct",
-        "requested": "[2.4.2, )",
-        "resolved": "2.4.2",
-        "contentHash": "6Mj73Ont3zj2CJuoykVJfE0ZmRwn7C+pTuRP8c4bnaaTFjwNG6tGe0prJ1yIbMe9AHrpDys63ctWacSsFJWK/w==",
+        "requested": "[2.5.0, )",
+        "resolved": "2.5.0",
+        "contentHash": "f2V5wuAdoaq0mRTt9UBmPbVex9HcwFYn+y7WaKUz5Xpakcrv7lhtQWBJUWNY4N3Z+o+atDBLyAALM1QWx04C6Q==",
         "dependencies": {
-          "xunit.analyzers": "1.0.0",
-          "xunit.assert": "2.4.2",
-          "xunit.core": "[2.4.2]"
+          "xunit.analyzers": "1.2.0",
+          "xunit.assert": "2.5.0",
+          "xunit.core": "[2.5.0]"
         }
       },
       "xunit.runner.visualstudio": {
         "type": "Direct",
-        "requested": "[2.4.5, )",
-        "resolved": "2.4.5",
-        "contentHash": "OwHamvBdUKgqsXfBzWiCW/O98BTx81UKzx2bieIOQI7CZFE5NEQZGi8PBQGIKawDW96xeRffiNf20SjfC0x9hw=="
+        "requested": "[2.5.0, )",
+        "resolved": "2.5.0",
+        "contentHash": "+Gp9vuC2431yPyKB15YrOTxCuEAErBQUTIs6CquumX1F073UaPHGW0VE/XVJLMh9W4sXdz3TBkcHdFWZrRn2Hw=="
       },
       "Azure.Core": {
         "type": "Transitive",
@@ -2460,30 +2460,30 @@
       },
       "xunit.analyzers": {
         "type": "Transitive",
-        "resolved": "1.0.0",
-        "contentHash": "BeO8hEgs/c8Ls2647fPfieMngncvf0D0xYNDfIO59MolxtCtVjFRd6SRc+7tj8VMqkVOuJcnc9eh4ngI2cAmLQ=="
+        "resolved": "1.2.0",
+        "contentHash": "d3dehV/DASLRlR8stWQmbPPjfYC2tct50Evav+OlsJMkfFqkhYvzO1k0s81lk0px8O0knZU/FqC8SqbXOtn+hw=="
       },
       "xunit.assert": {
         "type": "Transitive",
-        "resolved": "2.4.2",
-        "contentHash": "pxJISOFjn2XTTi1mcDCkRZrTFb9OtRRCtx2kZFNF51GdReLr1ls2rnyxvAS4JO247K3aNtflvh5Q0346K5BROA==",
+        "resolved": "2.5.0",
+        "contentHash": "wN84pKX5jzfpgJ0bB6arrCA/oelBeYLCpnQ9Wj5xGEVPydKzVSDY5tEatFLHE/rO0+0RC+I4H5igGE118jRh1w==",
         "dependencies": {
           "NETStandard.Library": "1.6.1"
         }
       },
       "xunit.core": {
         "type": "Transitive",
-        "resolved": "2.4.2",
-        "contentHash": "KB4yGCxNqIVyekhJLXtKSEq6BaXVp/JO3mbGVE1hxypZTLEe7h+sTbAhpA+yZW2dPtXTuiW+C1B2oxxHEkrmOw==",
+        "resolved": "2.5.0",
+        "contentHash": "dnV0Mn2s1C0y2m33AylQyMkEyhBQsL4R0302kwSGiEGuY3JwzEmhTa9pnghyMRPliYSs4fXfkEAP+5bKXryGFg==",
         "dependencies": {
-          "xunit.extensibility.core": "[2.4.2]",
-          "xunit.extensibility.execution": "[2.4.2]"
+          "xunit.extensibility.core": "[2.5.0]",
+          "xunit.extensibility.execution": "[2.5.0]"
         }
       },
       "xunit.extensibility.core": {
         "type": "Transitive",
-        "resolved": "2.4.2",
-        "contentHash": "W1BoXTIN1C6kpVSMw25huSet25ky6IAQUNovu3zGOGN/jWnbgSoTyCrlIhmXSg0tH5nEf8q7h3OjNHOjyu5PfA==",
+        "resolved": "2.5.0",
+        "contentHash": "xRm6NIV3i7I+LkjsAJ91Xz2fxJm/oMEi2CYq1G5HlGTgcK1Zo2wNbLO6nKX1VG5FZzXibSdoLwr/MofVvh3mFA==",
         "dependencies": {
           "NETStandard.Library": "1.6.1",
           "xunit.abstractions": "2.0.3"
@@ -2491,11 +2491,11 @@
       },
       "xunit.extensibility.execution": {
         "type": "Transitive",
-        "resolved": "2.4.2",
-        "contentHash": "CZmgcKkwpyo8FlupZdWpJCryrAOWLh1FBPG6gmVZuPQkGQsim/oL4PcP4nfrC2hHgXUFtluvaJ0Sp9PQKUMNpg==",
+        "resolved": "2.5.0",
+        "contentHash": "7+v2Bvp+1ew1iMGQVb1glICi8jcNdHbRUX6Ru0dmJBViGdjiS7kyqcX2VxleQhFbKNi+WF0an7/TeTXD283RlQ==",
         "dependencies": {
           "NETStandard.Library": "1.6.1",
-          "xunit.extensibility.core": "[2.4.2]"
+          "xunit.extensibility.core": "[2.5.0]"
         }
       },
       "apiservice": {
@@ -2557,7 +2557,7 @@
           "Microsoft.NET.Test.Sdk": "[17.6.2, )",
           "Moq": "[4.18.4, )",
           "System.Security.Cryptography.Pkcs": "[7.0.2, )",
-          "xunit": "[2.4.1, )"
+          "xunit": "[2.5.0, )"
         }
       }
     }

--- a/src/ApiService/Tests/OrmTest.cs
+++ b/src/ApiService/Tests/OrmTest.cs
@@ -466,7 +466,7 @@ namespace Tests {
         sealed record NestedEntity(
             [PartitionKey] int Id,
             [RowKey] string TheName,
-            [property: TypeDiscrimnatorAttribute("EventType", typeof(EventTypeProvider))]
+            [property: TypeDiscrimnator("EventType", typeof(EventTypeProvider))]
             [property: JsonConverter(typeof(BaseEventConverter))]
             Nested? EventType
         ) : EntityBase();

--- a/src/ApiService/Tests/TemplateTests.cs
+++ b/src/ApiService/Tests/TemplateTests.cs
@@ -223,8 +223,7 @@ public class TemplateTests {
                 "Test build",
                 1,
                 null
-            )
-        );
+            ),
+            null);
     }
-
 }

--- a/src/ApiService/Tests/Tests.csproj
+++ b/src/ApiService/Tests/Tests.csproj
@@ -10,13 +10,13 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="System.Security.Cryptography.Pkcs" Version="7.0.2" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="FluentAssertions" Version="6.11.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.2.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/ApiService/Tests/packages.lock.json
+++ b/src/ApiService/Tests/packages.lock.json
@@ -4,9 +4,9 @@
     "net7.0": {
       "coverlet.collector": {
         "type": "Direct",
-        "requested": "[3.2.0, )",
-        "resolved": "3.2.0",
-        "contentHash": "xjY8xBigSeWIYs4I7DgUHqSNoGqnHi7Fv7/7RZD02rvZyG3hlsjnQKiVKVWKgr9kRKgmV+dEfu8KScvysiC0Wg=="
+        "requested": "[6.0.0, )",
+        "resolved": "6.0.0",
+        "contentHash": "tW3lsNS+dAEII6YGUX/VMoJjBS1QvsxqJeqLaJXub08y1FSjasFPtQ4UBUsudE9PNrzLjooClMsPtY2cZLdXpQ=="
       },
       "FluentAssertions": {
         "type": "Direct",
@@ -66,20 +66,20 @@
       },
       "xunit": {
         "type": "Direct",
-        "requested": "[2.4.1, )",
-        "resolved": "2.4.1",
-        "contentHash": "XNR3Yz9QTtec16O0aKcO6+baVNpXmOnPUxDkCY97J+8krUYxPvXT1szYYEUdKk4sB8GOI2YbAjRIOm8ZnXRfzQ==",
+        "requested": "[2.5.0, )",
+        "resolved": "2.5.0",
+        "contentHash": "f2V5wuAdoaq0mRTt9UBmPbVex9HcwFYn+y7WaKUz5Xpakcrv7lhtQWBJUWNY4N3Z+o+atDBLyAALM1QWx04C6Q==",
         "dependencies": {
-          "xunit.analyzers": "0.10.0",
-          "xunit.assert": "[2.4.1]",
-          "xunit.core": "[2.4.1]"
+          "xunit.analyzers": "1.2.0",
+          "xunit.assert": "2.5.0",
+          "xunit.core": "[2.5.0]"
         }
       },
       "xunit.runner.visualstudio": {
         "type": "Direct",
-        "requested": "[2.4.3, )",
-        "resolved": "2.4.3",
-        "contentHash": "kZZSmOmKA8OBlAJaquPXnJJLM9RwQ27H7BMVqfMLUcTi9xHinWGJiWksa3D4NEtz0wZ/nxd2mogObvBgJKCRhQ=="
+        "requested": "[2.5.0, )",
+        "resolved": "2.5.0",
+        "contentHash": "+Gp9vuC2431yPyKB15YrOTxCuEAErBQUTIs6CquumX1F073UaPHGW0VE/XVJLMh9W4sXdz3TBkcHdFWZrRn2Hw=="
       },
       "Azure.Core": {
         "type": "Transitive",
@@ -2462,30 +2462,30 @@
       },
       "xunit.analyzers": {
         "type": "Transitive",
-        "resolved": "0.10.0",
-        "contentHash": "4/IDFCJfIeg6bix9apmUtIMwvOsiwqdEexeO/R2D4GReIGPLIRODTpId/l4LRSrAJk9lEO3Zx1H0Zx6uohJDNg=="
+        "resolved": "1.2.0",
+        "contentHash": "d3dehV/DASLRlR8stWQmbPPjfYC2tct50Evav+OlsJMkfFqkhYvzO1k0s81lk0px8O0knZU/FqC8SqbXOtn+hw=="
       },
       "xunit.assert": {
         "type": "Transitive",
-        "resolved": "2.4.1",
-        "contentHash": "O/Oe0BS5RmSsM+LQOb041TzuPo5MdH2Rov+qXGS37X+KFG1Hxz7kopYklM5+1Y+tRGeXrOx5+Xne1RuqLFQoyQ==",
+        "resolved": "2.5.0",
+        "contentHash": "wN84pKX5jzfpgJ0bB6arrCA/oelBeYLCpnQ9Wj5xGEVPydKzVSDY5tEatFLHE/rO0+0RC+I4H5igGE118jRh1w==",
         "dependencies": {
           "NETStandard.Library": "1.6.1"
         }
       },
       "xunit.core": {
         "type": "Transitive",
-        "resolved": "2.4.1",
-        "contentHash": "Zsj5OMU6JasNGERXZy8s72+pcheG6Q15atS5XpZXqAtULuyQiQ6XNnUsp1gyfC6WgqScqMvySiEHmHcOG6Eg0Q==",
+        "resolved": "2.5.0",
+        "contentHash": "dnV0Mn2s1C0y2m33AylQyMkEyhBQsL4R0302kwSGiEGuY3JwzEmhTa9pnghyMRPliYSs4fXfkEAP+5bKXryGFg==",
         "dependencies": {
-          "xunit.extensibility.core": "[2.4.1]",
-          "xunit.extensibility.execution": "[2.4.1]"
+          "xunit.extensibility.core": "[2.5.0]",
+          "xunit.extensibility.execution": "[2.5.0]"
         }
       },
       "xunit.extensibility.core": {
         "type": "Transitive",
-        "resolved": "2.4.1",
-        "contentHash": "yKZKm/8QNZnBnGZFD9SewkllHBiK0DThybQD/G4PiAmQjKtEZyHi6ET70QPU9KtSMJGRYS6Syk7EyR2EVDU4Kg==",
+        "resolved": "2.5.0",
+        "contentHash": "xRm6NIV3i7I+LkjsAJ91Xz2fxJm/oMEi2CYq1G5HlGTgcK1Zo2wNbLO6nKX1VG5FZzXibSdoLwr/MofVvh3mFA==",
         "dependencies": {
           "NETStandard.Library": "1.6.1",
           "xunit.abstractions": "2.0.3"
@@ -2493,11 +2493,11 @@
       },
       "xunit.extensibility.execution": {
         "type": "Transitive",
-        "resolved": "2.4.1",
-        "contentHash": "7e/1jqBpcb7frLkB6XDrHCGXAbKN4Rtdb88epYxCSRQuZDRW8UtTfdTEVpdTl8s4T56e07hOBVd4G0OdCxIY2A==",
+        "resolved": "2.5.0",
+        "contentHash": "7+v2Bvp+1ew1iMGQVb1glICi8jcNdHbRUX6Ru0dmJBViGdjiS7kyqcX2VxleQhFbKNi+WF0an7/TeTXD283RlQ==",
         "dependencies": {
           "NETStandard.Library": "1.6.1",
-          "xunit.extensibility.core": "[2.4.1]"
+          "xunit.extensibility.core": "[2.5.0]"
         }
       },
       "apiservice": {


### PR DESCRIPTION
Starts to address #3158.

Rather than storing the UPN and then removing it later, do not store it in the first place.

I found one problem while working on this which was that `UserInfo` was not actually stored on `Job`, so address that as well. This was because properties which are not constructor parameters are not stored by the ORM, so I've also removed other examples from `Task` and `Node` and have them only on the response types.

---

Also started to simplify the ORM roundtripping tests; remove the custom equality comparison and instead simply compare JSON-serialized values. Rely on the FsCheck automatic generation of values where it works, rather than writing a custom Arbitrary which does the same thing.