### PR TITLE
Revert "Update packaging of LibFuzzerDotNetLoader (#3248)"

### DIFF
--- a/src/agent/LibFuzzerDotnetLoader/LibFuzzerDotnetLoader.csproj
+++ b/src/agent/LibFuzzerDotnetLoader/LibFuzzerDotnetLoader.csproj
@@ -6,12 +6,6 @@
     <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <!-- make published binaries as small as possible -->
-    <SelfContained>true</SelfContained>
-    <PublishSingleFile>true</PublishSingleFile>
-    <InvariantGlobalization>true</InvariantGlobalization>
-    <DebuggerSupport>false</DebuggerSupport>
-    <!-- /end -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ci/dotnet-fuzzing-tools.ps1
+++ b/src/ci/dotnet-fuzzing-tools.ps1
@@ -26,7 +26,7 @@ popd
 
 # Build SharpFuzz and our dynamic loader harness for `libfuzzer-dotnet`.
 pushd src/agent/LibFuzzerDotnetLoader
-dotnet publish . -c Release -o $ARTIFACTS/LibFuzzerDotnetLoader -r win10-x64
+dotnet publish . -c Release -o $ARTIFACTS/LibFuzzerDotnetLoader --sc -r win10-x64
 if ($LASTEXITCODE -ne 0) { throw "dotnet publish exited with $LASTEXITCODE" }
 popd
 

--- a/src/ci/dotnet-fuzzing-tools.sh
+++ b/src/ci/dotnet-fuzzing-tools.sh
@@ -34,7 +34,7 @@ popd
 
 # Build SharpFuzz and our dynamic loader harness for `libfuzzer-dotnet`.
 pushd src/agent/LibFuzzerDotnetLoader
-dotnet publish . -c Release -o $ARTIFACTS/LibFuzzerDotnetLoader -r linux-x64
+dotnet publish . -c Release -o $ARTIFACTS/LibFuzzerDotnetLoader --sc -r linux-x64
 popd
 
 # Build `libfuzzer-dotnet`.


### PR DESCRIPTION
This reverts commit 25f125748dc0352d66385281e7a4468621233739.

The change broke the libfuzzer dotnet template (I could have sworn I validated first with check-pr but…)

Two things didn't work:
1. the path to the LibFuzzerDotNetLoader needed to change; I attempted to fix this in #3324 
2. minidumps weren't being captured, for an unknown reason. I haven't figured out why yet, thus I'm going to simply revert the change so we have this working for the next release.