### PR TITLE
Make crashdumps optional in config

### DIFF
--- a/src/ApiService/ApiService/onefuzzlib/Defs.cs
+++ b/src/ApiService/ApiService/onefuzzlib/Defs.cs
@@ -192,7 +192,7 @@ public static class Defs {
                         ),
                         new ContainerDefinition(
                             Type:ContainerType.Crashdumps,
-                            Compare: Compare.Equal,
+                            Compare: Compare.AtMost,
                             Value:1,
                             Permissions: ContainerPermission.Write
                             ),
@@ -287,7 +287,7 @@ public static class Defs {
                         ),
                         new ContainerDefinition(
                             Type:ContainerType.Crashdumps,
-                            Compare: Compare.Equal,
+                            Compare: Compare.AtMost,
                             Value:1,
                             Permissions: ContainerPermission.Write
                             ),

--- a/src/agent/onefuzz-task/src/local/libfuzzer_fuzz.rs
+++ b/src/agent/onefuzz-task/src/local/libfuzzer_fuzz.rs
@@ -51,7 +51,7 @@ pub fn build_fuzz_config(
         inputs,
         readonly_inputs,
         crashes,
-        crashdumps,
+        crashdumps: Some(crashdumps),
         target_exe,
         target_env,
         target_options,

--- a/src/agent/onefuzz-task/src/local/template.rs
+++ b/src/agent/onefuzz-task/src/local/template.rs
@@ -144,7 +144,9 @@ impl TaskConfig {
                     inputs: context.to_monitored_sync_dir("inputs", &config.inputs)?,
                     readonly_inputs: Some(ri?),
                     crashes: context.to_monitored_sync_dir("crashes", &config.crashes)?,
-                    crashdumps: context.to_monitored_sync_dir("crashdumps", &config.crashdumps)?,
+                    crashdumps: Some(
+                        context.to_monitored_sync_dir("crashdumps", &config.crashdumps)?,
+                    ),
                     target_exe: config.target_exe.clone(),
                     target_env: config.target_env.clone(),
                     target_options: config.target_options.clone(),

--- a/src/agent/onefuzz-task/src/tasks/fuzz/libfuzzer/common.rs
+++ b/src/agent/onefuzz-task/src/tasks/fuzz/libfuzzer/common.rs
@@ -74,7 +74,7 @@ pub struct Config<L: LibFuzzerType + Send + Sync + ?Sized> {
     pub inputs: SyncedDir,
     pub readonly_inputs: Option<Vec<SyncedDir>>,
     pub crashes: SyncedDir,
-    pub crashdumps: SyncedDir,
+    pub crashdumps: Option<SyncedDir>,
     pub target_exe: PathBuf,
     pub target_env: HashMap<String, String>,
     pub target_options: Vec<String>,
@@ -131,7 +131,13 @@ where
         let resync = self.continuous_sync_inputs();
         let new_inputs = self.config.inputs.monitor_results(new_coverage, true);
         let new_crashes = self.config.crashes.monitor_results(new_result, true);
-        let new_crashdumps = self.config.crashdumps.monitor_results(new_crashdump, true);
+        let new_crashdumps = async {
+            if let Some(crashdumps) = &self.config.crashdumps {
+                crashdumps.monitor_results(new_crashdump, true).await
+            } else {
+                Ok(())
+            }
+        };
 
         let (stats_sender, stats_receiver) = mpsc::unbounded_channel();
         let report_stats = report_runtime_stats(stats_receiver, hb_client);
@@ -350,64 +356,66 @@ where
             }
         }
 
-        // check for core dumps on Linux:
-        // note that collecting the dumps must be enabled by the template
-        #[cfg(target_os = "linux")]
-        if let Some(pid) = pid {
-            // expect crash dump to exist in CWD
-            let filename = format!("core.{pid}");
-            let dest_filename = dump_file_name.as_deref().unwrap_or(OsStr::new(&filename));
-            let dest_path = self.config.crashdumps.local_path.join(dest_filename);
-            match tokio::fs::rename(&filename, &dest_path).await {
-                Ok(()) => {
-                    info!(
-                        "moved crash dump {} to output directory: {}",
-                        filename,
-                        dest_path.display()
-                    );
-                }
-                Err(e) => {
-                    if e.kind() == std::io::ErrorKind::NotFound {
-                        // okay, no crash dump found
-                        info!("no crash dump found with name: {}", filename);
-                    } else {
-                        return Err(e).context("moving crash dump to output directory");
+        if let Some(crashdumps) = &self.config.crashdumps {
+            // check for core dumps on Linux:
+            // note that collecting the dumps must be enabled by the template
+            #[cfg(target_os = "linux")]
+            if let Some(pid) = pid {
+                // expect crash dump to exist in CWD
+                let filename = format!("core.{pid}");
+                let dest_filename = dump_file_name.as_deref().unwrap_or(OsStr::new(&filename));
+                let dest_path = crashdumps.local_path.join(dest_filename);
+                match tokio::fs::rename(&filename, &dest_path).await {
+                    Ok(()) => {
+                        info!(
+                            "moved crash dump {} to output directory: {}",
+                            filename,
+                            dest_path.display()
+                        );
+                    }
+                    Err(e) => {
+                        if e.kind() == std::io::ErrorKind::NotFound {
+                            // okay, no crash dump found
+                            info!("no crash dump found with name: {}", filename);
+                        } else {
+                            return Err(e).context("moving crash dump to output directory");
+                        }
                     }
                 }
+            } else {
+                warn!("no PID found for libfuzzer process");
             }
-        } else {
-            warn!("no PID found for libfuzzer process");
-        }
 
-        // check for crash dumps on Windows:
-        #[cfg(target_os = "windows")]
-        {
-            let dumpfile_extension = Some(std::ffi::OsStr::new("dmp"));
+            // check for crash dumps on Windows:
+            #[cfg(target_os = "windows")]
+            {
+                let dumpfile_extension = Some(std::ffi::OsStr::new("dmp"));
 
-            let mut working_dir = tokio::fs::read_dir(".").await?;
-            let mut found_dump = false;
-            while let Some(next) = working_dir.next_entry().await? {
-                if next.path().extension() == dumpfile_extension {
-                    // Windows dumps get a fixed filename so we will generate a random one,
-                    // if there's no valid target crash name:
-                    let dest_filename =
-                        dump_file_name.unwrap_or_else(|| uuid::Uuid::new_v4().to_string().into());
-                    let dest_path = self.config.crashdumps.local_path.join(&dest_filename);
-                    tokio::fs::rename(next.path(), &dest_path)
-                        .await
-                        .context("moving crash dump to output directory")?;
-                    info!(
-                        "moved crash dump {} to output directory: {}",
-                        next.path().display(),
-                        dest_path.display()
-                    );
-                    found_dump = true;
-                    break;
+                let mut working_dir = tokio::fs::read_dir(".").await?;
+                let mut found_dump = false;
+                while let Some(next) = working_dir.next_entry().await? {
+                    if next.path().extension() == dumpfile_extension {
+                        // Windows dumps get a fixed filename so we will generate a random one,
+                        // if there's no valid target crash name:
+                        let dest_filename = dump_file_name
+                            .unwrap_or_else(|| uuid::Uuid::new_v4().to_string().into());
+                        let dest_path = crashdumps.local_path.join(&dest_filename);
+                        tokio::fs::rename(next.path(), &dest_path)
+                            .await
+                            .context("moving crash dump to output directory")?;
+                        info!(
+                            "moved crash dump {} to output directory: {}",
+                            next.path().display(),
+                            dest_path.display()
+                        );
+                        found_dump = true;
+                        break;
+                    }
                 }
-            }
 
-            if !found_dump {
-                info!("no crash dump found with extension .dmp");
+                if !found_dump {
+                    info!("no crash dump found with extension .dmp");
+                }
             }
         }
 
@@ -425,7 +433,9 @@ where
 
         // output directories (init):
         self.config.crashes.init().await?;
-        self.config.crashdumps.init().await?;
+        if let Some(crashdumps) = &self.config.crashdumps {
+            crashdumps.init().await?;
+        }
 
         Ok(())
     }


### PR DESCRIPTION
Make crashdumps optional in task definition so that old CLI clients are not rejected.