### PR TITLE
Forcefully shut down the runtime before existing the main task

### DIFF
--- a/src/agent/onefuzz-task/src/main.rs
+++ b/src/agent/onefuzz-task/src/main.rs
@@ -40,6 +40,7 @@ fn main() -> Result<()> {
     let rt = tokio::runtime::Runtime::new()?;
     let result = rt.block_on(run(matches));
     atexit::execute();
+    rt.shutdown_background();
     result
 }
 


### PR DESCRIPTION
## Summary of the Pull Request

The default behavior or the runtime is [wait for all spawned work](https://docs.rs/tokio/latest/tokio/runtime/struct.Runtime.html#shutdown) to be done before exiting. This was causing the task to hang when  exiting. 
This change adds a force shutdown at the end of the main function of the task.


closes #3377