### PR TITLE
Fix #3309

### DIFF
--- a/src/cli/onefuzz/templates/libfuzzer.py
+++ b/src/cli/onefuzz/templates/libfuzzer.py
@@ -500,6 +500,7 @@ class Libfuzzer(Command):
             analyzer_env=analyzer_env,
             tools=tools,
             task_env=task_env,
+            target_timeout=target_timeout,
         )
 
         self.logger.info("done creating tasks")


### PR DESCRIPTION
LibFuzzer basic template was missing `target_timeout`