### PR TITLE
Tolerate errors when attempting to fetch metadata for some `CreateKind`s

### DIFF
--- a/src/agent/onefuzz/src/monitor.rs
+++ b/src/agent/onefuzz/src/monitor.rs
@@ -142,7 +142,7 @@ impl DirectoryMonitor {
                                 Err(e) => {
                                     warn!(
                                         "{:?}",
-                                        Err(e).context(format!(
+                                        Err::<(), _>(e).context(format!(
                                             "failed to get metadata for {}",
                                             path.display()
                                         ))

--- a/src/agent/onefuzz/src/monitor.rs
+++ b/src/agent/onefuzz/src/monitor.rs
@@ -132,13 +132,9 @@ impl DirectoryMonitor {
                             }
                         }
                         CreateKind::Any | CreateKind::Other => {
-                            if self.report_directories {
-                                return Ok(Some(path));
-                            }
-
                             if let Ok(metadata) = fs::metadata(&path).await {
-                                // check if it is a file
-                                if metadata.is_file() {
+                                // check if it is a file or a folder
+                                if metadata.is_file() || self.report_directories {
                                     return Ok(Some(path));
                                 }
                             }

--- a/src/agent/onefuzz/src/monitor.rs
+++ b/src/agent/onefuzz/src/monitor.rs
@@ -132,10 +132,15 @@ impl DirectoryMonitor {
                             }
                         }
                         CreateKind::Any | CreateKind::Other => {
+                            // Short-circuit and report this path if we're reporting everything.
+                            if self.report_directories {
+                                return Ok(Some(path));
+                            }
+
                             match fs::metadata(&path).await {
                                 Ok(metadata) => {
-                                    // check if it is a file or a folder
-                                    if metadata.is_file() || self.report_directories {
+                                    // We're only reporting files, so make sure this is a file first.
+                                    if metadata.is_file() {
                                         return Ok(Some(path));
                                     }
                                 }

--- a/src/agent/onefuzz/src/monitor.rs
+++ b/src/agent/onefuzz/src/monitor.rs
@@ -3,7 +3,7 @@
 
 use std::path::{Path, PathBuf};
 
-use anyhow::{format_err, Context, Result};
+use anyhow::{format_err, Result};
 use notify::{
     event::{CreateKind, ModifyKind, RenameMode},
     Event, EventKind, Watcher,
@@ -136,13 +136,11 @@ impl DirectoryMonitor {
                                 return Ok(Some(path));
                             }
 
-                            // check if it is a file
-                            let metadata = fs::metadata(&path)
-                                .await
-                                .context("checking metadata for file")?;
-
-                            if metadata.is_file() {
-                                return Ok(Some(path));
+                            if let Ok(metadata) = fs::metadata(&path).await {
+                                // check if it is a file
+                                if metadata.is_file() {
+                                    return Ok(Some(path));
+                                }
                             }
                         }
                     }

--- a/src/agent/onefuzz/src/monitor.rs
+++ b/src/agent/onefuzz/src/monitor.rs
@@ -141,7 +141,7 @@ impl DirectoryMonitor {
                                 }
                                 Err(e) => {
                                     warn!(
-                                        "{}",
+                                        "{:?}",
                                         Err(e).context(format!(
                                             "failed to get metadata for {}",
                                             path.display()

--- a/src/agent/onefuzz/src/monitor.rs
+++ b/src/agent/onefuzz/src/monitor.rs
@@ -3,7 +3,7 @@
 
 use std::path::{Path, PathBuf};
 
-use anyhow::{format_err, Context, Result};
+use anyhow::{format_err, Result};
 use notify::{
     event::{CreateKind, ModifyKind, RenameMode},
     Event, EventKind, Watcher,
@@ -140,13 +140,7 @@ impl DirectoryMonitor {
                                     }
                                 }
                                 Err(e) => {
-                                    warn!(
-                                        "{:?}",
-                                        Err::<(), _>(e).context(format!(
-                                            "failed to get metadata for {}",
-                                            path.display()
-                                        ))
-                                    );
+                                    warn!("failed to get metadata for {}: {:?}", path.display(), e);
                                 }
                             }
                         }


### PR DESCRIPTION
## Summary of the Pull Request

Fixing an error encountered in prod:

```
task failed. exit_status:ExitStatus { Code = 1, Signal = , Success = False }

ERROR [onefuzz_task::managed::cmd] error running task: Failure in monitor_inputs

Caused by:
    0: checking metadata for file
    1: The system cannot find the file specified. (os error 2)
```

## PR Checklist
* [ ] Applies to work item: #xxx
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/onefuzz) and sign the CLI.
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx
