### PR TITLE
Impl AsyncWrite for cobertura output

### DIFF
--- a/src/agent/cobertura/Cargo.toml
+++ b/src/agent/cobertura/Cargo.toml
@@ -7,3 +7,5 @@ license = "MIT"
 [dependencies]
 anyhow = "1.0"
 quick-xml = "0.30"
+tokio = "1"
+async-trait = "0.1"


### PR DESCRIPTION
So far, this PR is just me exploring with implementing AsyncWrite. The current 'blocker' is that the Writer implementation that uses async doesn't have 'high level' functions like `create_element` which we use from the sync impl. Next time, or the next person that picks up this PR should figure out how to have async versions of those high level functions.