### PR TITLE
Use `omnisharp` language features.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,6 +13,7 @@
 					"**/target/**": true
 				},
 				"lldb.executable": "/usr/bin/lldb",
+				"dotnet.server.useOmnisharp": true,
 				"omnisharp.enableEditorConfigSupport": true,
 				"omnisharp.enableRoslynAnalyzers": true,
 				"python.defaultInterpreterPath": "/workspaces/onefuzz/src/venv/bin/python",


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_
Microsoft C# vs code extension is broken with latest release. Enabling omnisharp as a workaround. 
See: https://github.com/dotnet/vscode-csharp/issues/6218#issuecomment-1692647319

