### PR TITLE
Update Rust edition to 2021 across all crates

### DIFF
--- a/src/agent/.rustfmt.toml
+++ b/src/agent/.rustfmt.toml
@@ -1,2 +1,2 @@
-edition = "2018"
+edition = "2021"
 newline_style = "Native"

--- a/src/agent/Cargo.toml
+++ b/src/agent/Cargo.toml
@@ -19,6 +19,8 @@ members = [
     "stacktrace-parser",
 ]
 
+resolver = "2"
+
 [profile.release]
 lto = "thin"
 # Per https://fasterthanli.me/articles/why-is-my-rust-build-so-slow:

--- a/src/agent/atexit/Cargo.toml
+++ b/src/agent/atexit/Cargo.toml
@@ -3,7 +3,7 @@ name = "atexit"
 version = "0.1.0"
 license = "MIT"
 authors = ["fuzzing@microsoft.com"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 ctrlc = "3.4.0"

--- a/src/agent/debugger/Cargo.toml
+++ b/src/agent/debugger/Cargo.toml
@@ -2,7 +2,7 @@
 name = "debugger"
 version = "0.1.0"
 authors = ["fuzzing@microsoft.com"]
-edition = "2018"
+edition = "2021"
 license = "MIT"
 
 [dependencies]
@@ -31,5 +31,5 @@ features = [
     "synchapi",
     "werapi",
     "winbase",
-    "winerror"
+    "winerror",
 ]

--- a/src/agent/input-tester/Cargo.toml
+++ b/src/agent/input-tester/Cargo.toml
@@ -2,7 +2,7 @@
 name = "input-tester"
 version = "0.1.0"
 authors = ["fuzzing@microsoft.com"]
-edition = "2018"
+edition = "2021"
 license = "MIT"
 
 [dependencies]

--- a/src/agent/libclusterfuzz/Cargo.toml
+++ b/src/agent/libclusterfuzz/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libclusterfuzz"
 version = "0.0.1"
 authors = ["fuzzing@microsoft.com>"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 description = "Minimal porting of features from libclusterfuzz"
 

--- a/src/agent/onefuzz-agent/Cargo.toml
+++ b/src/agent/onefuzz-agent/Cargo.toml
@@ -2,7 +2,7 @@
 name = "onefuzz-agent"
 version = "0.1.0"
 authors = ["fuzzing@microsoft.com"]
-edition = "2018"
+edition = "2021"
 publish = false
 license = "MIT"
 

--- a/src/agent/onefuzz-agent/src/heartbeat.rs
+++ b/src/agent/onefuzz-agent/src/heartbeat.rs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use crate::onefuzz::heartbeat::HeartbeatClient;
 use anyhow::Result;
+use onefuzz::heartbeat::HeartbeatClient;
 use reqwest::Url;
 use serde::{self, Deserialize, Serialize};
 use uuid::Uuid;

--- a/src/agent/onefuzz-agent/src/main.rs
+++ b/src/agent/onefuzz-agent/src/main.rs
@@ -9,7 +9,6 @@ extern crate downcast_rs;
 extern crate anyhow;
 #[macro_use]
 extern crate onefuzz_telemetry;
-extern crate onefuzz;
 
 use crate::{
     config::StaticConfig, coordinator::StateUpdateEvent, heartbeat::init_agent_heartbeat,

--- a/src/agent/onefuzz-agent/src/panic.rs
+++ b/src/agent/onefuzz-agent/src/panic.rs
@@ -2,7 +2,7 @@ use crate::failure::save_failure;
 use backtrace::Backtrace;
 use std::{panic, sync::Once};
 
-fn panic_hook(info: &panic::PanicInfo) {
+fn panic_hook(info: &panic::PanicInfo<'_>) {
     let err = anyhow!("supervisor panicked: {}\n{:?}", info, Backtrace::new());
     if let Err(err) = save_failure(&err, uuid::Uuid::nil()) {
         error!("unable to write panic log: {:?}", err);

--- a/src/agent/onefuzz-agent/src/scheduler.rs
+++ b/src/agent/onefuzz-agent/src/scheduler.rs
@@ -37,7 +37,7 @@ impl From<&Scheduler> for NodeState {
 }
 
 impl fmt::Display for Scheduler {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let s = match self {
             Self::Free(..) => "Scheduler::Free",
             Self::SettingUp(..) => "Scheduler::SettingUp",

--- a/src/agent/onefuzz-task/Cargo.toml
+++ b/src/agent/onefuzz-task/Cargo.toml
@@ -2,7 +2,7 @@
 name = "onefuzz-task"
 version = "0.2.0"
 authors = ["fuzzing@microsoft.com"]
-edition = "2018"
+edition = "2021"
 publish = false
 license = "MIT"
 
@@ -72,7 +72,7 @@ azure_storage_blobs = { version = "0.13", default-features = false, features = [
 ] }
 
 flexi_logger = "0.25"
-schemars =  {version = "0.8.12", features = ["uuid1"]}
+schemars = { version = "0.8.12", features = ["uuid1"] }
 
 [dev-dependencies]
 pretty_assertions = "1.4"

--- a/src/agent/onefuzz-task/src/tasks/coverage/generic.rs
+++ b/src/agent/onefuzz-task/src/tasks/coverage/generic.rs
@@ -487,11 +487,11 @@ impl<'a> TaskContext<'a> {
 
     async fn source_coverage(&self) -> Result<SourceCoverage> {
         // Must be owned due to `spawn_blocking()` lifetimes.
-        let allowlist = self.allowlist.clone();
+        let source_allowlist = self.allowlist.source_files.clone();
         let binary = self.coverage.clone();
 
         // Conversion to source coverage heavy on blocking I/O.
-        spawn_blocking(move || binary_to_source_coverage(&binary, allowlist.source_files)).await?
+        spawn_blocking(move || binary_to_source_coverage(&binary, source_allowlist)).await?
     }
 }
 

--- a/src/agent/onefuzz-telemetry/Cargo.toml
+++ b/src/agent/onefuzz-telemetry/Cargo.toml
@@ -2,7 +2,7 @@
 name = "onefuzz-telemetry"
 version = "0.1.0"
 authors = ["fuzzing@microsoft.com"]
-edition = "2018"
+edition = "2021"
 license = "MIT"
 
 [dependencies]

--- a/src/agent/onefuzz-telemetry/src/lib.rs
+++ b/src/agent/onefuzz-telemetry/src/lib.rs
@@ -28,7 +28,7 @@ impl MicrosoftTelemetryKey {
 }
 
 impl fmt::Display for MicrosoftTelemetryKey {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
     }
 }
@@ -42,7 +42,7 @@ impl InstanceTelemetryKey {
 }
 
 impl fmt::Display for InstanceTelemetryKey {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
     }
 }

--- a/src/agent/onefuzz/Cargo.toml
+++ b/src/agent/onefuzz/Cargo.toml
@@ -2,7 +2,7 @@
 name = "onefuzz"
 version = "0.1.0"
 authors = ["fuzzing@microsoft.com"]
-edition = "2018"
+edition = "2021"
 publish = false
 license = "MIT"
 

--- a/src/agent/onefuzz/src/auth.rs
+++ b/src/agent/onefuzz/src/auth.rs
@@ -33,13 +33,13 @@ impl<T> From<T> for Secret<T> {
 }
 
 impl<T> fmt::Debug for Secret<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Secret(<REDACTED>)")
     }
 }
 
 impl<T> fmt::Display for Secret<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "<REDACTED>")
     }
 }

--- a/src/agent/onefuzz/src/az_copy.rs
+++ b/src/agent/onefuzz/src/az_copy.rs
@@ -36,7 +36,7 @@ enum Mode {
 }
 
 impl fmt::Display for Mode {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let as_str = match self {
             Mode::Copy => "copy",
             Mode::Sync => "sync",

--- a/src/agent/onefuzz/src/blob/url.rs
+++ b/src/agent/onefuzz/src/blob/url.rs
@@ -94,13 +94,13 @@ impl BlobUrl {
 }
 
 impl fmt::Debug for BlobUrl {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", redact_query_sas_sig(&self.url()))
     }
 }
 
 impl fmt::Display for BlobUrl {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::AzureBlob(_) => write!(
                 f,
@@ -200,7 +200,7 @@ impl BlobContainerUrl {
 }
 
 impl fmt::Debug for BlobContainerUrl {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::BlobContainer(url) => write!(f, "{}", redact_query_sas_sig(url)),
             Self::Path(p) => write!(f, "{}", p.display()),
@@ -209,7 +209,7 @@ impl fmt::Debug for BlobContainerUrl {
 }
 
 impl fmt::Display for BlobContainerUrl {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Some(file_path) = self.as_file_path() {
             write!(f, "{file_path:?}")
         } else if let (Some(account), Some(container)) = (self.account(), self.container()) {
@@ -327,7 +327,7 @@ struct BlobContainerUrlVisitor;
 impl<'de> de::Visitor<'de> for BlobContainerUrlVisitor {
     type Value = BlobContainerUrl;
 
-    fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "a valid blob storage container URL")
     }
 
@@ -353,7 +353,7 @@ struct BlobUrlVisitor;
 impl<'de> de::Visitor<'de> for BlobUrlVisitor {
     type Value = BlobUrl;
 
-    fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "a valid blob storage URL")
     }
 

--- a/src/agent/onefuzz/src/expand.rs
+++ b/src/agent/onefuzz/src/expand.rs
@@ -416,7 +416,7 @@ impl<'a> Expand<'a> {
         let arg = arg.as_ref().to_owned();
         let mut errors = Vec::new();
 
-        let result = VAR_RE.replace_all(&arg, |captures: &regex::Captures| -> String {
+        let result = VAR_RE.replace_all(&arg, |captures: &regex::Captures<'_>| -> String {
             let matched = captures.get(0).unwrap().as_str(); // capture 0 must always be present here
             match self.values.get_key_value(matched) {
                 Some((placeholder, ev)) => {

--- a/src/agent/onefuzz/src/triage.rs
+++ b/src/agent/onefuzz/src/triage.rs
@@ -241,7 +241,7 @@ pub struct Frame {
 }
 
 impl fmt::Display for Frame {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let (Some(function), Some(module)) = (&self.function, &self.module) {
             return write!(
                 f,

--- a/src/agent/stacktrace-parser/Cargo.toml
+++ b/src/agent/stacktrace-parser/Cargo.toml
@@ -2,7 +2,7 @@
 name = "stacktrace-parser"
 version = "0.1.0"
 authors = ["<fuzzing@microsoft.com>"]
-edition = "2018"
+edition = "2021"
 license = "MIT"
 
 [dependencies]

--- a/src/agent/storage-queue/Cargo.toml
+++ b/src/agent/storage-queue/Cargo.toml
@@ -2,7 +2,7 @@
 name = "storage-queue"
 version = "0.1.0"
 authors = ["fuzzing@microsoft.com"]
-edition = "2018"
+edition = "2021"
 license = "MIT"
 
 [dependencies]

--- a/src/agent/win-util/Cargo.toml
+++ b/src/agent/win-util/Cargo.toml
@@ -2,7 +2,7 @@
 name = "win-util"
 version = "0.1.0"
 authors = ["fuzzing@microsoft.com"]
-edition = "2018"
+edition = "2021"
 license = "MIT"
 
 [dependencies]
@@ -32,5 +32,5 @@ features = [
     "werapi",
     "winbase",
     "winerror",
-    "wow64apiset"
+    "wow64apiset",
 ]

--- a/src/integration-tests/libfuzzer-rust/Cargo.toml
+++ b/src/integration-tests/libfuzzer-rust/Cargo.toml
@@ -3,7 +3,7 @@ name = "rust_fuzz_example"
 version = "0.1.0"
 license = "MIT"
 authors = ["<fuzzing@microsoft.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 libc = "0.2.79"

--- a/src/integration-tests/libfuzzer-rust/fuzz/Cargo.toml
+++ b/src/integration-tests/libfuzzer-rust/fuzz/Cargo.toml
@@ -3,7 +3,7 @@ name = "rust-fuzz"
 version = "0.0.0"
 authors = ["Automatically generated"]
 publish = false
-edition = "2018"
+edition = "2021"
 
 [package.metadata]
 cargo-fuzz = true

--- a/src/proxy-manager/Cargo.lock
+++ b/src/proxy-manager/Cargo.lock
@@ -1064,9 +1064,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81b9228215d82c7b61490fec1de287136b5de6f5700f6e58ea9ad61a7964ca51"
+checksum = "eff6510e86862b57b210fd8cbe8ed3f0d7d600b9c2863cd4549a2e033c66e956"
 dependencies = [
  "memchr",
  "serde",

--- a/src/proxy-manager/Cargo.toml
+++ b/src/proxy-manager/Cargo.toml
@@ -2,7 +2,7 @@
 name = "onefuzz-proxy-manager"
 version = "0.0.1"
 authors = ["fuzzing@microsoft.com"]
-edition = "2018"
+edition = "2021"
 publish = false
 license = "MIT"
 

--- a/src/utils/telemetry-stats/Cargo.toml
+++ b/src/utils/telemetry-stats/Cargo.toml
@@ -2,11 +2,15 @@
 name = "onefuzz-telemetry-stats"
 version = "0.1.0"
 authors = ["<fuzzing@microsoft.com>"]
-edition = "2018"
+edition = "2021"
 license = "MIT"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 anyhow = "1.0"
-chrono = { version = "0.4", default-features = false, features = ["clock", "std", "serde"] }
+chrono = { version = "0.4", default-features = false, features = [
+    "clock",
+    "std",
+    "serde",
+] }


### PR DESCRIPTION
Changes mostly done by `cargo fix --edition`.