### PR TITLE
Update `repro get_files` to handle regression reports

### DIFF
--- a/src/cli/onefuzz/api.py
+++ b/src/cli/onefuzz/api.py
@@ -612,6 +612,7 @@ class Repro(Endpoint):
                     crash_info["job_id"], enums.ContainerType.setup
                 )
             )[0]
+
             self.onefuzz.containers.files.download_dir(
                 primitives.Container(setup_container), output_dir
             )

--- a/src/cli/onefuzz/api.py
+++ b/src/cli/onefuzz/api.py
@@ -562,20 +562,19 @@ class Repro(Endpoint):
             "input_blob_name": None,
             "job_id": None,
         }
-        if "input_blob" not in report:
-            if "original_crash_test_result" in report:
-                original_report = report["original_crash_test_result"]["crash_report"]
-                regression_report = report["crash_test_result"]["crash_report"]
-                crash_info["input_blob_container"] = original_report["input_blob"]["container"]
-                crash_info["input_blob_name"] = original_report["input_blob"]["name"]
-                crash_info["job_id"] = regression_report["job_id"]
-            else:
-                self.logger.error("Encountered an unhandled report format, unable to retrieve repro files")
-                return
-        else:
+        if "input_blob" in report:
             crash_info["input_blob_container"] = report["input_blob"]["container"]
             crash_info["input_blob_name"] = report["input_blob"]["name"]
             crash_info["job_id"] = report["job_id"]
+        elif "original_crash_test_result" in report:
+            original_report = report["original_crash_test_result"]["crash_report"]
+            regression_report = report["crash_test_result"]["crash_report"] if "crash_test_result" in report else None
+            crash_info["input_blob_container"] = original_report["input_blob"]["container"]
+            crash_info["input_blob_name"] = original_report["input_blob"]["name"]
+            crash_info["job_id"] = regression_report["job_id"] if regression_report else original_report["job_id"]
+        else:
+            self.logger.error("Encountered an unhandled report format, unable to retrieve repro files")
+            return
 
         self.logger.info(
             "downloading files necessary to locally repro crash %s",

--- a/src/cli/onefuzz/api.py
+++ b/src/cli/onefuzz/api.py
@@ -568,12 +568,24 @@ class Repro(Endpoint):
             crash_info["job_id"] = report["job_id"]
         elif "original_crash_test_result" in report:
             original_report = report["original_crash_test_result"]["crash_report"]
-            regression_report = report["crash_test_result"]["crash_report"] if "crash_test_result" in report else None
-            crash_info["input_blob_container"] = original_report["input_blob"]["container"]
+            regression_report = (
+                report["crash_test_result"]["crash_report"]
+                if "crash_test_result" in report
+                else None
+            )
+            crash_info["input_blob_container"] = original_report["input_blob"][
+                "container"
+            ]
             crash_info["input_blob_name"] = original_report["input_blob"]["name"]
-            crash_info["job_id"] = regression_report["job_id"] if regression_report else original_report["job_id"]
+            crash_info["job_id"] = (
+                regression_report["job_id"]
+                if regression_report
+                else original_report["job_id"]
+            )
         else:
-            self.logger.error("Encountered an unhandled report format, unable to retrieve repro files")
+            self.logger.error(
+                "Encountered an unhandled report format, unable to retrieve repro files"
+            )
             return
 
         self.logger.info(

--- a/src/cli/onefuzz/api.py
+++ b/src/cli/onefuzz/api.py
@@ -558,7 +558,7 @@ class Repro(Endpoint):
         report = json.loads(report_bytes)
 
         crash_info = {
-            "input_blob_container": "",
+            "input_blob_container": primitives.Container(""),
             "input_blob_name": "",
             "job_id": "",
         }

--- a/src/cli/onefuzz/api.py
+++ b/src/cli/onefuzz/api.py
@@ -558,9 +558,9 @@ class Repro(Endpoint):
         report = json.loads(report_bytes)
 
         crash_info = {
-            "input_blob_container": None,
-            "input_blob_name": None,
-            "job_id": None,
+            "input_blob_container": "",
+            "input_blob_name": "",
+            "job_id": "",
         }
         if "input_blob" in report:
             crash_info["input_blob_container"] = report["input_blob"]["container"]

--- a/src/cli/onefuzz/api.py
+++ b/src/cli/onefuzz/api.py
@@ -587,7 +587,7 @@ class Repro(Endpoint):
                 "container"
             ]
             crash_info["input_blob_name"] = original_report["input_blob"]["name"]
-            crash_info["job_id"] = new_report
+            crash_info["job_id"] = new_report["job_id"]
         else:
             self.logger.error(
                 "Encountered an unhandled report format, repro files cannot be retrieved"


### PR DESCRIPTION
## Summary of the Pull Request

https://github.com/microsoft/onefuzz/issues/3338
`onefuzz repro get_files` only handles `reports` and not `regression_reports`.

## PR Checklist
* [ ] Applies to work item: #xxx
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/onefuzz) and sign the CLI.
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

Adds logic for checking that the fields expected in a normal report exist before falling back on fields expected from a regression report. An error is logged otherwise.

## Validation Steps Performed

_How does someone test & validate?_
