### PR TITLE
fix tag shadowing

### DIFF
--- a/src/ApiService/ApiService/Log.cs
+++ b/src/ApiService/ApiService/Log.cs
@@ -166,6 +166,9 @@ public class OneFuzzLogger : ILogger {
     /// <param name="eventId">Event Id information.</param>
     private void PopulateTelemetry<TState>(ISupportProperties telemetryItem, TState state, EventId eventId) {
         IDictionary<string, string> dict = telemetryItem.Properties;
+
+        PopulateTags(telemetryItem);
+
         dict["CategoryName"] = this.categoryName;
         dict["Logger"] = nameof(OneFuzzLogger);
 
@@ -181,11 +184,15 @@ public class OneFuzzLogger : ILogger {
                 if (string.Equals(item.Key, "{OriginalFormat}")) {
                     dict["OriginalFormat"] = Convert.ToString(item.Value, CultureInfo.InvariantCulture) ?? $"Failed to convert {item.Value}";
                 } else {
+                    //if there is an existing tag that is shadowing the log message tag - rename it
+                    if (dict.ContainsKey(item.Key)) {
+                        dict[$"!@#<--- {item.Key} --->#@!"] = dict[item.Key];
+                    }
                     dict[item.Key] = Convert.ToString(item.Value, CultureInfo.InvariantCulture) ?? $"Failed to convert {item.Value}";
                 }
             }
         }
-        PopulateTags(telemetryItem);
+
     }
 
     /// <param name="telemetryItem"></param>


### PR DESCRIPTION
Give precedence to the tags produced by log message over the added tags prior to the call with the clashing name to avoid the following issues:

![image](https://github.com/microsoft/onefuzz/assets/7307755/cc877424-2957-493f-bbc9-93910eff0563)
