### PR TITLE
Populate InputBlob when possible

### DIFF
--- a/src/ApiService/ApiService/onefuzzlib/notifications/Ado.cs
+++ b/src/ApiService/ApiService/onefuzzlib/notifications/Ado.cs
@@ -25,8 +25,8 @@ public class Ado : NotificationsBase, IAdo {
         if (reportable is RegressionReport regressionReport) {
             if (regressionReport.CrashTestResult.CrashReport is not null) {
                 report = regressionReport.CrashTestResult.CrashReport with {
-                    InputBlob = regressionReport?.OriginalCrashTestResult?.CrashReport?.InputBlob ??
-                                regressionReport?.OriginalCrashTestResult?.NoReproReport?.InputBlob
+                    InputBlob = regressionReport.OriginalCrashTestResult?.CrashReport?.InputBlob ??
+                                regressionReport.OriginalCrashTestResult?.NoReproReport?.InputBlob
                 };
                 _logTracer.LogInformation("parsing regression report for ado integration. container:{Container} filename:{Filename}", container, filename);
             } else {

--- a/src/ApiService/ApiService/onefuzzlib/notifications/Ado.cs
+++ b/src/ApiService/ApiService/onefuzzlib/notifications/Ado.cs
@@ -24,7 +24,10 @@ public class Ado : NotificationsBase, IAdo {
         Report? report;
         if (reportable is RegressionReport regressionReport) {
             if (regressionReport.CrashTestResult.CrashReport is not null) {
-                report = regressionReport.CrashTestResult.CrashReport;
+                report = regressionReport.CrashTestResult.CrashReport with {
+                    InputBlob = regressionReport?.OriginalCrashTestResult?.CrashReport?.InputBlob ??
+                                regressionReport?.OriginalCrashTestResult?.NoReproReport?.InputBlob
+                };
                 _logTracer.LogInformation("parsing regression report for ado integration. container:{Container} filename:{Filename}", container, filename);
             } else {
                 _logTracer.LogError("ado integration does not support this regression report. container:{Container} filename:{Filename}", container, filename);


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_

Closes #3339. RegressionReports don't always include an inputblob since they reference existing 