### PR TITLE
Deserialize the coverage files directly into the output files

### DIFF
--- a/src/agent/coverage/examples/cobertura.rs
+++ b/src/agent/coverage/examples/cobertura.rs
@@ -40,7 +40,7 @@ fn generate_output() -> Result<String> {
         coverage.files.insert(file_path, file);
     }
 
-    CoberturaCoverage::from(coverage).to_string()
+    CoberturaCoverage::from(&coverage).to_string()
 }
 
 #[cfg(test)]

--- a/src/agent/coverage/examples/record.rs
+++ b/src/agent/coverage/examples/record.rs
@@ -190,7 +190,7 @@ fn dump_modoff(coverage: &BinaryCoverage) -> Result<()> {
 }
 
 fn dump_source_line(binary: &BinaryCoverage, allowlist: AllowList) -> Result<()> {
-    let source = coverage::source::binary_to_source_coverage(binary, allowlist)?;
+    let source = coverage::source::binary_to_source_coverage(binary, &allowlist)?;
 
     for (path, file) in &source.files {
         for (line, count) in &file.lines {
@@ -202,7 +202,7 @@ fn dump_source_line(binary: &BinaryCoverage, allowlist: AllowList) -> Result<()>
 }
 
 fn dump_cobertura(binary: &BinaryCoverage, allowlist: AllowList) -> Result<()> {
-    let source = coverage::source::binary_to_source_coverage(binary, allowlist)?;
+    let source = coverage::source::binary_to_source_coverage(binary, &allowlist)?;
     let cobertura: CoberturaCoverage = (&source).into();
 
     println!("{}", cobertura.to_string()?);

--- a/src/agent/coverage/examples/record.rs
+++ b/src/agent/coverage/examples/record.rs
@@ -203,7 +203,7 @@ fn dump_source_line(binary: &BinaryCoverage, allowlist: AllowList) -> Result<()>
 
 fn dump_cobertura(binary: &BinaryCoverage, allowlist: AllowList) -> Result<()> {
     let source = coverage::source::binary_to_source_coverage(binary, allowlist)?;
-    let cobertura: CoberturaCoverage = source.into();
+    let cobertura: CoberturaCoverage = (&source).into();
 
     println!("{}", cobertura.to_string()?);
 

--- a/src/agent/coverage/src/cobertura.rs
+++ b/src/agent/coverage/src/cobertura.rs
@@ -16,8 +16,8 @@ use crate::source::SourceCoverage;
 // Dir -> Set<FilePath>
 type FileMap<'a> = BTreeMap<&'a str, BTreeSet<&'a FilePath>>;
 
-impl From<SourceCoverage> for CoberturaCoverage {
-    fn from(source: SourceCoverage) -> Self {
+impl From<&SourceCoverage> for CoberturaCoverage {
+    fn from(source: &SourceCoverage) -> Self {
         // The Cobertura data model is organized around `classes` and `methods` contained
         // in `packages`. Our source coverage has no language-level assumptions.
         //
@@ -51,7 +51,7 @@ impl From<SourceCoverage> for CoberturaCoverage {
         // Iterate through the grouped files, accumulating `<package>` elements.
         let (packages, hit_counts): (Vec<Package>, Vec<HitCounts>) = file_map
             .into_iter()
-            .map(|(directory, files)| directory_to_package(&source, directory, files))
+            .map(|(directory, files)| directory_to_package(source, directory, files))
             .unzip();
 
         let hit_count: HitCounts = hit_counts.into_iter().sum();

--- a/src/agent/coverage/src/source.rs
+++ b/src/agent/coverage/src/source.rs
@@ -51,7 +51,7 @@ impl From<Line> for u32 {
 
 pub fn binary_to_source_coverage(
     binary: &BinaryCoverage,
-    source_allowlist: AllowList,
+    source_allowlist: &AllowList,
 ) -> Result<SourceCoverage> {
     use std::collections::btree_map::Entry;
 

--- a/src/agent/coverage/src/source.rs
+++ b/src/agent/coverage/src/source.rs
@@ -58,7 +58,6 @@ pub fn binary_to_source_coverage(
     use symbolic::debuginfo::Object;
     use symbolic::symcache::{SymCache, SymCacheConverter};
 
-    // let source_allowlist = source_allowlist.unwrap_or_default();
     let loader = Loader::new();
 
     let mut source = SourceCoverage::default();

--- a/src/agent/coverage/src/source.rs
+++ b/src/agent/coverage/src/source.rs
@@ -51,14 +51,14 @@ impl From<Line> for u32 {
 
 pub fn binary_to_source_coverage(
     binary: &BinaryCoverage,
-    source_allowlist: impl Into<Option<AllowList>>,
+    source_allowlist: AllowList,
 ) -> Result<SourceCoverage> {
     use std::collections::btree_map::Entry;
 
     use symbolic::debuginfo::Object;
     use symbolic::symcache::{SymCache, SymCacheConverter};
 
-    let source_allowlist = source_allowlist.into().unwrap_or_default();
+    // let source_allowlist = source_allowlist.unwrap_or_default();
     let loader = Loader::new();
 
     let mut source = SourceCoverage::default();

--- a/src/agent/coverage/tests/snapshot.rs
+++ b/src/agent/coverage/tests/snapshot.rs
@@ -54,7 +54,7 @@ fn windows_snapshot_tests() {
 
         // generate source-line coverage info
         let source =
-            coverage::source::binary_to_source_coverage(&recorded.coverage, source_allowlist)
+            coverage::source::binary_to_source_coverage(&recorded.coverage, &source_allowlist)
                 .expect("binary_to_source_coverage");
 
         let file_coverage = source

--- a/src/agent/onefuzz-file-format/src/coverage/binary.rs
+++ b/src/agent/onefuzz-file-format/src/coverage/binary.rs
@@ -32,8 +32,8 @@ impl BinaryCoverageJson {
 }
 
 // Convert into the latest format.
-impl From<BinaryCoverage> for BinaryCoverageJson {
-    fn from(source: BinaryCoverage) -> Self {
+impl From<&BinaryCoverage> for BinaryCoverageJson {
+    fn from(source: &BinaryCoverage) -> Self {
         v1::BinaryCoverageJson::from(source).into()
     }
 }

--- a/src/agent/onefuzz-file-format/src/coverage/binary/v1.rs
+++ b/src/agent/onefuzz-file-format/src/coverage/binary/v1.rs
@@ -21,8 +21,8 @@ pub struct ModuleCoverageJson {
     pub blocks: BTreeMap<Hex, u32>,
 }
 
-impl From<BinaryCoverage> for BinaryCoverageJson {
-    fn from(binary: BinaryCoverage) -> Self {
+impl From<&BinaryCoverage> for BinaryCoverageJson {
+    fn from(binary: &BinaryCoverage) -> Self {
         let mut modules = BTreeMap::new();
 
         for (path, offsets) in &binary.modules {

--- a/src/agent/onefuzz-file-format/src/coverage/source.rs
+++ b/src/agent/onefuzz-file-format/src/coverage/source.rs
@@ -32,8 +32,8 @@ impl SourceCoverageJson {
 }
 
 // Convert into the latest format.
-impl From<SourceCoverage> for SourceCoverageJson {
-    fn from(source: SourceCoverage) -> Self {
+impl From<&SourceCoverage> for SourceCoverageJson {
+    fn from(source: &SourceCoverage) -> Self {
         v1::SourceCoverageJson::from(source).into()
     }
 }

--- a/src/agent/onefuzz-file-format/src/coverage/source/v1.rs
+++ b/src/agent/onefuzz-file-format/src/coverage/source/v1.rs
@@ -23,14 +23,14 @@ pub struct FileCoverageJson {
     pub lines: BTreeMap<LineNumber, HitCount>,
 }
 
-impl From<SourceCoverage> for SourceCoverageJson {
-    fn from(source: SourceCoverage) -> Self {
+impl From<&SourceCoverage> for SourceCoverageJson {
+    fn from(source: &SourceCoverage) -> Self {
         let mut json = SourceCoverageJson::default();
 
-        for (path, file) in source.files {
+        for (path, file) in &source.files {
             let mut file_json = FileCoverageJson::default();
 
-            for (line, count) in file.lines {
+            for (line, count) in &file.lines {
                 let line_number = LineNumber(line.number());
                 let hit_count = count.0;
                 file_json.lines.insert(line_number, hit_count);

--- a/src/agent/onefuzz-task/src/tasks/coverage/generic.rs
+++ b/src/agent/onefuzz-task/src/tasks/coverage/generic.rs
@@ -496,8 +496,6 @@ impl<'a> TaskContext<'a> {
         let source_coverage_path = self.config.coverage.local_path.join(SOURCE_COVERAGE_FILE);
         let binary_coverage_path = self.config.coverage.local_path.join(COVERAGE_FILE);
 
-        // let coverage = RwLock::read(&self.coverage).await;
-
         Self::save_coverage(
             &self.coverage,
             &self.source_allowlist,

--- a/src/agent/onefuzz-task/src/tasks/coverage/generic.rs
+++ b/src/agent/onefuzz-task/src/tasks/coverage/generic.rs
@@ -526,11 +526,10 @@ impl<'a> TaskContext<'a> {
         let coverage_file = std::fs::File::create(path)
             .with_context(|| format!("creating coverage file {}", path.display()))?;
         let coverage_file_writer = std::io::BufWriter::new(coverage_file);
-        serde_json::to_writer_pretty(coverage_file_writer, &json)
+        serde_json::to_writer(coverage_file_writer, &json)
             .with_context(|| format!("serializing binary coverage to {}", path.display()))?;
         Ok(())
     }
-
 }
 
 #[async_trait]


### PR DESCRIPTION
## Summary of the Pull Request

The Coverage file was loading the output of the coverage in memory before writing it to the output file. 
This could cause an increase in memory consumption. This change updates the logic to serialize the output directly in the output file without loading it in the memory.

closes #3420


