### PR TITLE
Fix 'missing' dependency

### DIFF
--- a/src/cli/onefuzz/backend.py
+++ b/src/cli/onefuzz/backend.py
@@ -123,7 +123,7 @@ class Backend:
         token_path: Optional[str] = None,
         client_secret: Optional[str] = None,
     ):
-        RequestsInstrumentor().instrument()
+        RequestsInstrumentor().instrument(skip_dep_check=True)
         self.config_path = os.path.expanduser(config_path or DEFAULT_CONFIG_PATH)
         self.token_path = os.path.expanduser(token_path or DEFAULT_TOKEN_PATH)
         self.client_secret = client_secret


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_

opentelemetry claims requests ~= 2.0 is not installed with the following message:
```
DependencyConflict: requested: "requests ~= 2.0" but found: "None"
```
This is false however, `requests` is installed and we should leave it up to pip to decide what's installed or not.