### PR TITLE
Cache FindContainer

### DIFF
--- a/src/ApiService/ApiService/Functions/Containers.cs
+++ b/src/ApiService/ApiService/Functions/Containers.cs
@@ -41,7 +41,7 @@ public class ContainersFunction {
                     req,
                     Error.Create(
                         ErrorCode.INVALID_REQUEST,
-                        "invalid container"),
+                        $"invalid container '{get.Name}'"),
                     context: get.Name.String);
             }
 
@@ -75,13 +75,7 @@ public class ContainersFunction {
 
         var delete = request.OkV;
         _logger.LogInformation("deleting {ContainerName}", delete.Name);
-        var container = await _context.Containers.FindContainer(delete.Name, StorageType.Corpus);
-
-        var deleted = false;
-        if (container is not null) {
-            deleted = await container.DeleteIfExistsAsync();
-        }
-
+        var deleted = await _context.Containers.DeleteContainerIfExists(delete.Name, StorageType.Corpus);
         return await RequestHandling.Ok(req, deleted);
     }
 

--- a/src/ApiService/ApiService/OneFuzzTypes/Model.cs
+++ b/src/ApiService/ApiService/OneFuzzTypes/Model.cs
@@ -173,7 +173,7 @@ public record Error(ErrorCode Code, List<string>? Errors) {
         => new(code, errors.ToList());
 
     public sealed override string ToString() {
-        var errorsString = Errors != null ? string.Concat("; ", Errors) : string.Empty;
+        var errorsString = Errors != null ? string.Join("; ", Errors) : string.Empty;
         return $"Error {{ Code = {Code}, Errors = {errorsString} }}";
     }
 };

--- a/src/ApiService/ApiService/OneFuzzTypes/Model.cs
+++ b/src/ApiService/ApiService/OneFuzzTypes/Model.cs
@@ -767,6 +767,11 @@ public record ClientCredentials
     string ClientSecret
 );
 
+public record ContainerInformation(
+    [PartitionKey] StorageType Type,
+    [RowKey] Container Name,
+    string ResourceId // full ARM resource ID for the container
+) : EntityBase;
 
 public record AgentConfig(
     ClientCredentials? ClientCredentials,

--- a/src/ApiService/ApiService/onefuzzlib/Containers.cs
+++ b/src/ApiService/ApiService/onefuzzlib/Containers.cs
@@ -217,7 +217,7 @@ public class Containers : Orm<ContainerInformation>, IContainers {
             return null;
         }
 
-        return await _storage.GetBlobContainerClientForResource(new ResourceIdentifier(containerInfo.ResourceId));
+        return await _storage.GetBlobContainerClientForContainerResource(new ResourceIdentifier(containerInfo.ResourceId));
     }
 
     public async Async.Task<bool> DeleteContainerIfExists(Container container, StorageType storageType) {

--- a/src/ApiService/ApiService/onefuzzlib/Containers.cs
+++ b/src/ApiService/ApiService/onefuzzlib/Containers.cs
@@ -1,4 +1,4 @@
-using System.IO;
+﻿using System.IO;
 using System.IO.Compression;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/ApiService/ApiService/onefuzzlib/Containers.cs
+++ b/src/ApiService/ApiService/onefuzzlib/Containers.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using System.IO.Compression;
 using System.Threading;
 using System.Threading.Tasks;
@@ -164,7 +164,7 @@ public class Containers : Orm<ContainerInformation>, IContainers {
         return null;
     }
 
-    private record ContainerKey(StorageType storageType, Container container);
+    private sealed record ContainerKey(StorageType storageType, Container container);
     public async Async.Task<BlobContainerClient?> FindContainer(Container container, StorageType storageType) {
         var containerInfo = await _cache.GetOrCreateAsync(
             new ContainerKey(storageType, container),

--- a/src/ApiService/ApiService/onefuzzlib/Containers.cs
+++ b/src/ApiService/ApiService/onefuzzlib/Containers.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using ApiService.OneFuzzLib.Orm;
 using Azure;
 using Azure.Core;
+using Azure.ResourceManager.Storage;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 using Azure.Storage.Blobs.Specialized;
@@ -22,6 +23,7 @@ public interface IContainers {
     public Async.Task<BlobContainerClient?> GetOrCreateContainerClient(Container container, StorageType storageType, IDictionary<string, string>? metadata);
 
     public Async.Task<BlobContainerClient?> FindContainer(Container container, StorageType storageType);
+    public Async.Task<bool> DeleteContainerIfExists(Container container, StorageType storageType);
 
     public Async.Task<Uri?> GetFileSasUrl(Container container, string name, StorageType storageType, BlobSasPermissions permissions, TimeSpan? duration = null);
     public Async.Task SaveBlob(Container container, string name, string data, StorageType storageType, DateOnly? expiresOn = null);
@@ -49,6 +51,7 @@ public class Containers : Orm<ContainerInformation>, IContainers {
     private readonly IMemoryCache _cache;
 
     static readonly TimeSpan CONTAINER_SAS_DEFAULT_DURATION = TimeSpan.FromDays(30);
+    static readonly TimeSpan CONTAINER_INFO_EXPIRATION_TIME = TimeSpan.FromMinutes(10);
 
     public Containers(
         ILogger<Containers> log,
@@ -132,16 +135,19 @@ public class Containers : Orm<ContainerInformation>, IContainers {
             return null;
         }
 
+        // record the fact that we created a new container
+        var resourceId = BlobContainerResource.CreateResourceIdentifier(
+            account.SubscriptionId,
+            account.ResourceGroupName,
+            account.Name,
+            containerName);
+
+        _ = await SetContainerInformation(container, storageType, resourceId);
+
         return cc;
     }
 
-    private async Task<ContainerInformation?> LoadContainerInformation(Container container, StorageType storageType) {
-        var result = await QueryAsync(Query.SingleEntity(storageType.ToString(), container.ToString())).FirstOrDefaultAsync();
-        if (result is not null) {
-            return result;
-        }
-
-        // we don't have metadata about this account yet, find it:
+    private async Task<ResourceIdentifier?> FindContainerInAccounts(Container container, StorageType storageType) {
         var containerName = _config.OneFuzzStoragePrefix + container;
         // Check secondary accounts first by searching in reverse.
         // 
@@ -154,30 +160,74 @@ public class Containers : Orm<ContainerInformation>, IContainers {
             var accountClient = await _storage.GetBlobServiceClientForAccount(account);
             var containerClient = accountClient.GetBlobContainerClient(containerName);
             if (await containerClient.ExistsAsync()) {
-                // insert it into the table so we find it next time:
-                var containerInfo = new ContainerInformation(storageType, container, account.ToString());
-                _ = await Replace(containerInfo);
-                return containerInfo;
+                return BlobContainerResource.CreateResourceIdentifier(
+                    account.SubscriptionId,
+                    account.ResourceGroupName,
+                    account.Name,
+                    containerName);
             }
         }
 
         return null;
     }
 
+    private async Task<ContainerInformation> SetContainerInformation(Container container, StorageType storageType, ResourceIdentifier resourceId) {
+        var containerInfo = new ContainerInformation(storageType, container, resourceId.ToString());
+        _ = await Replace(containerInfo);
+        _ = _cache.Set(new ContainerKey(storageType, container), containerInfo, CONTAINER_INFO_EXPIRATION_TIME);
+        return containerInfo;
+    }
+
+    private async Task<bool> DeleteContainerInformation(Container container, StorageType storageType) {
+        var result = await DeleteIfExists(storageType.ToString(), container.ToString());
+        _cache.Remove(new ContainerKey(storageType, container));
+        return result.IsOk && result.OkV;
+    }
+
+    private async Task<ContainerInformation?> LoadContainerInformation(Container container, StorageType storageType) {
+        var result = await QueryAsync(Query.SingleEntity(storageType.ToString(), container.ToString())).FirstOrDefaultAsync();
+        if (result is not null) {
+            _ = _cache.Set(new ContainerKey(storageType, container), result, CONTAINER_INFO_EXPIRATION_TIME);
+            return result;
+        }
+
+        // we don't have metadata about this account yet, find it:
+        var resourceId = await FindContainerInAccounts(container, storageType);
+        if (resourceId is null) {
+            // never negatively-cache container info, so containers created by other instances
+            // can be found
+            return null;
+        }
+
+        // we found the container, insert it into the table (and cache) so we find it next time:
+        return await SetContainerInformation(container, storageType, resourceId);
+    }
+
     private sealed record ContainerKey(StorageType storageType, Container container);
     public async Async.Task<BlobContainerClient?> FindContainer(Container container, StorageType storageType) {
-        var containerInfo = await _cache.GetOrCreateAsync(
-            new ContainerKey(storageType, container),
-            async entry => {
-                entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromDays(1);
-                return await LoadContainerInformation(container, storageType);
-            });
+        var containerInfo =
+            _cache.Get<ContainerInformation>(new ContainerKey(storageType, container))
+            ?? await LoadContainerInformation(container, storageType);
 
         if (containerInfo is null) {
             return null;
         }
 
         return await _storage.GetBlobContainerClientForResource(new ResourceIdentifier(containerInfo.ResourceId));
+    }
+
+    public async Async.Task<bool> DeleteContainerIfExists(Container container, StorageType storageType) {
+        var client = await FindContainer(container, storageType);
+        if (client is null) {
+            // container doesn't exist
+            return false;
+        }
+
+        var (_, result) = await (
+            DeleteContainerInformation(container, storageType),
+            client.DeleteIfExistsAsync());
+
+        return result;
     }
 
     public async Async.Task<Uri?> GetFileSasUrl(Container container, string name, StorageType storageType, BlobSasPermissions permissions, TimeSpan? duration = null) {

--- a/src/ApiService/ApiService/onefuzzlib/Storage.cs
+++ b/src/ApiService/ApiService/onefuzzlib/Storage.cs
@@ -47,8 +47,10 @@ public interface IStorage {
 
     public Task<BlobServiceClient> GetBlobServiceClientForAccountName(string accountName);
 
-    public async Task<BlobContainerClient> GetBlobContainerClientForResource(ResourceIdentifier containerResourceId) {
-        var accountId = containerResourceId.Parent ?? throw new ArgumentException("resource ID must have parent", nameof(containerResourceId));
+    public async Task<BlobContainerClient> GetBlobContainerClientForContainerResource(ResourceIdentifier containerResourceId) {
+        // parent of container resource = blob services
+        // parent of blob services = storage account
+        var accountId = containerResourceId.Parent?.Parent ?? throw new ArgumentException("resource ID must have parent", nameof(containerResourceId));
         var accountClient = await GetBlobServiceClientForAccount(accountId);
         return accountClient.GetBlobContainerClient(containerResourceId.Name);
     }

--- a/src/ApiService/ApiService/onefuzzlib/Storage.cs
+++ b/src/ApiService/ApiService/onefuzzlib/Storage.cs
@@ -47,6 +47,12 @@ public interface IStorage {
 
     public Task<BlobServiceClient> GetBlobServiceClientForAccountName(string accountName);
 
+    public async Task<BlobContainerClient> GetBlobContainerClientForResource(ResourceIdentifier containerResourceId) {
+        var accountId = containerResourceId.Parent ?? throw new ArgumentException("resource ID must have parent", nameof(containerResourceId));
+        var accountClient = await GetBlobServiceClientForAccount(accountId);
+        return accountClient.GetBlobContainerClient(containerResourceId.Name);
+    }
+
     public Uri GenerateBlobContainerSasUri(
         BlobContainerSasPermissions permissions,
         BlobContainerClient containerClient,

--- a/src/ApiService/ApiService/onefuzzlib/orm/EntityConverter.cs
+++ b/src/ApiService/ApiService/onefuzzlib/orm/EntityConverter.cs
@@ -257,6 +257,8 @@ public class EntityConverter {
                 return int.Parse(stringValue);
             } else if (ef.type == typeof(long)) {
                 return long.Parse(stringValue);
+            } else if (ef.type.IsEnum) {
+                return Enum.Parse(ef.type, stringValue);
             } else if (ef.type.IsClass) {
                 try {
                     if (ef.type.GetMethod("Parse", BindingFlags.Static | BindingFlags.Public) is MethodInfo mi) {
@@ -275,7 +277,6 @@ public class EntityConverter {
         var fieldName = ef.columnName;
         var obj = entity[fieldName];
         if (obj == null) {
-
             if (ef.parameterInfo.HasDefaultValue) {
                 return ef.parameterInfo.DefaultValue;
             }

--- a/src/ApiService/IntegrationTests/Fakes/TestContainers.cs
+++ b/src/ApiService/IntegrationTests/Fakes/TestContainers.cs
@@ -1,8 +1,9 @@
-﻿using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
 using Microsoft.OneFuzz.Service;
 
 // TestContainers class allows use of InstanceID without having to set it up in blob storage
 sealed class TestContainers : Containers {
-    public TestContainers(ILogger<Containers> log, IStorage storage, IServiceConfig config, IOnefuzzContext context)
-        : base(log, storage, config, context) { }
+    public TestContainers(ILogger<Containers> log, IStorage storage, IServiceConfig config, IOnefuzzContext context, IMemoryCache cache)
+        : base(log, storage, config, context, cache) { }
 }

--- a/src/ApiService/IntegrationTests/Fakes/TestContext.cs
+++ b/src/ApiService/IntegrationTests/Fakes/TestContext.cs
@@ -16,7 +16,7 @@ namespace IntegrationTests.Fakes;
 // of functions as unit or integration tests.
 public sealed class TestContext : IOnefuzzContext {
     public TestContext(IHttpClientFactory httpClientFactory, OneFuzzLoggerProvider provider, IStorage storage, ICreds creds, string storagePrefix) {
-        var cache = new MemoryCache(Options.Create(new MemoryCacheOptions()));
+        Cache = new MemoryCache(Options.Create(new MemoryCacheOptions()));
         ServiceConfiguration = new TestServiceConfiguration(storagePrefix);
         Storage = storage;
         Creds = creds;
@@ -26,18 +26,18 @@ public sealed class TestContext : IOnefuzzContext {
         // this one is faked entirely; we can’t perform these operations at test time
         VmssOperations = new TestVmssOperations();
 
-        Containers = new Containers(provider.CreateLogger<Containers>(), Storage, ServiceConfiguration, this);
+        Containers = new Containers(provider.CreateLogger<Containers>(), Storage, ServiceConfiguration, this, Cache);
         Queue = new Queue(Storage, provider.CreateLogger<Queue>());
         RequestHandling = new RequestHandling(provider.CreateLogger<RequestHandling>());
-        TaskOperations = new TaskOperations(provider.CreateLogger<TaskOperations>(), cache, this);
+        TaskOperations = new TaskOperations(provider.CreateLogger<TaskOperations>(), Cache, this);
         NodeOperations = new NodeOperations(provider.CreateLogger<NodeOperations>(), this);
         JobOperations = new JobOperations(provider.CreateLogger<JobOperations>(), this);
         NodeTasksOperations = new NodeTasksOperations(provider.CreateLogger<NodeTasksOperations>(), this);
         TaskEventOperations = new TaskEventOperations(provider.CreateLogger<TaskEventOperations>(), this);
         NodeMessageOperations = new NodeMessageOperations(provider.CreateLogger<NodeMessageOperations>(), this);
-        ConfigOperations = new ConfigOperations(provider.CreateLogger<ConfigOperations>(), this, cache);
+        ConfigOperations = new ConfigOperations(provider.CreateLogger<ConfigOperations>(), this, Cache);
         PoolOperations = new PoolOperations(provider.CreateLogger<PoolOperations>(), this);
-        ScalesetOperations = new ScalesetOperations(provider.CreateLogger<ScalesetOperations>(), cache, this);
+        ScalesetOperations = new ScalesetOperations(provider.CreateLogger<ScalesetOperations>(), Cache, this);
         ReproOperations = new ReproOperations(provider.CreateLogger<ReproOperations>(), this);
         Reports = new Reports(provider.CreateLogger<Reports>(), Containers);
         NotificationOperations = new NotificationOperations(provider.CreateLogger<NotificationOperations>(), this);
@@ -67,6 +67,8 @@ public sealed class TestContext : IOnefuzzContext {
             }));
 
     // Implementations:
+
+    public IMemoryCache Cache { get; }
 
     public IEvents Events { get; }
     public IMetrics Metrics { get; }

--- a/src/ApiService/IntegrationTests/PoolTests.cs
+++ b/src/ApiService/IntegrationTests/PoolTests.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using IntegrationTests.Fakes;
-using Microsoft.Extensions.Caching.Memory;
 using Microsoft.OneFuzz.Service;
 using Xunit;
 using Xunit.Abstractions;

--- a/src/ApiService/IntegrationTests/PoolTests.cs
+++ b/src/ApiService/IntegrationTests/PoolTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using IntegrationTests.Fakes;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.OneFuzz.Service;
 using Xunit;
 using Xunit.Abstractions;
@@ -48,7 +49,12 @@ public abstract class PoolTestBase : FunctionTestBase {
         await Context.Queue.CreateQueue(Context.PoolOperations.GetPoolQueue(_poolId), StorageType.Corpus);
 
         // use test class to override instance ID
-        Context.Containers = new TestContainers(LoggerProvider.CreateLogger<Containers>(), Context.Storage, Context.ServiceConfiguration, Context);
+        Context.Containers = new TestContainers(
+            LoggerProvider.CreateLogger<Containers>(),
+            Context.Storage,
+            Context.ServiceConfiguration,
+            Context,
+            Context.Cache);
 
         var req = new PoolSearch(PoolId: _poolId);
         var func = new PoolFunction(Context);
@@ -76,7 +82,12 @@ public abstract class PoolTestBase : FunctionTestBase {
         await Context.Queue.CreateQueue(Context.PoolOperations.GetPoolQueue(_poolId), StorageType.Corpus);
 
         // use test class to override instance ID
-        Context.Containers = new TestContainers(LoggerProvider.CreateLogger<Containers>(), Context.Storage, Context.ServiceConfiguration, Context);
+        Context.Containers = new TestContainers(
+            LoggerProvider.CreateLogger<Containers>(),
+            Context.Storage,
+            Context.ServiceConfiguration,
+            Context,
+            Context.Cache);
 
         var req = new PoolSearch(Name: _poolName);
         var func = new PoolFunction(Context);
@@ -166,7 +177,12 @@ public abstract class PoolTestBase : FunctionTestBase {
             new InstanceConfig(Context.ServiceConfiguration.OneFuzzInstanceName!) { Admins = new[] { _userObjectId } }); // needed for admin check
 
         // need to override instance id
-        Context.Containers = new TestContainers(LoggerProvider.CreateLogger<Containers>(), Context.Storage, Context.ServiceConfiguration, Context);
+        Context.Containers = new TestContainers(
+            LoggerProvider.CreateLogger<Containers>(),
+            Context.Storage,
+            Context.ServiceConfiguration,
+            Context,
+            Context.Cache);
 
         var func = new PoolFunction(Context);
         var req = new PoolCreate(Name: _poolName, Os.Linux, Architecture.x86_64, true);


### PR DESCRIPTION
Closes #3156.

From now on, we will store additional information about containers in a table (`ContainerInformation`). This is populated when a container is created, or lazily when looking for a container we have not yet stored in the table.

Reads from this table are also cached in memory for a short period of time (currently 10 minutes).

The table is currently used to speed up lookups for containers across storage accounts; we round-robin creation of containers across multiple storage accounts to spread load, so when we read from a container we need to find what storage account it lives in.

The `ContainerInformation` table could also be used in future to store information about access control (see, e.g. #1419).