### PR TITLE
Exclude ASAN runtime from minimized stacktrace

### DIFF
--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -570,6 +570,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "const_format"
+version = "0.2.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c990efc7a285731f9a4378d81aff2f0e85a2c8781a05ef0f8baa8dac54d0ff48"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e026b6ce194a874cb9cf32cd5772d1ef9767cc8fcb5765948d74f37a9d8b2bf6"
+dependencies = [
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
+ "unicode-xid 0.2.4",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1797,7 +1817,6 @@ name = "libclusterfuzz"
 version = "0.0.1"
 dependencies = [
  "anyhow",
- "lazy_static",
  "regex",
 ]
 
@@ -2622,7 +2641,7 @@ version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 dependencies = [
- "unicode-xid",
+ "unicode-xid 0.1.0",
 ]
 
 [[package]]
@@ -3312,9 +3331,9 @@ name = "stacktrace-parser"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "const_format",
  "hex",
  "insta",
- "lazy_static",
  "libclusterfuzz",
  "pretty_assertions",
  "regex",
@@ -3503,7 +3522,7 @@ checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
 dependencies = [
  "proc-macro2 0.4.30",
  "quote 0.6.13",
- "unicode-xid",
+ "unicode-xid 0.1.0",
 ]
 
 [[package]]
@@ -3783,6 +3802,12 @@ name = "unicode-xid"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "unwind"

--- a/src/agent/libclusterfuzz/Cargo.toml
+++ b/src/agent/libclusterfuzz/Cargo.toml
@@ -11,4 +11,3 @@ description = "Minimal porting of features from libclusterfuzz"
 [dependencies]
 anyhow = "1.0"
 regex = "1.9.1"
-lazy_static = "1.4"

--- a/src/agent/libclusterfuzz/src/generated.rs
+++ b/src/agent/libclusterfuzz/src/generated.rs
@@ -210,4 +210,7 @@ pub const STACK_FRAME_IGNORE_REGEXES: &[&str] = &[
     r".*libc\+\+_shared\.so",
     r".*libstdc\+\+\.so",
     r".*libc-.*\.so",
+    // OneFuzz added: ignore ASAN runtime on Windows
+    r"clang_rt.asan_dynamic-x86_64.dll$",
+    r"clang_rt.asan_dbg_dynamic-x86_64.dll$",
 ];

--- a/src/agent/libclusterfuzz/src/lib.rs
+++ b/src/agent/libclusterfuzz/src/lib.rs
@@ -18,8 +18,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[macro_use]
-extern crate lazy_static;
+use std::sync::OnceLock;
 
 use regex::RegexSet;
 
@@ -28,11 +27,12 @@ mod generated;
 pub fn get_stack_filter() -> &'static RegexSet {
     // NOTE: this is build upon first use, but we've verified these will compile
     // using unit tests
-    lazy_static! {
-        static ref RE: RegexSet = RegexSet::new(generated::STACK_FRAME_IGNORE_REGEXES)
-            .expect("libclusterfuzz regex compile error");
-    }
-    &RE
+    static ONCE: OnceLock<RegexSet> = OnceLock::new();
+
+    ONCE.get_or_init(|| {
+        RegexSet::new(generated::STACK_FRAME_IGNORE_REGEXES)
+            .expect("libclusterfuzz regex compile error")
+    })
 }
 
 #[cfg(test)]

--- a/src/agent/stacktrace-parser/Cargo.toml
+++ b/src/agent/stacktrace-parser/Cargo.toml
@@ -7,9 +7,9 @@ license = "MIT"
 
 [dependencies]
 anyhow = "1.0"
+const_format = "0.2.31"
 hex = "0.4"
 regex = "1.9.1"
-lazy_static = "1.4.0"
 sha2 = "0.10.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/src/agent/stacktrace-parser/data/parsed-traces/check_dir@asan-missing-symbols.txt.snap
+++ b/src/agent/stacktrace-parser/data/parsed-traces/check_dir@asan-missing-symbols.txt.snap
@@ -1,0 +1,88 @@
+---
+source: stacktrace-parser/src/lib.rs
+expression: parsed
+input_file: stacktrace-parser/data/stack-traces/asan-missing-symbols.txt
+---
+{
+  "text": "=================================================================\n==1496==ERROR: AddressSanitizer: unknown-crash on address 0x10c2bc680000 at pc 0x7ffa9fed7325 bp 0x0097f4f791a0 sp 0x0097f4f78930\nREAD of size 1440 at 0x10c2bc680000 thread T4\n    #0 0x7ffa9fed7324  (C:\\onefuzz\\blob-containers\\samplefolder\\clang_rt.asan_dynamic-x86_64.dll+0x180057324)\n    #1 0x7ff68a914308 in MyCode::myFunction(struct MyStruct *) path\\to\\src\\mycode.cpp:1536\n    #2 0x7ffa9feee12e  (C:\\onefuzz\\blob-containers\\samplefolder\\clang_rt.asan_dynamic-x86_64.dll+0x18006e12e)\n    #3 0x7ffac20c7613  (C:\\Windows\\System32\\KERNEL32.DLL+0x180017613)\n    #4 0x7ffac40a26f0  (C:\\Windows\\SYSTEM32\\ntdll.dll+0x1800526f0)\n\nSUMMARY: AddressSanitizer: unknown-crash (C:\\onefuzz\\blob-containers\\samplefolder\\clang_rt.asan_dynamic-x86_64.dll+0x18004b7b3) in _asan_wrap_GlobalSize+0x48963\n",
+  "sanitizer": "AddressSanitizer",
+  "summary": "AddressSanitizer: unknown-crash (C:\\onefuzz\\blob-containers\\samplefolder\\clang_rt.asan_dynamic-x86_64.dll+0x18004b7b3) in _asan_wrap_GlobalSize+0x48963",
+  "fault_type": "unknown-crash",
+  "call_stack": [
+    "#0 0x7ffa9fed7324  (C:\\onefuzz\\blob-containers\\samplefolder\\clang_rt.asan_dynamic-x86_64.dll+0x180057324)",
+    "#1 0x7ff68a914308 in MyCode::myFunction(struct MyStruct *) path\\to\\src\\mycode.cpp:1536",
+    "#2 0x7ffa9feee12e  (C:\\onefuzz\\blob-containers\\samplefolder\\clang_rt.asan_dynamic-x86_64.dll+0x18006e12e)",
+    "#3 0x7ffac20c7613  (C:\\Windows\\System32\\KERNEL32.DLL+0x180017613)",
+    "#4 0x7ffac40a26f0  (C:\\Windows\\SYSTEM32\\ntdll.dll+0x1800526f0)"
+  ],
+  "full_stack_details": [
+    {
+      "line": "#0 0x7ffa9fed7324  (C:\\onefuzz\\blob-containers\\samplefolder\\clang_rt.asan_dynamic-x86_64.dll+0x180057324)",
+      "address": 140714401690404,
+      "module_path": "C:\\onefuzz\\blob-containers\\samplefolder\\clang_rt.asan_dynamic-x86_64.dll",
+      "module_offset": 6442808100
+    },
+    {
+      "line": "#1 0x7ff68a914308 in MyCode::myFunction(struct MyStruct *) path\\to\\src\\mycode.cpp:1536",
+      "address": 140696863458056,
+      "function_name": "MyCode::myFunction(struct MyStruct *)",
+      "source_file_name": "mycode.cpp",
+      "source_file_path": "path\\to\\src\\mycode.cpp",
+      "source_file_line": 1536
+    },
+    {
+      "line": "#2 0x7ffa9feee12e  (C:\\onefuzz\\blob-containers\\samplefolder\\clang_rt.asan_dynamic-x86_64.dll+0x18006e12e)",
+      "address": 140714401784110,
+      "module_path": "C:\\onefuzz\\blob-containers\\samplefolder\\clang_rt.asan_dynamic-x86_64.dll",
+      "module_offset": 6442901806
+    },
+    {
+      "line": "#3 0x7ffac20c7613  (C:\\Windows\\System32\\KERNEL32.DLL+0x180017613)",
+      "address": 140714974148115,
+      "module_path": "C:\\Windows\\System32\\KERNEL32.DLL",
+      "module_offset": 6442546707
+    },
+    {
+      "line": "#4 0x7ffac40a26f0  (C:\\Windows\\SYSTEM32\\ntdll.dll+0x1800526f0)",
+      "address": 140715007551216,
+      "module_path": "C:\\Windows\\SYSTEM32\\ntdll.dll",
+      "module_offset": 6442788592
+    }
+  ],
+  "full_stack_names": [
+    "MyCode::myFunction"
+  ],
+  "minimized_stack_details": [
+    {
+      "line": "#1 0x7ff68a914308 in MyCode::myFunction(struct MyStruct *) path\\to\\src\\mycode.cpp:1536",
+      "address": 140696863458056,
+      "function_name": "MyCode::myFunction(struct MyStruct *)",
+      "source_file_name": "mycode.cpp",
+      "source_file_path": "path\\to\\src\\mycode.cpp",
+      "source_file_line": 1536
+    },
+    {
+      "line": "#3 0x7ffac20c7613  (C:\\Windows\\System32\\KERNEL32.DLL+0x180017613)",
+      "address": 140714974148115,
+      "module_path": "C:\\Windows\\System32\\KERNEL32.DLL",
+      "module_offset": 6442546707
+    },
+    {
+      "line": "#4 0x7ffac40a26f0  (C:\\Windows\\SYSTEM32\\ntdll.dll+0x1800526f0)",
+      "address": 140715007551216,
+      "module_path": "C:\\Windows\\SYSTEM32\\ntdll.dll",
+      "module_offset": 6442788592
+    }
+  ],
+  "minimized_stack": [
+    "#1 0x7ff68a914308 in MyCode::myFunction(struct MyStruct *) path\\to\\src\\mycode.cpp:1536",
+    "#3 0x7ffac20c7613  (C:\\Windows\\System32\\KERNEL32.DLL+0x180017613)",
+    "#4 0x7ffac40a26f0  (C:\\Windows\\SYSTEM32\\ntdll.dll+0x1800526f0)"
+  ],
+  "minimized_stack_function_names": [
+    "MyCode::myFunction"
+  ],
+  "minimized_stack_function_lines": [
+    "MyCode::myFunction(struct MyStruct *) mycode.cpp:1536"
+  ]
+}

--- a/src/agent/stacktrace-parser/data/parsed-traces/check_dir@example-deadly_signal.txt.snap
+++ b/src/agent/stacktrace-parser/data/parsed-traces/check_dir@example-deadly_signal.txt.snap
@@ -1,0 +1,170 @@
+---
+source: stacktrace-parser/src/lib.rs
+expression: parsed
+input_file: stacktrace-parser/data/stack-traces/example-deadly_signal.txt
+---
+{
+  "text": "==63924== ERROR: libFuzzer: deadly signal\n    #0 0x55af7a69cae1 in __sanitizer_print_stack_trace (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0xe4ae1) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n    #1 0x55af7a60f378 in fuzzer::PrintStackTrace() (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x57378) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n    #2 0x55af7a5f4df3 in fuzzer::Fuzzer::CrashCallback() (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x3cdf3) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n    #3 0x7f1c2425051f  (/lib/x86_64-linux-gnu/libc.so.6+0x4251f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)\n    #4 0x7f1c242a4a7b in pthread_kill (/lib/x86_64-linux-gnu/libc.so.6+0x96a7b) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)\n    #5 0x7f1c24250475 in gsignal (/lib/x86_64-linux-gnu/libc.so.6+0x42475) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)\n    #6 0x7f1c242367f2 in abort (/lib/x86_64-linux-gnu/libc.so.6+0x287f2) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)\n    #7 0x55af7a6ce4c0 in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:92:9\n    #8 0x55af7a5f6383 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x3e383) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n    #9 0x55af7a5e00ff in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x280ff) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n    #10 0x55af7a5e5e56 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x2de56) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n    #11 0x55af7a60fc72 in main (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x57c72) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n    #12 0x7f1c24237d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)\n    #13 0x7f1c24237e3f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x29e3f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)\n    #14 0x55af7a5da9c4 in _start (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x229c4) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n\nNOTE: libFuzzer has rudimentary signal handlers.\n      Combine libFuzzer with AddressSanitizer or similar for better crash reports.\nSUMMARY: libFuzzer: deadly signal\n",
+  "sanitizer": "libFuzzer",
+  "summary": "libFuzzer: deadly signal",
+  "fault_type": "deadly signal",
+  "call_stack": [
+    "#0 0x55af7a69cae1 in __sanitizer_print_stack_trace (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0xe4ae1) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+    "#1 0x55af7a60f378 in fuzzer::PrintStackTrace() (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x57378) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+    "#2 0x55af7a5f4df3 in fuzzer::Fuzzer::CrashCallback() (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x3cdf3) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+    "#3 0x7f1c2425051f  (/lib/x86_64-linux-gnu/libc.so.6+0x4251f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)",
+    "#4 0x7f1c242a4a7b in pthread_kill (/lib/x86_64-linux-gnu/libc.so.6+0x96a7b) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)",
+    "#5 0x7f1c24250475 in gsignal (/lib/x86_64-linux-gnu/libc.so.6+0x42475) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)",
+    "#6 0x7f1c242367f2 in abort (/lib/x86_64-linux-gnu/libc.so.6+0x287f2) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)",
+    "#7 0x55af7a6ce4c0 in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:92:9",
+    "#8 0x55af7a5f6383 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x3e383) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+    "#9 0x55af7a5e00ff in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x280ff) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+    "#10 0x55af7a5e5e56 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x2de56) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+    "#11 0x55af7a60fc72 in main (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x57c72) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+    "#12 0x7f1c24237d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)",
+    "#13 0x7f1c24237e3f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x29e3f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)",
+    "#14 0x55af7a5da9c4 in _start (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x229c4) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)"
+  ],
+  "full_stack_details": [
+    {
+      "line": "#0 0x55af7a69cae1 in __sanitizer_print_stack_trace (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0xe4ae1) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+      "address": 94212161391329,
+      "function_name": "__sanitizer_print_stack_trace",
+      "module_path": "/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe",
+      "module_offset": 936673
+    },
+    {
+      "line": "#1 0x55af7a60f378 in fuzzer::PrintStackTrace() (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x57378) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+      "address": 94212160811896,
+      "function_name": "fuzzer::PrintStackTrace()",
+      "module_path": "/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe",
+      "module_offset": 357240
+    },
+    {
+      "line": "#2 0x55af7a5f4df3 in fuzzer::Fuzzer::CrashCallback() (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x3cdf3) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+      "address": 94212160703987,
+      "function_name": "fuzzer::Fuzzer::CrashCallback()",
+      "module_path": "/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe",
+      "module_offset": 249331
+    },
+    {
+      "line": "#3 0x7f1c2425051f  (/lib/x86_64-linux-gnu/libc.so.6+0x4251f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)",
+      "address": 139758842217759,
+      "module_path": "/lib/x86_64-linux-gnu/libc.so.6",
+      "module_offset": 271647
+    },
+    {
+      "line": "#4 0x7f1c242a4a7b in pthread_kill (/lib/x86_64-linux-gnu/libc.so.6+0x96a7b) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)",
+      "address": 139758842563195,
+      "function_name": "pthread_kill",
+      "module_path": "/lib/x86_64-linux-gnu/libc.so.6",
+      "module_offset": 617083
+    },
+    {
+      "line": "#5 0x7f1c24250475 in gsignal (/lib/x86_64-linux-gnu/libc.so.6+0x42475) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)",
+      "address": 139758842217589,
+      "function_name": "gsignal",
+      "module_path": "/lib/x86_64-linux-gnu/libc.so.6",
+      "module_offset": 271477
+    },
+    {
+      "line": "#6 0x7f1c242367f2 in abort (/lib/x86_64-linux-gnu/libc.so.6+0x287f2) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)",
+      "address": 139758842111986,
+      "function_name": "abort",
+      "module_path": "/lib/x86_64-linux-gnu/libc.so.6",
+      "module_offset": 165874
+    },
+    {
+      "line": "#7 0x55af7a6ce4c0 in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:92:9",
+      "address": 94212161594560,
+      "function_name": "LLVMFuzzerTestOneInput",
+      "function_offset": 9,
+      "source_file_name": "simple.c",
+      "source_file_path": "/workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c",
+      "source_file_line": 92
+    },
+    {
+      "line": "#8 0x55af7a5f6383 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x3e383) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+      "address": 94212160709507,
+      "function_name": "fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long)",
+      "module_path": "/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe",
+      "module_offset": 254851
+    },
+    {
+      "line": "#9 0x55af7a5e00ff in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x280ff) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+      "address": 94212160618751,
+      "function_name": "fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long)",
+      "module_path": "/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe",
+      "module_offset": 164095
+    },
+    {
+      "line": "#10 0x55af7a5e5e56 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x2de56) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+      "address": 94212160642646,
+      "function_name": "fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long))",
+      "module_path": "/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe",
+      "module_offset": 187990
+    },
+    {
+      "line": "#11 0x55af7a60fc72 in main (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x57c72) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+      "address": 94212160814194,
+      "function_name": "main",
+      "module_path": "/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe",
+      "module_offset": 359538
+    },
+    {
+      "line": "#12 0x7f1c24237d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)",
+      "address": 139758842117519,
+      "module_path": "/lib/x86_64-linux-gnu/libc.so.6",
+      "module_offset": 171407
+    },
+    {
+      "line": "#13 0x7f1c24237e3f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x29e3f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)",
+      "address": 139758842117695,
+      "function_name": "__libc_start_main",
+      "module_path": "/lib/x86_64-linux-gnu/libc.so.6",
+      "module_offset": 171583
+    },
+    {
+      "line": "#14 0x55af7a5da9c4 in _start (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x229c4) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+      "address": 94212160596420,
+      "function_name": "_start",
+      "module_path": "/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe",
+      "module_offset": 141764
+    }
+  ],
+  "full_stack_names": [
+    "__sanitizer_print_stack_trace",
+    "fuzzer::PrintStackTrace",
+    "fuzzer::Fuzzer::CrashCallback",
+    "pthread_kill",
+    "gsignal",
+    "abort",
+    "LLVMFuzzerTestOneInput",
+    "fuzzer::Fuzzer::ExecuteCallback",
+    "fuzzer::RunOneTest",
+    "fuzzer::FuzzerDriver",
+    "main",
+    "__libc_start_main",
+    "_start"
+  ],
+  "minimized_stack_details": [
+    {
+      "line": "#7 0x55af7a6ce4c0 in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:92:9",
+      "address": 94212161594560,
+      "function_name": "simple.c",
+      "function_offset": 9,
+      "source_file_name": "simple.c",
+      "source_file_path": "/workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c",
+      "source_file_line": 92
+    }
+  ],
+  "minimized_stack": [
+    "#7 0x55af7a6ce4c0 in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:92:9"
+  ],
+  "minimized_stack_function_names": [
+    "simple.c"
+  ],
+  "minimized_stack_function_lines": [
+    "simple.c simple.c:92:9"
+  ]
+}

--- a/src/agent/stacktrace-parser/data/parsed-traces/check_dir@example-double-free.txt.snap
+++ b/src/agent/stacktrace-parser/data/parsed-traces/check_dir@example-double-free.txt.snap
@@ -1,0 +1,118 @@
+---
+source: stacktrace-parser/src/lib.rs
+expression: parsed
+input_file: stacktrace-parser/data/stack-traces/example-double-free.txt
+---
+{
+  "text": "=================================================================\n==63086==ERROR: AddressSanitizer: attempting double-free on 0x602000000050 in thread T0:\n    #0 0x55faae2b3752 in __interceptor_free (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0xda752) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n    #1 0x55faae2ef2fc in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:73:56\n    #2 0x55faae217383 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x3e383) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n    #3 0x55faae2010ff in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x280ff) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n    #4 0x55faae206e56 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x2de56) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n    #5 0x55faae230c72 in main (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x57c72) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n    #6 0x7fda0af66d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)\n    #7 0x7fda0af66e3f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x29e3f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)\n    #8 0x55faae1fb9c4 in _start (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x229c4) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n\n0x602000000050 is located 0 bytes inside of 4-byte region [0x602000000050,0x602000000054)\nfreed by thread T0 here:\n    #0 0x55faae2b3752 in __interceptor_free (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0xda752) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n    #1 0x55faae2ef2f0 in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:73:47\n    #2 0x55faae217383 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x3e383) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n    #3 0x55faae2010ff in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x280ff) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n    #4 0x55faae206e56 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x2de56) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n    #5 0x55faae230c72 in main (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x57c72) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n    #6 0x7fda0af66d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)\n\npreviously allocated by thread T0 here:\n    #0 0x55faae2b39fe in malloc (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0xda9fe) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n    #1 0x55faae2ef2dd in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:73:26\n    #2 0x55faae217383 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x3e383) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n    #3 0x55faae2010ff in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x280ff) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n    #4 0x55faae206e56 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x2de56) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n    #5 0x55faae230c72 in main (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x57c72) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n    #6 0x7fda0af66d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)\n\nSUMMARY: AddressSanitizer: double-free (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0xda752) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0) in __interceptor_free\n==63086==ABORTING\n",
+  "sanitizer": "AddressSanitizer",
+  "summary": "AddressSanitizer: double-free (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0xda752) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0) in __interceptor_free",
+  "fault_type": "double-free",
+  "call_stack": [
+    "#0 0x55faae2b3752 in __interceptor_free (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0xda752) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+    "#1 0x55faae2ef2fc in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:73:56",
+    "#2 0x55faae217383 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x3e383) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+    "#3 0x55faae2010ff in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x280ff) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+    "#4 0x55faae206e56 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x2de56) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+    "#5 0x55faae230c72 in main (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x57c72) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+    "#6 0x7fda0af66d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)",
+    "#7 0x7fda0af66e3f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x29e3f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)",
+    "#8 0x55faae1fb9c4 in _start (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x229c4) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)"
+  ],
+  "full_stack_details": [
+    {
+      "line": "#0 0x55faae2b3752 in __interceptor_free (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0xda752) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+      "address": 94535152252754,
+      "function_name": "__interceptor_free",
+      "module_path": "/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe",
+      "module_offset": 894802
+    },
+    {
+      "line": "#1 0x55faae2ef2fc in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:73:56",
+      "address": 94535152497404,
+      "function_name": "LLVMFuzzerTestOneInput",
+      "function_offset": 56,
+      "source_file_name": "simple.c",
+      "source_file_path": "/workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c",
+      "source_file_line": 73
+    },
+    {
+      "line": "#2 0x55faae217383 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x3e383) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+      "address": 94535151612803,
+      "function_name": "fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long)",
+      "module_path": "/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe",
+      "module_offset": 254851
+    },
+    {
+      "line": "#3 0x55faae2010ff in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x280ff) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+      "address": 94535151522047,
+      "function_name": "fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long)",
+      "module_path": "/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe",
+      "module_offset": 164095
+    },
+    {
+      "line": "#4 0x55faae206e56 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x2de56) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+      "address": 94535151545942,
+      "function_name": "fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long))",
+      "module_path": "/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe",
+      "module_offset": 187990
+    },
+    {
+      "line": "#5 0x55faae230c72 in main (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x57c72) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+      "address": 94535151717490,
+      "function_name": "main",
+      "module_path": "/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe",
+      "module_offset": 359538
+    },
+    {
+      "line": "#6 0x7fda0af66d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)",
+      "address": 140574463520143,
+      "module_path": "/lib/x86_64-linux-gnu/libc.so.6",
+      "module_offset": 171407
+    },
+    {
+      "line": "#7 0x7fda0af66e3f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x29e3f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)",
+      "address": 140574463520319,
+      "function_name": "__libc_start_main",
+      "module_path": "/lib/x86_64-linux-gnu/libc.so.6",
+      "module_offset": 171583
+    },
+    {
+      "line": "#8 0x55faae1fb9c4 in _start (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x229c4) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+      "address": 94535151499716,
+      "function_name": "_start",
+      "module_path": "/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe",
+      "module_offset": 141764
+    }
+  ],
+  "full_stack_names": [
+    "__interceptor_free",
+    "LLVMFuzzerTestOneInput",
+    "fuzzer::Fuzzer::ExecuteCallback",
+    "fuzzer::RunOneTest",
+    "fuzzer::FuzzerDriver",
+    "main",
+    "__libc_start_main",
+    "_start"
+  ],
+  "minimized_stack_details": [
+    {
+      "line": "#1 0x55faae2ef2fc in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:73:56",
+      "address": 94535152497404,
+      "function_name": "simple.c",
+      "function_offset": 56,
+      "source_file_name": "simple.c",
+      "source_file_path": "/workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c",
+      "source_file_line": 73
+    }
+  ],
+  "minimized_stack": [
+    "#1 0x55faae2ef2fc in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:73:56"
+  ],
+  "minimized_stack_function_names": [
+    "simple.c"
+  ],
+  "minimized_stack_function_lines": [
+    "simple.c simple.c:73:56"
+  ]
+}

--- a/src/agent/stacktrace-parser/data/parsed-traces/check_dir@example-fpe.txt.snap
+++ b/src/agent/stacktrace-parser/data/parsed-traces/check_dir@example-fpe.txt.snap
@@ -1,0 +1,109 @@
+---
+source: stacktrace-parser/src/lib.rs
+expression: parsed
+input_file: stacktrace-parser/data/stack-traces/example-fpe.txt
+---
+{
+  "text": "=================================================================\n==63741==ERROR: AddressSanitizer: FPE on unknown address 0x556e7dca348e (pc 0x556e7dca348e bp 0x7ffe07bae220 sp 0x7ffe07bae020 T0)\n    #0 0x556e7dca348e in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:88:32\n    #1 0x556e7dbcb383 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x3e383) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n    #2 0x556e7dbb50ff in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x280ff) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n    #3 0x556e7dbbae56 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x2de56) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n    #4 0x556e7dbe4c72 in main (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x57c72) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n    #5 0x7fa30424cd8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)\n    #6 0x7fa30424ce3f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x29e3f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)\n    #7 0x556e7dbaf9c4 in _start (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x229c4) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n\nAddressSanitizer can not provide additional info.\nSUMMARY: AddressSanitizer: FPE /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:88:32 in LLVMFuzzerTestOneInput\n==63741==ABORTING\n",
+  "sanitizer": "AddressSanitizer",
+  "summary": "AddressSanitizer: FPE /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:88:32 in LLVMFuzzerTestOneInput",
+  "fault_type": "FPE",
+  "call_stack": [
+    "#0 0x556e7dca348e in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:88:32",
+    "#1 0x556e7dbcb383 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x3e383) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+    "#2 0x556e7dbb50ff in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x280ff) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+    "#3 0x556e7dbbae56 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x2de56) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+    "#4 0x556e7dbe4c72 in main (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x57c72) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+    "#5 0x7fa30424cd8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)",
+    "#6 0x7fa30424ce3f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x29e3f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)",
+    "#7 0x556e7dbaf9c4 in _start (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x229c4) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)"
+  ],
+  "full_stack_details": [
+    {
+      "line": "#0 0x556e7dca348e in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:88:32",
+      "address": 93933045167246,
+      "function_name": "LLVMFuzzerTestOneInput",
+      "function_offset": 32,
+      "source_file_name": "simple.c",
+      "source_file_path": "/workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c",
+      "source_file_line": 88
+    },
+    {
+      "line": "#1 0x556e7dbcb383 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x3e383) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+      "address": 93933044282243,
+      "function_name": "fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long)",
+      "module_path": "/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe",
+      "module_offset": 254851
+    },
+    {
+      "line": "#2 0x556e7dbb50ff in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x280ff) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+      "address": 93933044191487,
+      "function_name": "fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long)",
+      "module_path": "/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe",
+      "module_offset": 164095
+    },
+    {
+      "line": "#3 0x556e7dbbae56 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x2de56) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+      "address": 93933044215382,
+      "function_name": "fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long))",
+      "module_path": "/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe",
+      "module_offset": 187990
+    },
+    {
+      "line": "#4 0x556e7dbe4c72 in main (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x57c72) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+      "address": 93933044386930,
+      "function_name": "main",
+      "module_path": "/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe",
+      "module_offset": 359538
+    },
+    {
+      "line": "#5 0x7fa30424cd8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)",
+      "address": 140338125917583,
+      "module_path": "/lib/x86_64-linux-gnu/libc.so.6",
+      "module_offset": 171407
+    },
+    {
+      "line": "#6 0x7fa30424ce3f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x29e3f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)",
+      "address": 140338125917759,
+      "function_name": "__libc_start_main",
+      "module_path": "/lib/x86_64-linux-gnu/libc.so.6",
+      "module_offset": 171583
+    },
+    {
+      "line": "#7 0x556e7dbaf9c4 in _start (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x229c4) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+      "address": 93933044169156,
+      "function_name": "_start",
+      "module_path": "/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe",
+      "module_offset": 141764
+    }
+  ],
+  "full_stack_names": [
+    "LLVMFuzzerTestOneInput",
+    "fuzzer::Fuzzer::ExecuteCallback",
+    "fuzzer::RunOneTest",
+    "fuzzer::FuzzerDriver",
+    "main",
+    "__libc_start_main",
+    "_start"
+  ],
+  "minimized_stack_details": [
+    {
+      "line": "#0 0x556e7dca348e in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:88:32",
+      "address": 93933045167246,
+      "function_name": "simple.c",
+      "function_offset": 32,
+      "source_file_name": "simple.c",
+      "source_file_path": "/workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c",
+      "source_file_line": 88
+    }
+  ],
+  "minimized_stack": [
+    "#0 0x556e7dca348e in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:88:32"
+  ],
+  "minimized_stack_function_names": [
+    "simple.c"
+  ],
+  "minimized_stack_function_lines": [
+    "simple.c simple.c:88:32"
+  ]
+}

--- a/src/agent/stacktrace-parser/data/parsed-traces/check_dir@example-free-on-address.txt.snap
+++ b/src/agent/stacktrace-parser/data/parsed-traces/check_dir@example-free-on-address.txt.snap
@@ -1,0 +1,118 @@
+---
+source: stacktrace-parser/src/lib.rs
+expression: parsed
+input_file: stacktrace-parser/data/stack-traces/example-free-on-address.txt
+---
+{
+  "text": "=================================================================\n==61632==ERROR: AddressSanitizer: attempting free on address which was not malloc()-ed: 0x7fff501dd020 in thread T0\n    #0 0x55c4d93d6752 in __interceptor_free (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0xda752) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n    #1 0x55c4d94122b6 in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:68:24\n    #2 0x55c4d933a383 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x3e383) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n    #3 0x55c4d93240ff in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x280ff) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n    #4 0x55c4d9329e56 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x2de56) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n    #5 0x55c4d9353c72 in main (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x57c72) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n    #6 0x7fb4e6c0ad8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)\n    #7 0x7fb4e6c0ae3f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x29e3f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)\n    #8 0x55c4d931e9c4 in _start (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x229c4) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n\nAddress 0x7fff501dd020 is located in stack of thread T0 at offset 32 in frame\n    #0 0x55c4d9411aaf in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:38\n\n  This frame has 1 object(s):\n    [32, 36) 'cnt' (line 39) <== Memory access at offset 32 is inside this variable\nHINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork\n      (longjmp and C++ exceptions *are* supported)\nSUMMARY: AddressSanitizer: bad-free (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0xda752) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0) in __interceptor_free\n==61632==ABORTING\n",
+  "sanitizer": "AddressSanitizer",
+  "summary": "AddressSanitizer: bad-free (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0xda752) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0) in __interceptor_free",
+  "fault_type": "bad-free",
+  "call_stack": [
+    "#0 0x55c4d93d6752 in __interceptor_free (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0xda752) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+    "#1 0x55c4d94122b6 in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:68:24",
+    "#2 0x55c4d933a383 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x3e383) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+    "#3 0x55c4d93240ff in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x280ff) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+    "#4 0x55c4d9329e56 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x2de56) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+    "#5 0x55c4d9353c72 in main (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x57c72) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+    "#6 0x7fb4e6c0ad8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)",
+    "#7 0x7fb4e6c0ae3f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x29e3f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)",
+    "#8 0x55c4d931e9c4 in _start (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x229c4) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)"
+  ],
+  "full_stack_details": [
+    {
+      "line": "#0 0x55c4d93d6752 in __interceptor_free (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0xda752) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+      "address": 94303946630994,
+      "function_name": "__interceptor_free",
+      "module_path": "/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe",
+      "module_offset": 894802
+    },
+    {
+      "line": "#1 0x55c4d94122b6 in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:68:24",
+      "address": 94303946875574,
+      "function_name": "LLVMFuzzerTestOneInput",
+      "function_offset": 24,
+      "source_file_name": "simple.c",
+      "source_file_path": "/workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c",
+      "source_file_line": 68
+    },
+    {
+      "line": "#2 0x55c4d933a383 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x3e383) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+      "address": 94303945991043,
+      "function_name": "fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long)",
+      "module_path": "/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe",
+      "module_offset": 254851
+    },
+    {
+      "line": "#3 0x55c4d93240ff in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x280ff) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+      "address": 94303945900287,
+      "function_name": "fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long)",
+      "module_path": "/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe",
+      "module_offset": 164095
+    },
+    {
+      "line": "#4 0x55c4d9329e56 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x2de56) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+      "address": 94303945924182,
+      "function_name": "fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long))",
+      "module_path": "/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe",
+      "module_offset": 187990
+    },
+    {
+      "line": "#5 0x55c4d9353c72 in main (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x57c72) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+      "address": 94303946095730,
+      "function_name": "main",
+      "module_path": "/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe",
+      "module_offset": 359538
+    },
+    {
+      "line": "#6 0x7fb4e6c0ad8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)",
+      "address": 140414942227855,
+      "module_path": "/lib/x86_64-linux-gnu/libc.so.6",
+      "module_offset": 171407
+    },
+    {
+      "line": "#7 0x7fb4e6c0ae3f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x29e3f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)",
+      "address": 140414942228031,
+      "function_name": "__libc_start_main",
+      "module_path": "/lib/x86_64-linux-gnu/libc.so.6",
+      "module_offset": 171583
+    },
+    {
+      "line": "#8 0x55c4d931e9c4 in _start (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x229c4) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+      "address": 94303945877956,
+      "function_name": "_start",
+      "module_path": "/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe",
+      "module_offset": 141764
+    }
+  ],
+  "full_stack_names": [
+    "__interceptor_free",
+    "LLVMFuzzerTestOneInput",
+    "fuzzer::Fuzzer::ExecuteCallback",
+    "fuzzer::RunOneTest",
+    "fuzzer::FuzzerDriver",
+    "main",
+    "__libc_start_main",
+    "_start"
+  ],
+  "minimized_stack_details": [
+    {
+      "line": "#1 0x55c4d94122b6 in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:68:24",
+      "address": 94303946875574,
+      "function_name": "simple.c",
+      "function_offset": 24,
+      "source_file_name": "simple.c",
+      "source_file_path": "/workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c",
+      "source_file_line": 68
+    }
+  ],
+  "minimized_stack": [
+    "#1 0x55c4d94122b6 in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:68:24"
+  ],
+  "minimized_stack_function_names": [
+    "simple.c"
+  ],
+  "minimized_stack_function_lines": [
+    "simple.c simple.c:68:24"
+  ]
+}

--- a/src/agent/stacktrace-parser/data/parsed-traces/check_dir@example-heap-buffer-overflow.txt.snap
+++ b/src/agent/stacktrace-parser/data/parsed-traces/check_dir@example-heap-buffer-overflow.txt.snap
@@ -1,0 +1,109 @@
+---
+source: stacktrace-parser/src/lib.rs
+expression: parsed
+input_file: stacktrace-parser/data/stack-traces/example-heap-buffer-overflow.txt
+---
+{
+  "text": "=================================================================\n==63506==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x603000000150 at pc 0x55985b227427 bp 0x7ffed7cabb50 sp 0x7ffed7cabb48\nWRITE of size 4 at 0x603000000150 thread T0\n    #0 0x55985b227426 in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:83:91\n    #1 0x55985b14f383 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x3e383) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n    #2 0x55985b1390ff in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x280ff) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n    #3 0x55985b13ee56 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x2de56) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n    #4 0x55985b168c72 in main (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x57c72) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n    #5 0x7fd7b9330d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)\n    #6 0x7fd7b9330e3f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x29e3f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)\n    #7 0x55985b1339c4 in _start (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x229c4) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n\n0x603000000150 is located 0 bytes to the right of 32-byte region [0x603000000130,0x603000000150)\nallocated by thread T0 here:\n    #0 0x55985b1eb9fe in malloc (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0xda9fe) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n    #1 0x55985b227399 in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:83:26\n    #2 0x55985b14f383 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x3e383) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n    #3 0x55985b1390ff in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x280ff) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n    #4 0x55985b13ee56 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x2de56) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n    #5 0x55985b168c72 in main (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x57c72) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n    #6 0x7fd7b9330d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)\n\nSUMMARY: AddressSanitizer: heap-buffer-overflow /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:83:91 in LLVMFuzzerTestOneInput\nShadow bytes around the buggy address:\n  0x0c067fff7fd0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00\n  0x0c067fff7fe0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00\n  0x0c067fff7ff0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00\n  0x0c067fff8000: fa fa 00 00 00 fa fa fa 00 00 00 fa fa fa 00 00\n  0x0c067fff8010: 00 00 fa fa 00 00 00 fa fa fa 00 00 00 00 fa fa\n=>0x0c067fff8020: 00 00 00 00 fa fa 00 00 00 00[fa]fa fa fa fa fa\n  0x0c067fff8030: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa\n  0x0c067fff8040: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa\n  0x0c067fff8050: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa\n  0x0c067fff8060: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa\n  0x0c067fff8070: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa\nShadow byte legend (one shadow byte represents 8 application bytes):\n  Addressable:           00\n  Partially addressable: 01 02 03 04 05 06 07 \n  Heap left redzone:       fa\n  Freed heap region:       fd\n  Stack left redzone:      f1\n  Stack mid redzone:       f2\n  Stack right redzone:     f3\n  Stack after return:      f5\n  Stack use after scope:   f8\n  Global redzone:          f9\n  Global init order:       f6\n  Poisoned by user:        f7\n  Container overflow:      fc\n  Array cookie:            ac\n  Intra object redzone:    bb\n  ASan internal:           fe\n  Left alloca redzone:     ca\n  Right alloca redzone:    cb\n==63506==ABORTING\n",
+  "sanitizer": "AddressSanitizer",
+  "summary": "AddressSanitizer: heap-buffer-overflow /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:83:91 in LLVMFuzzerTestOneInput",
+  "fault_type": "heap-buffer-overflow",
+  "call_stack": [
+    "#0 0x55985b227426 in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:83:91",
+    "#1 0x55985b14f383 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x3e383) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+    "#2 0x55985b1390ff in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x280ff) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+    "#3 0x55985b13ee56 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x2de56) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+    "#4 0x55985b168c72 in main (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x57c72) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+    "#5 0x7fd7b9330d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)",
+    "#6 0x7fd7b9330e3f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x29e3f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)",
+    "#7 0x55985b1339c4 in _start (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x229c4) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)"
+  ],
+  "full_stack_details": [
+    {
+      "line": "#0 0x55985b227426 in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:83:91",
+      "address": 94112852374566,
+      "function_name": "LLVMFuzzerTestOneInput",
+      "function_offset": 91,
+      "source_file_name": "simple.c",
+      "source_file_path": "/workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c",
+      "source_file_line": 83
+    },
+    {
+      "line": "#1 0x55985b14f383 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x3e383) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+      "address": 94112851489667,
+      "function_name": "fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long)",
+      "module_path": "/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe",
+      "module_offset": 254851
+    },
+    {
+      "line": "#2 0x55985b1390ff in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x280ff) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+      "address": 94112851398911,
+      "function_name": "fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long)",
+      "module_path": "/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe",
+      "module_offset": 164095
+    },
+    {
+      "line": "#3 0x55985b13ee56 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x2de56) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+      "address": 94112851422806,
+      "function_name": "fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long))",
+      "module_path": "/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe",
+      "module_offset": 187990
+    },
+    {
+      "line": "#4 0x55985b168c72 in main (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x57c72) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+      "address": 94112851594354,
+      "function_name": "main",
+      "module_path": "/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe",
+      "module_offset": 359538
+    },
+    {
+      "line": "#5 0x7fd7b9330d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)",
+      "address": 140564501826959,
+      "module_path": "/lib/x86_64-linux-gnu/libc.so.6",
+      "module_offset": 171407
+    },
+    {
+      "line": "#6 0x7fd7b9330e3f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x29e3f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)",
+      "address": 140564501827135,
+      "function_name": "__libc_start_main",
+      "module_path": "/lib/x86_64-linux-gnu/libc.so.6",
+      "module_offset": 171583
+    },
+    {
+      "line": "#7 0x55985b1339c4 in _start (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x229c4) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+      "address": 94112851376580,
+      "function_name": "_start",
+      "module_path": "/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe",
+      "module_offset": 141764
+    }
+  ],
+  "full_stack_names": [
+    "LLVMFuzzerTestOneInput",
+    "fuzzer::Fuzzer::ExecuteCallback",
+    "fuzzer::RunOneTest",
+    "fuzzer::FuzzerDriver",
+    "main",
+    "__libc_start_main",
+    "_start"
+  ],
+  "minimized_stack_details": [
+    {
+      "line": "#0 0x55985b227426 in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:83:91",
+      "address": 94112852374566,
+      "function_name": "simple.c",
+      "function_offset": 91,
+      "source_file_name": "simple.c",
+      "source_file_path": "/workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c",
+      "source_file_line": 83
+    }
+  ],
+  "minimized_stack": [
+    "#0 0x55985b227426 in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:83:91"
+  ],
+  "minimized_stack_function_names": [
+    "simple.c"
+  ],
+  "minimized_stack_function_lines": [
+    "simple.c simple.c:83:91"
+  ]
+}

--- a/src/agent/stacktrace-parser/data/parsed-traces/check_dir@example-heap-use-after-free.txt.snap
+++ b/src/agent/stacktrace-parser/data/parsed-traces/check_dir@example-heap-use-after-free.txt.snap
@@ -1,0 +1,109 @@
+---
+source: stacktrace-parser/src/lib.rs
+expression: parsed
+input_file: stacktrace-parser/data/stack-traces/example-heap-use-after-free.txt
+---
+{
+  "text": "=================================================================\n==63302==ERROR: AddressSanitizer: heap-use-after-free on address 0x602000000050 at pc 0x55cba0d8c377 bp 0x7fff6409d3d0 sp 0x7fff6409d3c8\nWRITE of size 4 at 0x602000000050 thread T0\n    #0 0x55cba0d8c376 in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:78:59\n    #1 0x55cba0cb4383 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x3e383) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n    #2 0x55cba0c9e0ff in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x280ff) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n    #3 0x55cba0ca3e56 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x2de56) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n    #4 0x55cba0ccdc72 in main (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x57c72) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n    #5 0x7f0fe85ddd8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)\n    #6 0x7f0fe85dde3f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x29e3f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)\n    #7 0x55cba0c989c4 in _start (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x229c4) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n\n0x602000000050 is located 0 bytes inside of 4-byte region [0x602000000050,0x602000000054)\nfreed by thread T0 here:\n    #0 0x55cba0d50752 in __interceptor_free (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0xda752) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n    #1 0x55cba0d8c336 in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:78:47\n    #2 0x55cba0cb4383 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x3e383) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n    #3 0x55cba0c9e0ff in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x280ff) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n    #4 0x55cba0ca3e56 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x2de56) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n    #5 0x55cba0ccdc72 in main (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x57c72) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n    #6 0x7f0fe85ddd8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)\n\npreviously allocated by thread T0 here:\n    #0 0x55cba0d509fe in malloc (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0xda9fe) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n    #1 0x55cba0d8c323 in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:78:26\n    #2 0x55cba0cb4383 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x3e383) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n    #3 0x55cba0c9e0ff in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x280ff) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n    #4 0x55cba0ca3e56 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x2de56) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n    #5 0x55cba0ccdc72 in main (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x57c72) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n    #6 0x7f0fe85ddd8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)\n\nSUMMARY: AddressSanitizer: heap-use-after-free /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:78:59 in LLVMFuzzerTestOneInput\nShadow bytes around the buggy address:\n  0x0c047fff7fb0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00\n  0x0c047fff7fc0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00\n  0x0c047fff7fd0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00\n  0x0c047fff7fe0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00\n  0x0c047fff7ff0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00\n=>0x0c047fff8000: fa fa 05 fa fa fa 05 fa fa fa[fd]fa fa fa fa fa\n  0x0c047fff8010: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa\n  0x0c047fff8020: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa\n  0x0c047fff8030: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa\n  0x0c047fff8040: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa\n  0x0c047fff8050: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa\nShadow byte legend (one shadow byte represents 8 application bytes):\n  Addressable:           00\n  Partially addressable: 01 02 03 04 05 06 07 \n  Heap left redzone:       fa\n  Freed heap region:       fd\n  Stack left redzone:      f1\n  Stack mid redzone:       f2\n  Stack right redzone:     f3\n  Stack after return:      f5\n  Stack use after scope:   f8\n  Global redzone:          f9\n  Global init order:       f6\n  Poisoned by user:        f7\n  Container overflow:      fc\n  Array cookie:            ac\n  Intra object redzone:    bb\n  ASan internal:           fe\n  Left alloca redzone:     ca\n  Right alloca redzone:    cb\n==63302==ABORTING\n",
+  "sanitizer": "AddressSanitizer",
+  "summary": "AddressSanitizer: heap-use-after-free /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:78:59 in LLVMFuzzerTestOneInput",
+  "fault_type": "heap-use-after-free",
+  "call_stack": [
+    "#0 0x55cba0d8c376 in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:78:59",
+    "#1 0x55cba0cb4383 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x3e383) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+    "#2 0x55cba0c9e0ff in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x280ff) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+    "#3 0x55cba0ca3e56 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x2de56) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+    "#4 0x55cba0ccdc72 in main (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x57c72) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+    "#5 0x7f0fe85ddd8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)",
+    "#6 0x7f0fe85dde3f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x29e3f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)",
+    "#7 0x55cba0c989c4 in _start (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x229c4) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)"
+  ],
+  "full_stack_details": [
+    {
+      "line": "#0 0x55cba0d8c376 in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:78:59",
+      "address": 94333065282422,
+      "function_name": "LLVMFuzzerTestOneInput",
+      "function_offset": 59,
+      "source_file_name": "simple.c",
+      "source_file_path": "/workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c",
+      "source_file_line": 78
+    },
+    {
+      "line": "#1 0x55cba0cb4383 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x3e383) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+      "address": 94333064397699,
+      "function_name": "fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long)",
+      "module_path": "/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe",
+      "module_offset": 254851
+    },
+    {
+      "line": "#2 0x55cba0c9e0ff in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x280ff) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+      "address": 94333064306943,
+      "function_name": "fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long)",
+      "module_path": "/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe",
+      "module_offset": 164095
+    },
+    {
+      "line": "#3 0x55cba0ca3e56 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x2de56) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+      "address": 94333064330838,
+      "function_name": "fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long))",
+      "module_path": "/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe",
+      "module_offset": 187990
+    },
+    {
+      "line": "#4 0x55cba0ccdc72 in main (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x57c72) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+      "address": 94333064502386,
+      "function_name": "main",
+      "module_path": "/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe",
+      "module_offset": 359538
+    },
+    {
+      "line": "#5 0x7f0fe85ddd8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)",
+      "address": 139706299702671,
+      "module_path": "/lib/x86_64-linux-gnu/libc.so.6",
+      "module_offset": 171407
+    },
+    {
+      "line": "#6 0x7f0fe85dde3f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x29e3f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)",
+      "address": 139706299702847,
+      "function_name": "__libc_start_main",
+      "module_path": "/lib/x86_64-linux-gnu/libc.so.6",
+      "module_offset": 171583
+    },
+    {
+      "line": "#7 0x55cba0c989c4 in _start (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x229c4) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+      "address": 94333064284612,
+      "function_name": "_start",
+      "module_path": "/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe",
+      "module_offset": 141764
+    }
+  ],
+  "full_stack_names": [
+    "LLVMFuzzerTestOneInput",
+    "fuzzer::Fuzzer::ExecuteCallback",
+    "fuzzer::RunOneTest",
+    "fuzzer::FuzzerDriver",
+    "main",
+    "__libc_start_main",
+    "_start"
+  ],
+  "minimized_stack_details": [
+    {
+      "line": "#0 0x55cba0d8c376 in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:78:59",
+      "address": 94333065282422,
+      "function_name": "simple.c",
+      "function_offset": 59,
+      "source_file_name": "simple.c",
+      "source_file_path": "/workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c",
+      "source_file_line": 78
+    }
+  ],
+  "minimized_stack": [
+    "#0 0x55cba0d8c376 in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:78:59"
+  ],
+  "minimized_stack_function_names": [
+    "simple.c"
+  ],
+  "minimized_stack_function_lines": [
+    "simple.c simple.c:78:59"
+  ]
+}

--- a/src/agent/stacktrace-parser/data/parsed-traces/check_dir@example-segv.txt.snap
+++ b/src/agent/stacktrace-parser/data/parsed-traces/check_dir@example-segv.txt.snap
@@ -1,0 +1,109 @@
+---
+source: stacktrace-parser/src/lib.rs
+expression: parsed
+input_file: stacktrace-parser/data/stack-traces/example-segv.txt
+---
+{
+  "text": "=================================================================\n==62189==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000000 (pc 0x55b1150570b0 bp 0x7ffc48bbbe30 sp 0x7ffc48bbbc40 T0)\n==62189==The signal is caused by a WRITE memory access.\n==62189==Hint: address points to the zero page.\n    #0 0x55b1150570b0 in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:53:27\n    #1 0x55b114f7f383 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x3e383) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n    #2 0x55b114f690ff in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x280ff) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n    #3 0x55b114f6ee56 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x2de56) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n    #4 0x55b114f98c72 in main (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x57c72) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n    #5 0x7ff53bbe6d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)\n    #6 0x7ff53bbe6e3f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x29e3f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)\n    #7 0x55b114f639c4 in _start (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x229c4) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n\nAddressSanitizer can not provide additional info.\nSUMMARY: AddressSanitizer: SEGV /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:53:27 in LLVMFuzzerTestOneInput\n==62189==ABORTING\n",
+  "sanitizer": "AddressSanitizer",
+  "summary": "AddressSanitizer: SEGV /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:53:27 in LLVMFuzzerTestOneInput",
+  "fault_type": "SEGV",
+  "call_stack": [
+    "#0 0x55b1150570b0 in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:53:27",
+    "#1 0x55b114f7f383 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x3e383) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+    "#2 0x55b114f690ff in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x280ff) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+    "#3 0x55b114f6ee56 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x2de56) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+    "#4 0x55b114f98c72 in main (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x57c72) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+    "#5 0x7ff53bbe6d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)",
+    "#6 0x7ff53bbe6e3f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x29e3f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)",
+    "#7 0x55b114f639c4 in _start (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x229c4) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)"
+  ],
+  "full_stack_details": [
+    {
+      "line": "#0 0x55b1150570b0 in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:53:27",
+      "address": 94219050250416,
+      "function_name": "LLVMFuzzerTestOneInput",
+      "function_offset": 27,
+      "source_file_name": "simple.c",
+      "source_file_path": "/workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c",
+      "source_file_line": 53
+    },
+    {
+      "line": "#1 0x55b114f7f383 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x3e383) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+      "address": 94219049366403,
+      "function_name": "fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long)",
+      "module_path": "/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe",
+      "module_offset": 254851
+    },
+    {
+      "line": "#2 0x55b114f690ff in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x280ff) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+      "address": 94219049275647,
+      "function_name": "fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long)",
+      "module_path": "/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe",
+      "module_offset": 164095
+    },
+    {
+      "line": "#3 0x55b114f6ee56 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x2de56) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+      "address": 94219049299542,
+      "function_name": "fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long))",
+      "module_path": "/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe",
+      "module_offset": 187990
+    },
+    {
+      "line": "#4 0x55b114f98c72 in main (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x57c72) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+      "address": 94219049471090,
+      "function_name": "main",
+      "module_path": "/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe",
+      "module_offset": 359538
+    },
+    {
+      "line": "#5 0x7ff53bbe6d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)",
+      "address": 140691246050703,
+      "module_path": "/lib/x86_64-linux-gnu/libc.so.6",
+      "module_offset": 171407
+    },
+    {
+      "line": "#6 0x7ff53bbe6e3f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x29e3f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)",
+      "address": 140691246050879,
+      "function_name": "__libc_start_main",
+      "module_path": "/lib/x86_64-linux-gnu/libc.so.6",
+      "module_offset": 171583
+    },
+    {
+      "line": "#7 0x55b114f639c4 in _start (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x229c4) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+      "address": 94219049253316,
+      "function_name": "_start",
+      "module_path": "/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe",
+      "module_offset": 141764
+    }
+  ],
+  "full_stack_names": [
+    "LLVMFuzzerTestOneInput",
+    "fuzzer::Fuzzer::ExecuteCallback",
+    "fuzzer::RunOneTest",
+    "fuzzer::FuzzerDriver",
+    "main",
+    "__libc_start_main",
+    "_start"
+  ],
+  "minimized_stack_details": [
+    {
+      "line": "#0 0x55b1150570b0 in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:53:27",
+      "address": 94219050250416,
+      "function_name": "simple.c",
+      "function_offset": 27,
+      "source_file_name": "simple.c",
+      "source_file_path": "/workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c",
+      "source_file_line": 53
+    }
+  ],
+  "minimized_stack": [
+    "#0 0x55b1150570b0 in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:53:27"
+  ],
+  "minimized_stack_function_names": [
+    "simple.c"
+  ],
+  "minimized_stack_function_lines": [
+    "simple.c simple.c:53:27"
+  ]
+}

--- a/src/agent/stacktrace-parser/data/parsed-traces/check_dir@example-stack-buffer-overflow.txt.snap
+++ b/src/agent/stacktrace-parser/data/parsed-traces/check_dir@example-stack-buffer-overflow.txt.snap
@@ -1,0 +1,109 @@
+---
+source: stacktrace-parser/src/lib.rs
+expression: parsed
+input_file: stacktrace-parser/data/stack-traces/example-stack-buffer-overflow.txt
+---
+{
+  "text": "=================================================================\n==62893==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7fffb9b7ed9c at pc 0x55ec35545245 bp 0x7fffb9b7ed50 sp 0x7fffb9b7ed48\nWRITE of size 4 at 0x7fffb9b7ed9c thread T0\n    #0 0x55ec35545244 in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:63:69\n    #1 0x55ec3546d383 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x3e383) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n    #2 0x55ec354570ff in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x280ff) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n    #3 0x55ec3545ce56 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x2de56) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n    #4 0x55ec35486c72 in main (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x57c72) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n    #5 0x7fb1900d1d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)\n    #6 0x7fb1900d1e3f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x29e3f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)\n    #7 0x55ec354519c4 in _start (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x229c4) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n\nAddress 0x7fffb9b7ed9c is located in stack of thread T0 at offset 60 in frame\n    #0 0x55ec35544aaf in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:38\n\n  This frame has 1 object(s):\n    [32, 36) 'cnt' (line 39) <== Memory access at offset 60 overflows this variable\nHINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork\n      (longjmp and C++ exceptions *are* supported)\nSUMMARY: AddressSanitizer: stack-buffer-overflow /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:63:69 in LLVMFuzzerTestOneInput\nShadow bytes around the buggy address:\n  0x100077367d60: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00\n  0x100077367d70: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00\n  0x100077367d80: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00\n  0x100077367d90: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00\n  0x100077367da0: 00 00 00 00 00 00 00 00 00 00 00 00 f1 f1 f1 f1\n=>0x100077367db0: 04 f3 f3[f3]00 00 00 00 00 00 00 00 00 00 00 00\n  0x100077367dc0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00\n  0x100077367dd0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00\n  0x100077367de0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00\n  0x100077367df0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00\n  0x100077367e00: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00\nShadow byte legend (one shadow byte represents 8 application bytes):\n  Addressable:           00\n  Partially addressable: 01 02 03 04 05 06 07 \n  Heap left redzone:       fa\n  Freed heap region:       fd\n  Stack left redzone:      f1\n  Stack mid redzone:       f2\n  Stack right redzone:     f3\n  Stack after return:      f5\n  Stack use after scope:   f8\n  Global redzone:          f9\n  Global init order:       f6\n  Poisoned by user:        f7\n  Container overflow:      fc\n  Array cookie:            ac\n  Intra object redzone:    bb\n  ASan internal:           fe\n  Left alloca redzone:     ca\n  Right alloca redzone:    cb\n==62893==ABORTING\n",
+  "sanitizer": "AddressSanitizer",
+  "summary": "AddressSanitizer: stack-buffer-overflow /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:63:69 in LLVMFuzzerTestOneInput",
+  "fault_type": "stack-buffer-overflow",
+  "call_stack": [
+    "#0 0x55ec35545244 in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:63:69",
+    "#1 0x55ec3546d383 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x3e383) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+    "#2 0x55ec354570ff in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x280ff) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+    "#3 0x55ec3545ce56 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x2de56) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+    "#4 0x55ec35486c72 in main (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x57c72) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+    "#5 0x7fb1900d1d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)",
+    "#6 0x7fb1900d1e3f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x29e3f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)",
+    "#7 0x55ec354519c4 in _start (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x229c4) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)"
+  ],
+  "full_stack_details": [
+    {
+      "line": "#0 0x55ec35545244 in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:63:69",
+      "address": 94472995361348,
+      "function_name": "LLVMFuzzerTestOneInput",
+      "function_offset": 69,
+      "source_file_name": "simple.c",
+      "source_file_path": "/workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c",
+      "source_file_line": 63
+    },
+    {
+      "line": "#1 0x55ec3546d383 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x3e383) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+      "address": 94472994476931,
+      "function_name": "fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long)",
+      "module_path": "/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe",
+      "module_offset": 254851
+    },
+    {
+      "line": "#2 0x55ec354570ff in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x280ff) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+      "address": 94472994386175,
+      "function_name": "fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long)",
+      "module_path": "/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe",
+      "module_offset": 164095
+    },
+    {
+      "line": "#3 0x55ec3545ce56 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x2de56) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+      "address": 94472994410070,
+      "function_name": "fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long))",
+      "module_path": "/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe",
+      "module_offset": 187990
+    },
+    {
+      "line": "#4 0x55ec35486c72 in main (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x57c72) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+      "address": 94472994581618,
+      "function_name": "main",
+      "module_path": "/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe",
+      "module_offset": 359538
+    },
+    {
+      "line": "#5 0x7fb1900d1d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)",
+      "address": 140400602717583,
+      "module_path": "/lib/x86_64-linux-gnu/libc.so.6",
+      "module_offset": 171407
+    },
+    {
+      "line": "#6 0x7fb1900d1e3f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x29e3f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)",
+      "address": 140400602717759,
+      "function_name": "__libc_start_main",
+      "module_path": "/lib/x86_64-linux-gnu/libc.so.6",
+      "module_offset": 171583
+    },
+    {
+      "line": "#7 0x55ec354519c4 in _start (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x229c4) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+      "address": 94472994363844,
+      "function_name": "_start",
+      "module_path": "/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe",
+      "module_offset": 141764
+    }
+  ],
+  "full_stack_names": [
+    "LLVMFuzzerTestOneInput",
+    "fuzzer::Fuzzer::ExecuteCallback",
+    "fuzzer::RunOneTest",
+    "fuzzer::FuzzerDriver",
+    "main",
+    "__libc_start_main",
+    "_start"
+  ],
+  "minimized_stack_details": [
+    {
+      "line": "#0 0x55ec35545244 in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:63:69",
+      "address": 94472995361348,
+      "function_name": "simple.c",
+      "function_offset": 69,
+      "source_file_name": "simple.c",
+      "source_file_path": "/workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c",
+      "source_file_line": 63
+    }
+  ],
+  "minimized_stack": [
+    "#0 0x55ec35545244 in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:63:69"
+  ],
+  "minimized_stack_function_names": [
+    "simple.c"
+  ],
+  "minimized_stack_function_lines": [
+    "simple.c simple.c:63:69"
+  ]
+}

--- a/src/agent/stacktrace-parser/data/parsed-traces/check_dir@example-stack-buffer-underflow.txt.snap
+++ b/src/agent/stacktrace-parser/data/parsed-traces/check_dir@example-stack-buffer-underflow.txt.snap
@@ -1,0 +1,109 @@
+---
+source: stacktrace-parser/src/lib.rs
+expression: parsed
+input_file: stacktrace-parser/data/stack-traces/example-stack-buffer-underflow.txt
+---
+{
+  "text": "=================================================================\n==62612==ERROR: AddressSanitizer: stack-buffer-underflow on address 0x7fffe06ddf80 at pc 0x562de266b15d bp 0x7fffe06ddf70 sp 0x7fffe06ddf68\nWRITE of size 4 at 0x7fffe06ddf80 thread T0\n    #0 0x562de266b15c in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:58:69\n    #1 0x562de2593383 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x3e383) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n    #2 0x562de257d0ff in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x280ff) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n    #3 0x562de2582e56 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x2de56) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n    #4 0x562de25acc72 in main (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x57c72) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n    #5 0x7fe76a3d5d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)\n    #6 0x7fe76a3d5e3f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x29e3f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)\n    #7 0x562de25779c4 in _start (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x229c4) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)\n\nAddress 0x7fffe06ddf80 is located in stack of thread T0 at offset 0 in frame\n    #0 0x562de266aaaf in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:38\n\n  This frame has 1 object(s):\n    [32, 36) 'cnt' (line 39)\nHINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork\n      (longjmp and C++ exceptions *are* supported)\nSUMMARY: AddressSanitizer: stack-buffer-underflow /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:58:69 in LLVMFuzzerTestOneInput\nShadow bytes around the buggy address:\n  0x10007c0d3ba0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00\n  0x10007c0d3bb0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00\n  0x10007c0d3bc0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00\n  0x10007c0d3bd0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00\n  0x10007c0d3be0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00\n=>0x10007c0d3bf0:[f1]f1 f1 f1 04 f3 f3 f3 00 00 00 00 00 00 00 00\n  0x10007c0d3c00: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00\n  0x10007c0d3c10: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00\n  0x10007c0d3c20: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00\n  0x10007c0d3c30: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00\n  0x10007c0d3c40: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00\nShadow byte legend (one shadow byte represents 8 application bytes):\n  Addressable:           00\n  Partially addressable: 01 02 03 04 05 06 07 \n  Heap left redzone:       fa\n  Freed heap region:       fd\n  Stack left redzone:      f1\n  Stack mid redzone:       f2\n  Stack right redzone:     f3\n  Stack after return:      f5\n  Stack use after scope:   f8\n  Global redzone:          f9\n  Global init order:       f6\n  Poisoned by user:        f7\n  Container overflow:      fc\n  Array cookie:            ac\n  Intra object redzone:    bb\n  ASan internal:           fe\n  Left alloca redzone:     ca\n  Right alloca redzone:    cb\n==62612==ABORTING\n",
+  "sanitizer": "AddressSanitizer",
+  "summary": "AddressSanitizer: stack-buffer-underflow /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:58:69 in LLVMFuzzerTestOneInput",
+  "fault_type": "stack-buffer-underflow",
+  "call_stack": [
+    "#0 0x562de266b15c in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:58:69",
+    "#1 0x562de2593383 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x3e383) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+    "#2 0x562de257d0ff in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x280ff) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+    "#3 0x562de2582e56 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x2de56) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+    "#4 0x562de25acc72 in main (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x57c72) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+    "#5 0x7fe76a3d5d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)",
+    "#6 0x7fe76a3d5e3f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x29e3f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)",
+    "#7 0x562de25779c4 in _start (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x229c4) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)"
+  ],
+  "full_stack_details": [
+    {
+      "line": "#0 0x562de266b15c in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:58:69",
+      "address": 94755071897948,
+      "function_name": "LLVMFuzzerTestOneInput",
+      "function_offset": 69,
+      "source_file_name": "simple.c",
+      "source_file_path": "/workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c",
+      "source_file_line": 58
+    },
+    {
+      "line": "#1 0x562de2593383 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x3e383) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+      "address": 94755071013763,
+      "function_name": "fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long)",
+      "module_path": "/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe",
+      "module_offset": 254851
+    },
+    {
+      "line": "#2 0x562de257d0ff in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x280ff) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+      "address": 94755070923007,
+      "function_name": "fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long)",
+      "module_path": "/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe",
+      "module_offset": 164095
+    },
+    {
+      "line": "#3 0x562de2582e56 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x2de56) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+      "address": 94755070946902,
+      "function_name": "fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long))",
+      "module_path": "/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe",
+      "module_offset": 187990
+    },
+    {
+      "line": "#4 0x562de25acc72 in main (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x57c72) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+      "address": 94755071118450,
+      "function_name": "main",
+      "module_path": "/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe",
+      "module_offset": 359538
+    },
+    {
+      "line": "#5 0x7fe76a3d5d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)",
+      "address": 140631896579471,
+      "module_path": "/lib/x86_64-linux-gnu/libc.so.6",
+      "module_offset": 171407
+    },
+    {
+      "line": "#6 0x7fe76a3d5e3f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x29e3f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)",
+      "address": 140631896579647,
+      "function_name": "__libc_start_main",
+      "module_path": "/lib/x86_64-linux-gnu/libc.so.6",
+      "module_offset": 171583
+    },
+    {
+      "line": "#7 0x562de25779c4 in _start (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x229c4) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)",
+      "address": 94755070900676,
+      "function_name": "_start",
+      "module_path": "/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe",
+      "module_offset": 141764
+    }
+  ],
+  "full_stack_names": [
+    "LLVMFuzzerTestOneInput",
+    "fuzzer::Fuzzer::ExecuteCallback",
+    "fuzzer::RunOneTest",
+    "fuzzer::FuzzerDriver",
+    "main",
+    "__libc_start_main",
+    "_start"
+  ],
+  "minimized_stack_details": [
+    {
+      "line": "#0 0x562de266b15c in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:58:69",
+      "address": 94755071897948,
+      "function_name": "simple.c",
+      "function_offset": 69,
+      "source_file_name": "simple.c",
+      "source_file_path": "/workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c",
+      "source_file_line": 58
+    }
+  ],
+  "minimized_stack": [
+    "#0 0x562de266b15c in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:58:69"
+  ],
+  "minimized_stack_function_names": [
+    "simple.c"
+  ],
+  "minimized_stack_function_lines": [
+    "simple.c simple.c:58:69"
+  ]
+}

--- a/src/agent/stacktrace-parser/data/stack-traces/asan-missing-symbols.txt
+++ b/src/agent/stacktrace-parser/data/stack-traces/asan-missing-symbols.txt
@@ -1,0 +1,10 @@
+=================================================================
+==1496==ERROR: AddressSanitizer: unknown-crash on address 0x10c2bc680000 at pc 0x7ffa9fed7325 bp 0x0097f4f791a0 sp 0x0097f4f78930
+READ of size 1440 at 0x10c2bc680000 thread T4
+    #0 0x7ffa9fed7324  (C:\onefuzz\blob-containers\samplefolder\clang_rt.asan_dynamic-x86_64.dll+0x180057324)
+    #1 0x7ff68a914308 in MyCode::myFunction(struct MyStruct *) path\to\src\mycode.cpp:1536
+    #2 0x7ffa9feee12e  (C:\onefuzz\blob-containers\samplefolder\clang_rt.asan_dynamic-x86_64.dll+0x18006e12e)
+    #3 0x7ffac20c7613  (C:\Windows\System32\KERNEL32.DLL+0x180017613)
+    #4 0x7ffac40a26f0  (C:\Windows\SYSTEM32\ntdll.dll+0x1800526f0)
+
+SUMMARY: AddressSanitizer: unknown-crash (C:\onefuzz\blob-containers\samplefolder\clang_rt.asan_dynamic-x86_64.dll+0x18004b7b3) in _asan_wrap_GlobalSize+0x48963

--- a/src/agent/stacktrace-parser/data/stack-traces/example-deadly_signal.txt
+++ b/src/agent/stacktrace-parser/data/stack-traces/example-deadly_signal.txt
@@ -1,0 +1,20 @@
+==63924== ERROR: libFuzzer: deadly signal
+    #0 0x55af7a69cae1 in __sanitizer_print_stack_trace (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0xe4ae1) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+    #1 0x55af7a60f378 in fuzzer::PrintStackTrace() (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x57378) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+    #2 0x55af7a5f4df3 in fuzzer::Fuzzer::CrashCallback() (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x3cdf3) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+    #3 0x7f1c2425051f  (/lib/x86_64-linux-gnu/libc.so.6+0x4251f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)
+    #4 0x7f1c242a4a7b in pthread_kill (/lib/x86_64-linux-gnu/libc.so.6+0x96a7b) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)
+    #5 0x7f1c24250475 in gsignal (/lib/x86_64-linux-gnu/libc.so.6+0x42475) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)
+    #6 0x7f1c242367f2 in abort (/lib/x86_64-linux-gnu/libc.so.6+0x287f2) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)
+    #7 0x55af7a6ce4c0 in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:92:9
+    #8 0x55af7a5f6383 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x3e383) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+    #9 0x55af7a5e00ff in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x280ff) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+    #10 0x55af7a5e5e56 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x2de56) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+    #11 0x55af7a60fc72 in main (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x57c72) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+    #12 0x7f1c24237d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)
+    #13 0x7f1c24237e3f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x29e3f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)
+    #14 0x55af7a5da9c4 in _start (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x229c4) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+
+NOTE: libFuzzer has rudimentary signal handlers.
+      Combine libFuzzer with AddressSanitizer or similar for better crash reports.
+SUMMARY: libFuzzer: deadly signal

--- a/src/agent/stacktrace-parser/data/stack-traces/example-double-free.txt
+++ b/src/agent/stacktrace-parser/data/stack-traces/example-double-free.txt
@@ -1,0 +1,33 @@
+=================================================================
+==63086==ERROR: AddressSanitizer: attempting double-free on 0x602000000050 in thread T0:
+    #0 0x55faae2b3752 in __interceptor_free (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0xda752) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+    #1 0x55faae2ef2fc in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:73:56
+    #2 0x55faae217383 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x3e383) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+    #3 0x55faae2010ff in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x280ff) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+    #4 0x55faae206e56 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x2de56) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+    #5 0x55faae230c72 in main (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x57c72) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+    #6 0x7fda0af66d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)
+    #7 0x7fda0af66e3f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x29e3f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)
+    #8 0x55faae1fb9c4 in _start (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x229c4) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+
+0x602000000050 is located 0 bytes inside of 4-byte region [0x602000000050,0x602000000054)
+freed by thread T0 here:
+    #0 0x55faae2b3752 in __interceptor_free (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0xda752) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+    #1 0x55faae2ef2f0 in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:73:47
+    #2 0x55faae217383 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x3e383) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+    #3 0x55faae2010ff in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x280ff) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+    #4 0x55faae206e56 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x2de56) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+    #5 0x55faae230c72 in main (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x57c72) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+    #6 0x7fda0af66d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)
+
+previously allocated by thread T0 here:
+    #0 0x55faae2b39fe in malloc (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0xda9fe) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+    #1 0x55faae2ef2dd in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:73:26
+    #2 0x55faae217383 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x3e383) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+    #3 0x55faae2010ff in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x280ff) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+    #4 0x55faae206e56 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x2de56) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+    #5 0x55faae230c72 in main (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x57c72) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+    #6 0x7fda0af66d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)
+
+SUMMARY: AddressSanitizer: double-free (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0xda752) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0) in __interceptor_free
+==63086==ABORTING

--- a/src/agent/stacktrace-parser/data/stack-traces/example-fpe.txt
+++ b/src/agent/stacktrace-parser/data/stack-traces/example-fpe.txt
@@ -1,0 +1,14 @@
+=================================================================
+==63741==ERROR: AddressSanitizer: FPE on unknown address 0x556e7dca348e (pc 0x556e7dca348e bp 0x7ffe07bae220 sp 0x7ffe07bae020 T0)
+    #0 0x556e7dca348e in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:88:32
+    #1 0x556e7dbcb383 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x3e383) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+    #2 0x556e7dbb50ff in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x280ff) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+    #3 0x556e7dbbae56 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x2de56) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+    #4 0x556e7dbe4c72 in main (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x57c72) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+    #5 0x7fa30424cd8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)
+    #6 0x7fa30424ce3f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x29e3f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)
+    #7 0x556e7dbaf9c4 in _start (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x229c4) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+
+AddressSanitizer can not provide additional info.
+SUMMARY: AddressSanitizer: FPE /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:88:32 in LLVMFuzzerTestOneInput
+==63741==ABORTING

--- a/src/agent/stacktrace-parser/data/stack-traces/example-free-on-address.txt
+++ b/src/agent/stacktrace-parser/data/stack-traces/example-free-on-address.txt
@@ -1,0 +1,21 @@
+=================================================================
+==61632==ERROR: AddressSanitizer: attempting free on address which was not malloc()-ed: 0x7fff501dd020 in thread T0
+    #0 0x55c4d93d6752 in __interceptor_free (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0xda752) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+    #1 0x55c4d94122b6 in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:68:24
+    #2 0x55c4d933a383 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x3e383) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+    #3 0x55c4d93240ff in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x280ff) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+    #4 0x55c4d9329e56 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x2de56) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+    #5 0x55c4d9353c72 in main (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x57c72) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+    #6 0x7fb4e6c0ad8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)
+    #7 0x7fb4e6c0ae3f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x29e3f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)
+    #8 0x55c4d931e9c4 in _start (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x229c4) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+
+Address 0x7fff501dd020 is located in stack of thread T0 at offset 32 in frame
+    #0 0x55c4d9411aaf in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:38
+
+  This frame has 1 object(s):
+    [32, 36) 'cnt' (line 39) <== Memory access at offset 32 is inside this variable
+HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
+      (longjmp and C++ exceptions *are* supported)
+SUMMARY: AddressSanitizer: bad-free (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0xda752) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0) in __interceptor_free
+==61632==ABORTING

--- a/src/agent/stacktrace-parser/data/stack-traces/example-heap-buffer-overflow.txt
+++ b/src/agent/stacktrace-parser/data/stack-traces/example-heap-buffer-overflow.txt
@@ -1,0 +1,55 @@
+=================================================================
+==63506==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x603000000150 at pc 0x55985b227427 bp 0x7ffed7cabb50 sp 0x7ffed7cabb48
+WRITE of size 4 at 0x603000000150 thread T0
+    #0 0x55985b227426 in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:83:91
+    #1 0x55985b14f383 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x3e383) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+    #2 0x55985b1390ff in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x280ff) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+    #3 0x55985b13ee56 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x2de56) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+    #4 0x55985b168c72 in main (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x57c72) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+    #5 0x7fd7b9330d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)
+    #6 0x7fd7b9330e3f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x29e3f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)
+    #7 0x55985b1339c4 in _start (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x229c4) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+
+0x603000000150 is located 0 bytes to the right of 32-byte region [0x603000000130,0x603000000150)
+allocated by thread T0 here:
+    #0 0x55985b1eb9fe in malloc (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0xda9fe) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+    #1 0x55985b227399 in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:83:26
+    #2 0x55985b14f383 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x3e383) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+    #3 0x55985b1390ff in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x280ff) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+    #4 0x55985b13ee56 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x2de56) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+    #5 0x55985b168c72 in main (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x57c72) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+    #6 0x7fd7b9330d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)
+
+SUMMARY: AddressSanitizer: heap-buffer-overflow /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:83:91 in LLVMFuzzerTestOneInput
+Shadow bytes around the buggy address:
+  0x0c067fff7fd0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+  0x0c067fff7fe0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+  0x0c067fff7ff0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+  0x0c067fff8000: fa fa 00 00 00 fa fa fa 00 00 00 fa fa fa 00 00
+  0x0c067fff8010: 00 00 fa fa 00 00 00 fa fa fa 00 00 00 00 fa fa
+=>0x0c067fff8020: 00 00 00 00 fa fa 00 00 00 00[fa]fa fa fa fa fa
+  0x0c067fff8030: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
+  0x0c067fff8040: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
+  0x0c067fff8050: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
+  0x0c067fff8060: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
+  0x0c067fff8070: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
+Shadow byte legend (one shadow byte represents 8 application bytes):
+  Addressable:           00
+  Partially addressable: 01 02 03 04 05 06 07 
+  Heap left redzone:       fa
+  Freed heap region:       fd
+  Stack left redzone:      f1
+  Stack mid redzone:       f2
+  Stack right redzone:     f3
+  Stack after return:      f5
+  Stack use after scope:   f8
+  Global redzone:          f9
+  Global init order:       f6
+  Poisoned by user:        f7
+  Container overflow:      fc
+  Array cookie:            ac
+  Intra object redzone:    bb
+  ASan internal:           fe
+  Left alloca redzone:     ca
+  Right alloca redzone:    cb
+==63506==ABORTING

--- a/src/agent/stacktrace-parser/data/stack-traces/example-heap-use-after-free.txt
+++ b/src/agent/stacktrace-parser/data/stack-traces/example-heap-use-after-free.txt
@@ -1,0 +1,64 @@
+=================================================================
+==63302==ERROR: AddressSanitizer: heap-use-after-free on address 0x602000000050 at pc 0x55cba0d8c377 bp 0x7fff6409d3d0 sp 0x7fff6409d3c8
+WRITE of size 4 at 0x602000000050 thread T0
+    #0 0x55cba0d8c376 in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:78:59
+    #1 0x55cba0cb4383 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x3e383) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+    #2 0x55cba0c9e0ff in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x280ff) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+    #3 0x55cba0ca3e56 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x2de56) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+    #4 0x55cba0ccdc72 in main (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x57c72) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+    #5 0x7f0fe85ddd8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)
+    #6 0x7f0fe85dde3f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x29e3f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)
+    #7 0x55cba0c989c4 in _start (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x229c4) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+
+0x602000000050 is located 0 bytes inside of 4-byte region [0x602000000050,0x602000000054)
+freed by thread T0 here:
+    #0 0x55cba0d50752 in __interceptor_free (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0xda752) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+    #1 0x55cba0d8c336 in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:78:47
+    #2 0x55cba0cb4383 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x3e383) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+    #3 0x55cba0c9e0ff in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x280ff) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+    #4 0x55cba0ca3e56 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x2de56) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+    #5 0x55cba0ccdc72 in main (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x57c72) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+    #6 0x7f0fe85ddd8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)
+
+previously allocated by thread T0 here:
+    #0 0x55cba0d509fe in malloc (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0xda9fe) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+    #1 0x55cba0d8c323 in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:78:26
+    #2 0x55cba0cb4383 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x3e383) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+    #3 0x55cba0c9e0ff in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x280ff) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+    #4 0x55cba0ca3e56 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x2de56) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+    #5 0x55cba0ccdc72 in main (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x57c72) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+    #6 0x7f0fe85ddd8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)
+
+SUMMARY: AddressSanitizer: heap-use-after-free /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:78:59 in LLVMFuzzerTestOneInput
+Shadow bytes around the buggy address:
+  0x0c047fff7fb0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+  0x0c047fff7fc0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+  0x0c047fff7fd0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+  0x0c047fff7fe0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+  0x0c047fff7ff0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+=>0x0c047fff8000: fa fa 05 fa fa fa 05 fa fa fa[fd]fa fa fa fa fa
+  0x0c047fff8010: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
+  0x0c047fff8020: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
+  0x0c047fff8030: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
+  0x0c047fff8040: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
+  0x0c047fff8050: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
+Shadow byte legend (one shadow byte represents 8 application bytes):
+  Addressable:           00
+  Partially addressable: 01 02 03 04 05 06 07 
+  Heap left redzone:       fa
+  Freed heap region:       fd
+  Stack left redzone:      f1
+  Stack mid redzone:       f2
+  Stack right redzone:     f3
+  Stack after return:      f5
+  Stack use after scope:   f8
+  Global redzone:          f9
+  Global init order:       f6
+  Poisoned by user:        f7
+  Container overflow:      fc
+  Array cookie:            ac
+  Intra object redzone:    bb
+  ASan internal:           fe
+  Left alloca redzone:     ca
+  Right alloca redzone:    cb
+==63302==ABORTING

--- a/src/agent/stacktrace-parser/data/stack-traces/example-segv.txt
+++ b/src/agent/stacktrace-parser/data/stack-traces/example-segv.txt
@@ -1,0 +1,16 @@
+=================================================================
+==62189==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000000 (pc 0x55b1150570b0 bp 0x7ffc48bbbe30 sp 0x7ffc48bbbc40 T0)
+==62189==The signal is caused by a WRITE memory access.
+==62189==Hint: address points to the zero page.
+    #0 0x55b1150570b0 in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:53:27
+    #1 0x55b114f7f383 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x3e383) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+    #2 0x55b114f690ff in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x280ff) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+    #3 0x55b114f6ee56 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x2de56) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+    #4 0x55b114f98c72 in main (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x57c72) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+    #5 0x7ff53bbe6d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)
+    #6 0x7ff53bbe6e3f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x29e3f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)
+    #7 0x55b114f639c4 in _start (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x229c4) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+
+AddressSanitizer can not provide additional info.
+SUMMARY: AddressSanitizer: SEGV /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:53:27 in LLVMFuzzerTestOneInput
+==62189==ABORTING

--- a/src/agent/stacktrace-parser/data/stack-traces/example-stack-buffer-overflow.txt
+++ b/src/agent/stacktrace-parser/data/stack-traces/example-stack-buffer-overflow.txt
@@ -1,0 +1,52 @@
+=================================================================
+==62893==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7fffb9b7ed9c at pc 0x55ec35545245 bp 0x7fffb9b7ed50 sp 0x7fffb9b7ed48
+WRITE of size 4 at 0x7fffb9b7ed9c thread T0
+    #0 0x55ec35545244 in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:63:69
+    #1 0x55ec3546d383 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x3e383) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+    #2 0x55ec354570ff in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x280ff) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+    #3 0x55ec3545ce56 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x2de56) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+    #4 0x55ec35486c72 in main (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x57c72) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+    #5 0x7fb1900d1d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)
+    #6 0x7fb1900d1e3f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x29e3f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)
+    #7 0x55ec354519c4 in _start (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x229c4) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+
+Address 0x7fffb9b7ed9c is located in stack of thread T0 at offset 60 in frame
+    #0 0x55ec35544aaf in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:38
+
+  This frame has 1 object(s):
+    [32, 36) 'cnt' (line 39) <== Memory access at offset 60 overflows this variable
+HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
+      (longjmp and C++ exceptions *are* supported)
+SUMMARY: AddressSanitizer: stack-buffer-overflow /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:63:69 in LLVMFuzzerTestOneInput
+Shadow bytes around the buggy address:
+  0x100077367d60: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+  0x100077367d70: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+  0x100077367d80: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+  0x100077367d90: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+  0x100077367da0: 00 00 00 00 00 00 00 00 00 00 00 00 f1 f1 f1 f1
+=>0x100077367db0: 04 f3 f3[f3]00 00 00 00 00 00 00 00 00 00 00 00
+  0x100077367dc0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+  0x100077367dd0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+  0x100077367de0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+  0x100077367df0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+  0x100077367e00: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+Shadow byte legend (one shadow byte represents 8 application bytes):
+  Addressable:           00
+  Partially addressable: 01 02 03 04 05 06 07 
+  Heap left redzone:       fa
+  Freed heap region:       fd
+  Stack left redzone:      f1
+  Stack mid redzone:       f2
+  Stack right redzone:     f3
+  Stack after return:      f5
+  Stack use after scope:   f8
+  Global redzone:          f9
+  Global init order:       f6
+  Poisoned by user:        f7
+  Container overflow:      fc
+  Array cookie:            ac
+  Intra object redzone:    bb
+  ASan internal:           fe
+  Left alloca redzone:     ca
+  Right alloca redzone:    cb
+==62893==ABORTING

--- a/src/agent/stacktrace-parser/data/stack-traces/example-stack-buffer-underflow.txt
+++ b/src/agent/stacktrace-parser/data/stack-traces/example-stack-buffer-underflow.txt
@@ -1,0 +1,52 @@
+=================================================================
+==62612==ERROR: AddressSanitizer: stack-buffer-underflow on address 0x7fffe06ddf80 at pc 0x562de266b15d bp 0x7fffe06ddf70 sp 0x7fffe06ddf68
+WRITE of size 4 at 0x7fffe06ddf80 thread T0
+    #0 0x562de266b15c in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:58:69
+    #1 0x562de2593383 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x3e383) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+    #2 0x562de257d0ff in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x280ff) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+    #3 0x562de2582e56 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x2de56) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+    #4 0x562de25acc72 in main (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x57c72) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+    #5 0x7fe76a3d5d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)
+    #6 0x7fe76a3d5e3f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x29e3f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)
+    #7 0x562de25779c4 in _start (/workspaces/onefuzz/src/integration-tests/libfuzzer/fuzz.exe+0x229c4) (BuildId: 193b8a11b86868d1d18710a6ee963ada85f0f3a0)
+
+Address 0x7fffe06ddf80 is located in stack of thread T0 at offset 0 in frame
+    #0 0x562de266aaaf in LLVMFuzzerTestOneInput /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:38
+
+  This frame has 1 object(s):
+    [32, 36) 'cnt' (line 39)
+HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
+      (longjmp and C++ exceptions *are* supported)
+SUMMARY: AddressSanitizer: stack-buffer-underflow /workspaces/onefuzz/src/integration-tests/libfuzzer/simple.c:58:69 in LLVMFuzzerTestOneInput
+Shadow bytes around the buggy address:
+  0x10007c0d3ba0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+  0x10007c0d3bb0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+  0x10007c0d3bc0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+  0x10007c0d3bd0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+  0x10007c0d3be0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+=>0x10007c0d3bf0:[f1]f1 f1 f1 04 f3 f3 f3 00 00 00 00 00 00 00 00
+  0x10007c0d3c00: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+  0x10007c0d3c10: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+  0x10007c0d3c20: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+  0x10007c0d3c30: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+  0x10007c0d3c40: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+Shadow byte legend (one shadow byte represents 8 application bytes):
+  Addressable:           00
+  Partially addressable: 01 02 03 04 05 06 07 
+  Heap left redzone:       fa
+  Freed heap region:       fd
+  Stack left redzone:      f1
+  Stack mid redzone:       f2
+  Stack right redzone:     f3
+  Stack after return:      f5
+  Stack use after scope:   f8
+  Global redzone:          f9
+  Global init order:       f6
+  Poisoned by user:        f7
+  Container overflow:      fc
+  Array cookie:            ac
+  Intra object redzone:    bb
+  ASan internal:           fe
+  Left alloca redzone:     ca
+  Right alloca redzone:    cb
+==62612==ABORTING


### PR DESCRIPTION
Starts to address #3335. 

On Linux, the ASAN runtime was being excluded via module name; on Windows this was not done, but ASAN functions were excluded by function name. However, when symbols are not available this doesn't function properly, so also exclude by module name.