### PR TITLE
Render System.Title before trying to trim

### DIFF
--- a/src/ApiService/ApiService/onefuzzlib/NotificationOperations.cs
+++ b/src/ApiService/ApiService/onefuzzlib/NotificationOperations.cs
@@ -91,7 +91,7 @@ public class NotificationOperations : Orm<Notification>, INotificationOperations
                     notification.NotificationId);
             case GithubIssuesTemplate githubIssuesTemplate when reportOrRegression is not null:
                 await _context.GithubIssues.GithubIssue(githubIssuesTemplate, container, reportOrRegression,
-                    notification.NotificationId);
+                    notification.NotificationId, _context.Creds.GetInstanceUrl());
                 break;
         }
 

--- a/src/ApiService/ApiService/onefuzzlib/NotificationOperations.cs
+++ b/src/ApiService/ApiService/onefuzzlib/NotificationOperations.cs
@@ -91,7 +91,7 @@ public class NotificationOperations : Orm<Notification>, INotificationOperations
                     notification.NotificationId);
             case GithubIssuesTemplate githubIssuesTemplate when reportOrRegression is not null:
                 await _context.GithubIssues.GithubIssue(githubIssuesTemplate, container, reportOrRegression,
-                    notification.NotificationId, _context.Creds.GetInstanceUrl());
+                    notification.NotificationId);
                 break;
         }
 

--- a/src/ApiService/ApiService/onefuzzlib/notifications/GithubIssues.cs
+++ b/src/ApiService/ApiService/onefuzzlib/notifications/GithubIssues.cs
@@ -3,7 +3,7 @@ using Octokit;
 namespace Microsoft.OneFuzz.Service;
 
 public interface IGithubIssues {
-    Async.Task GithubIssue(GithubIssuesTemplate config, Container container, IReport reportable, Guid notificationId, Uri instanceUrl);
+    Async.Task GithubIssue(GithubIssuesTemplate config, Container container, IReport reportable, Guid notificationId);
 }
 
 public class GithubIssues : NotificationsBase, IGithubIssues {
@@ -11,7 +11,7 @@ public class GithubIssues : NotificationsBase, IGithubIssues {
     public GithubIssues(ILogger<GithubIssues> logTracer, IOnefuzzContext context)
     : base(logTracer, context) { }
 
-    public async Async.Task GithubIssue(GithubIssuesTemplate config, Container container, IReport reportable, Guid notificationId, Uri instanceUrl) {
+    public async Async.Task GithubIssue(GithubIssuesTemplate config, Container container, IReport reportable, Guid notificationId) {
         var filename = reportable.FileName();
 
         if (reportable is RegressionReport) {
@@ -22,7 +22,7 @@ public class GithubIssues : NotificationsBase, IGithubIssues {
         var report = (Report)reportable;
 
         try {
-            await Process(config, container, filename, config.Title, report, instanceUrl);
+            await Process(config, container, filename, config.Title, report, _context.Creds.GetInstanceUrl());
         } catch (ApiException e) {
             await LogFailedNotification(report, e, notificationId);
         }

--- a/src/ApiService/ApiService/onefuzzlib/notifications/GithubIssues.cs
+++ b/src/ApiService/ApiService/onefuzzlib/notifications/GithubIssues.cs
@@ -3,7 +3,7 @@ using Octokit;
 namespace Microsoft.OneFuzz.Service;
 
 public interface IGithubIssues {
-    Async.Task GithubIssue(GithubIssuesTemplate config, Container container, IReport reportable, Guid notificationId);
+    Async.Task GithubIssue(GithubIssuesTemplate config, Container container, IReport reportable, Guid notificationId, Uri instanceUrl);
 }
 
 public class GithubIssues : NotificationsBase, IGithubIssues {
@@ -11,7 +11,7 @@ public class GithubIssues : NotificationsBase, IGithubIssues {
     public GithubIssues(ILogger<GithubIssues> logTracer, IOnefuzzContext context)
     : base(logTracer, context) { }
 
-    public async Async.Task GithubIssue(GithubIssuesTemplate config, Container container, IReport reportable, Guid notificationId) {
+    public async Async.Task GithubIssue(GithubIssuesTemplate config, Container container, IReport reportable, Guid notificationId, Uri instanceUrl) {
         var filename = reportable.FileName();
 
         if (reportable is RegressionReport) {
@@ -22,7 +22,7 @@ public class GithubIssues : NotificationsBase, IGithubIssues {
         var report = (Report)reportable;
 
         try {
-            await Process(config, container, filename, config.Title, report);
+            await Process(config, container, filename, config.Title, report, instanceUrl);
         } catch (ApiException e) {
             await LogFailedNotification(report, e, notificationId);
         }
@@ -63,8 +63,8 @@ public class GithubIssues : NotificationsBase, IGithubIssues {
         };
     }
 
-    private async Async.Task Process(GithubIssuesTemplate config, Container container, string filename, string issueTitle, Report report) {
-        var renderer = await Renderer.ConstructRenderer(_context, container, filename, issueTitle, report, _logTracer);
+    private async Async.Task Process(GithubIssuesTemplate config, Container container, string filename, string issueTitle, Report report, Uri instanceUrl) {
+        var renderer = await Renderer.ConstructRenderer(_context, container, filename, issueTitle, report, instanceUrl, _logTracer);
         var handler = await GithubConnnector.GithubConnnectorCreator(config, renderer, _context.Creds.GetInstanceUrl(), _context, _logTracer);
         await handler.Process();
     }

--- a/src/ApiService/ApiService/onefuzzlib/notifications/JinjaTemplateAdapter.cs
+++ b/src/ApiService/ApiService/onefuzzlib/notifications/JinjaTemplateAdapter.cs
@@ -35,7 +35,7 @@ public class JinjaTemplateAdapter {
     public static async Async.Task<TemplateValidationResponse> ValidateScribanTemplate(IOnefuzzContext context, ILogger log, TemplateRenderContext? renderContext, string template) {
         var instanceUrl = context.ServiceConfiguration.OneFuzzInstance;
 
-        var (renderer, templateRenderContext) = await GenerateTemplateRenderContext(context, log, renderContext);
+        var (renderer, templateRenderContext) = await GenerateTemplateRenderContext(context, instanceUrl, log, renderContext);
 
         var renderedTemplate = renderer.Render(template, instanceUrl, strictRendering: true);
 
@@ -45,7 +45,7 @@ public class JinjaTemplateAdapter {
         );
     }
 
-    private static async Async.Task<(NotificationsBase.Renderer, TemplateRenderContext)> GenerateTemplateRenderContext(IOnefuzzContext context, ILogger log, TemplateRenderContext? templateRenderContext) {
+    private static async Async.Task<(NotificationsBase.Renderer, TemplateRenderContext)> GenerateTemplateRenderContext(IOnefuzzContext context, Uri instanceUrl, ILogger log, TemplateRenderContext? templateRenderContext) {
         if (templateRenderContext != null) {
             log.LogInformation("Using custom TemplateRenderContext");
         } else {
@@ -220,6 +220,7 @@ public class JinjaTemplateAdapter {
             reportFileName,
             issueTitle,
             report,
+            instanceUrl,
             log,
             task,
             job,

--- a/src/ApiService/ApiService/onefuzzlib/notifications/NotificationsBase.cs
+++ b/src/ApiService/ApiService/onefuzzlib/notifications/NotificationsBase.cs
@@ -37,6 +37,7 @@ public abstract class NotificationsBase {
         private readonly Report _report;
         private readonly Container _container;
         private readonly string _filename;
+        public string IssueTitle => _issueTitle;
         private readonly string _issueTitle;
         private readonly TaskConfig _taskConfig;
         private readonly JobConfig _jobConfig;
@@ -51,6 +52,7 @@ public abstract class NotificationsBase {
             string filename,
             string issueTitle,
             Report report,
+            Uri instanceUrl,
             ILogger log,
             Task? task = null,
             Job? job = null,
@@ -84,10 +86,23 @@ public abstract class NotificationsBase {
 
             var scribanOnly = scribanOnlyOverride ?? scribanOnlyFeatureFlag;
 
+            var renderedIssueTitle = new Renderer(
+                container,
+                filename,
+                string.Empty,
+                report,
+                checkedTask,
+                checkedJob,
+                targetUrl,
+                inputUrl!, // TODO: incorrect
+                reportUrl,
+                scribanOnly)
+                .Render(issueTitle, instanceUrl);
+
             return new Renderer(
                 container,
                 filename,
-                issueTitle,
+                renderedIssueTitle,
                 report,
                 checkedTask,
                 checkedJob,


### PR DESCRIPTION
## Summary of the Pull Request

The [last fix for trimming System.Title](https://github.com/microsoft/onefuzz/pull/3284) wasn't much of a fix as it checked the pre-rendered System.Title length.
This PR fixes that issue by rendering the title in ConstructRenderer() and giving the rendered title a public accessor.

## PR Checklist
* [ ] Applies to work item: #xxx
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/onefuzz) and sign the CLI.
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

System.Title trim fix and some logging that happens when the title is too long.

## Validation Steps Performed

Deployed changes to a manual instance and filed a bug that triggers the updated code.
