### PR TITLE
Implement with_tasks option to expand the task information

### DIFF
--- a/src/ApiService/ApiService/Functions/Jobs.cs
+++ b/src/ApiService/ApiService/Functions/Jobs.cs
@@ -135,10 +135,14 @@ public class Jobs {
 
             static JobTaskInfo TaskToJobTaskInfo(Task t) => new(t.TaskId, t.Config.Task.Type, t.State);
 
-            // TODO: search.WithTasks is not checked in Python code?
-
-            var taskInfo = await _context.TaskOperations.SearchStates(jobId).Select(TaskToJobTaskInfo).ToListAsync();
-            return await RequestHandling.Ok(req, JobResponse.ForJob(job, taskInfo));
+            var tasks = _context.TaskOperations.SearchStates(jobId);
+            if (search.WithTasks ?? false) {
+                var ts = await tasks.ToListAsync();
+                return await RequestHandling.Ok(req, JobResponse.ForJob(job, ts));
+            } else {
+                var taskInfo = await tasks.Select(TaskToJobTaskInfo).ToListAsync();
+                return await RequestHandling.Ok(req, JobResponse.ForJob(job, taskInfo));
+            }
         }
 
         var jobs = await _context.JobOperations.SearchState(states: search.State ?? Enumerable.Empty<JobState>()).ToListAsync();

--- a/src/ApiService/ApiService/OneFuzzTypes/Model.cs
+++ b/src/ApiService/ApiService/OneFuzzTypes/Model.cs
@@ -899,30 +899,14 @@ public record JobConfig(
     }
 }
 
-[JsonConverter(typeof(IJobTaskInfoConverter))]
+[JsonDerivedType(typeof(Task), typeDiscriminator: "Task")]
+[JsonDerivedType(typeof(JobTaskInfo), typeDiscriminator: "JobTaskInfo")]
 public interface IJobTaskInfo {
     Guid TaskId { get; }
     TaskType Type { get; }
     TaskState State { get; }
-
 }
 
-public class IJobTaskInfoConverter : JsonConverter<IJobTaskInfo> {
-    public override IJobTaskInfo Read(
-        ref Utf8JsonReader reader,
-        Type typeToConvert,
-        JsonSerializerOptions options) {
-        throw new NotImplementedException();
-    }
-
-    public override void Write(
-        Utf8JsonWriter writer,
-        IJobTaskInfo value,
-        JsonSerializerOptions options) {
-        var type = value.GetType();
-        JsonSerializer.Serialize(writer, value, type, options);
-    }
-}
 public record JobTaskInfo(
     Guid TaskId,
     TaskType Type,

--- a/src/ApiService/ApiService/OneFuzzTypes/Responses.cs
+++ b/src/ApiService/ApiService/OneFuzzTypes/Responses.cs
@@ -96,13 +96,13 @@ public record JobResponse(
     JobConfig Config,
     string? Error,
     DateTimeOffset? EndTime,
-    List<JobTaskInfo>? TaskInfo,
+    IEnumerable<IJobTaskInfo>? TaskInfo,
     StoredUserInfo? UserInfo,
     [property: JsonPropertyName("Timestamp")] // must retain capital T for backcompat
     DateTimeOffset? Timestamp
 // not including UserInfo from Job model
 ) : BaseResponse() {
-    public static JobResponse ForJob(Job j, List<JobTaskInfo>? taskInfo)
+    public static JobResponse ForJob(Job j, IEnumerable<IJobTaskInfo>? taskInfo)
         => new(
             JobId: j.JobId,
             State: j.State,

--- a/src/ApiService/IntegrationTests/JobsTests.cs
+++ b/src/ApiService/IntegrationTests/JobsTests.cs
@@ -175,4 +175,55 @@ public abstract class JobsTestBase : FunctionTestBase {
         var metadata = Assert.Single(container.Value);
         Assert.Equal(new KeyValuePair<string, string>("container_type", "logs"), metadata);
     }
+    
+    
+    [Fact]
+    public async Async.Task Get_CanFindSpecificJobWithTaskInfo() {
+        
+        var taskConfig = new TaskConfig(_jobId, new List<Guid>(), new TaskDetails(TaskType.Coverage, 60));
+        var task = new Task(_jobId, Guid.NewGuid(), TaskState.Running, Os.Windows, taskConfig);
+        
+        await Context.InsertAll(
+            new Job(_jobId, JobState.Stopped, _config, null), task);
+
+        var func = new Jobs(Context, LoggerProvider.CreateLogger<Jobs>());
+
+        var ctx = new TestFunctionContext();
+        var result = await func.Run(TestHttpRequestData.FromJson("GET", new JobSearch(JobId: _jobId, WithTasks: false)), ctx);
+        Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+
+        var response = BodyAs<JobResponse>(result);
+        Assert.Equal(_jobId, response.JobId);
+        Assert.NotNull(response.TaskInfo);
+        var returnedTasks = response.TaskInfo.OfType<JobTaskInfo>().ToList();
+        Assert.NotEmpty(returnedTasks);
+        Assert.Equal(task.TaskId, returnedTasks[0].TaskId);
+        Assert.Equal(task.State, returnedTasks[0].State);
+        Assert.Equal(task.Config.Task.Type, returnedTasks[0].Type);
+    }
+    
+    [Fact]
+    public async Async.Task Get_CanFindSpecificJobWithFullTask() {
+        var taskConfig = new TaskConfig(_jobId, new List<Guid>(), new TaskDetails(TaskType.Coverage, 60));
+        var task = new Task(_jobId, Guid.NewGuid(), TaskState.Running, Os.Windows, taskConfig);
+        
+        await Context.InsertAll(
+            new Job(_jobId, JobState.Stopped, _config, null), task);
+
+        var func = new Jobs(Context, LoggerProvider.CreateLogger<Jobs>());
+
+        var ctx = new TestFunctionContext();
+        var result = await func.Run(TestHttpRequestData.FromJson("GET", new JobSearch(JobId: _jobId, WithTasks: true)), ctx);
+        Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+
+        var response = BodyAs<JobResponse>(result);
+        Assert.Equal(_jobId, response.JobId);
+        Assert.NotNull(response.TaskInfo);
+        var returnedTasks = response.TaskInfo.OfType<Task>().ToList();
+        Assert.NotEmpty(returnedTasks);
+        Assert.Equal(task.TaskId, returnedTasks[0].TaskId);
+        Assert.Equal(task.State, returnedTasks[0].State);
+        Assert.Equal(task.Config.Task.Type, returnedTasks[0].Type);
+        
+    }
 }

--- a/src/ApiService/IntegrationTests/JobsTests.cs
+++ b/src/ApiService/IntegrationTests/JobsTests.cs
@@ -175,14 +175,14 @@ public abstract class JobsTestBase : FunctionTestBase {
         var metadata = Assert.Single(container.Value);
         Assert.Equal(new KeyValuePair<string, string>("container_type", "logs"), metadata);
     }
-    
-    
+
+
     [Fact]
     public async Async.Task Get_CanFindSpecificJobWithTaskInfo() {
-        
+
         var taskConfig = new TaskConfig(_jobId, new List<Guid>(), new TaskDetails(TaskType.Coverage, 60));
         var task = new Task(_jobId, Guid.NewGuid(), TaskState.Running, Os.Windows, taskConfig);
-        
+
         await Context.InsertAll(
             new Job(_jobId, JobState.Stopped, _config, null), task);
 
@@ -201,12 +201,12 @@ public abstract class JobsTestBase : FunctionTestBase {
         Assert.Equal(task.State, returnedTasks[0].State);
         Assert.Equal(task.Config.Task.Type, returnedTasks[0].Type);
     }
-    
+
     [Fact]
     public async Async.Task Get_CanFindSpecificJobWithFullTask() {
         var taskConfig = new TaskConfig(_jobId, new List<Guid>(), new TaskDetails(TaskType.Coverage, 60));
         var task = new Task(_jobId, Guid.NewGuid(), TaskState.Running, Os.Windows, taskConfig);
-        
+
         await Context.InsertAll(
             new Job(_jobId, JobState.Stopped, _config, null), task);
 
@@ -224,6 +224,6 @@ public abstract class JobsTestBase : FunctionTestBase {
         Assert.Equal(task.TaskId, returnedTasks[0].TaskId);
         Assert.Equal(task.State, returnedTasks[0].State);
         Assert.Equal(task.Config.Task.Type, returnedTasks[0].Type);
-        
+
     }
 }

--- a/src/cli/onefuzz/api.py
+++ b/src/cli/onefuzz/api.py
@@ -1271,14 +1271,16 @@ class Jobs(Endpoint):
             "DELETE", models.Job, data=requests.JobGet(job_id=job_id_expanded)
         )
 
-    def get(self, job_id: UUID_EXPANSION) -> models.Job:
+    def get(self, job_id: UUID_EXPANSION, with_tasks: bool = False) -> models.Job:
         """Get information about a specific job"""
         job_id_expanded = self._disambiguate_uuid(
             "job_id", job_id, lambda: [str(x.job_id) for x in self.list()]
         )
         self.logger.debug("get job: %s", job_id_expanded)
         job = self._req_model(
-            "GET", models.Job, data=requests.JobGet(job_id=job_id_expanded)
+            "GET",
+            models.Job,
+            data=requests.JobGet(job_id=job_id_expanded, with_tasks=with_tasks),
         )
         return job
 

--- a/src/pytypes/onefuzztypes/models.py
+++ b/src/pytypes/onefuzztypes/models.py
@@ -463,17 +463,6 @@ class JobTaskInfo(BaseModel):
     state: TaskState
 
 
-class Job(BaseModel):
-    timestamp: Optional[datetime] = Field(alias="Timestamp")
-    job_id: UUID = Field(default_factory=uuid4)
-    state: JobState = Field(default=JobState.init)
-    config: JobConfig
-    error: Optional[str]
-    end_time: Optional[datetime] = None
-    task_info: Optional[List[JobTaskInfo]]
-    user_info: Optional[UserInfo]
-
-
 class TaskHeartbeatEntry(BaseModel):
     task_id: UUID
     job_id: Optional[UUID]
@@ -754,6 +743,17 @@ class Task(BaseModel):
     end_time: Optional[datetime]
     events: Optional[List[TaskEventSummary]]
     nodes: Optional[List[NodeAssignment]]
+    user_info: Optional[UserInfo]
+
+
+class Job(BaseModel):
+    timestamp: Optional[datetime] = Field(alias="Timestamp")
+    job_id: UUID = Field(default_factory=uuid4)
+    state: JobState = Field(default=JobState.init)
+    config: JobConfig
+    error: Optional[str]
+    end_time: Optional[datetime] = None
+    task_info: Optional[List[Union[Task, JobTaskInfo]]]
     user_info: Optional[UserInfo]
 
 

--- a/src/pytypes/onefuzztypes/requests.py
+++ b/src/pytypes/onefuzztypes/requests.py
@@ -39,13 +39,13 @@ class BaseRequest(BaseModel):
 
 class JobGet(BaseRequest):
     job_id: UUID
+    with_tasks: Optional[bool]
 
 
 class JobSearch(BaseRequest):
     job_id: Optional[UUID]
     state: Optional[List[JobState]]
     task_state: Optional[List[TaskState]]
-    with_tasks: Optional[bool]
 
 
 class NotificationCreate(BaseRequest, NotificationConfig):


### PR DESCRIPTION
## Summary of the Pull Request

`onefuzz jobs get <job_id> --with_tasks` now include the full task information

closes #3330

