### PR TITLE
Improve area/iteration path validation

### DIFF
--- a/src/ApiService/ApiService/OneFuzzTypes/Enums.cs
+++ b/src/ApiService/ApiService/OneFuzzTypes/Enums.cs
@@ -49,6 +49,7 @@ public enum ErrorCode {
     ADO_VALIDATION_MISSING_PAT_SCOPES = 492,
     ADO_WORKITEM_PROCESSING_DISABLED = 494,
     ADO_VALIDATION_INVALID_PATH = 495,
+    ADO_VALIDATION_INVALID_PROJECT = 496,
     // NB: if you update this enum, also update enums.py
 }
 

--- a/src/ApiService/ApiService/onefuzzlib/notifications/Ado.cs
+++ b/src/ApiService/ApiService/onefuzzlib/notifications/Ado.cs
@@ -109,7 +109,7 @@ public class Ado : NotificationsBase, IAdo {
         erroneous = pathParts.FirstOrDefault(part => invalidChars.Any(part.Contains));
         if (erroneous != null) {
             return OneFuzzResultVoid.Error(ErrorCode.ADO_VALIDATION_INVALID_PATH, new string[] {
-                $"{pathType} Path \"{path}\" is invalid. \"{erroneous}\" contains an invalid character ({string.Join(", ", invalidChars)}).",
+                $"{pathType} Path \"{path}\" is invalid. \"{erroneous}\" contains an invalid character ({string.Join(" ", invalidChars)}).",
                 "Make sure that the path is separated by backslashes (\\) and not forward slashes (/).",
             });
         }

--- a/src/ApiService/Tests/TreePathTests.cs
+++ b/src/ApiService/Tests/TreePathTests.cs
@@ -67,8 +67,7 @@ public class TreePathTests {
 
     [Theory]
     [InlineData("project/foo/bar/baz")]
-    [InlineData("project\\foo.\\bar\\baz")]
-    [InlineData("project\\foo\f\\bar\\baz")]
+    [InlineData("project\\foo:\\bar\\baz")]
     public void TestPathContainsInvalidChar(string invalidPath) {
         var path = SplitPath(invalidPath);
         var treePath = SplitPath(@"project\foo\bar\baz");
@@ -81,10 +80,13 @@ public class TreePathTests {
         Assert.Contains("invalid character", result.ErrorV!.Errors![0]);
     }
 
-    [Fact]
-    public void TestPathContainsUnicodeControlChar() {
-        var path = SplitPath("project\\foo\\ba\u0005r\\baz");
-        var root = MockTreeNode(path, TreeNodeStructureType.Area);
+    [Theory]
+    [InlineData("project\\foo\\ba\u0005r\\baz")]
+    [InlineData("project\\\nfoo\\bar\\baz")]
+    public void TestPathContainsUnicodeControlChar(string invalidPath) {
+        var path = SplitPath(invalidPath);
+        var treePath = SplitPath(@"project\foo\bar\baz");
+        var root = MockTreeNode(treePath, TreeNodeStructureType.Area);
 
         var result = Ado.ValidateTreePath(path, root);
 

--- a/src/ApiService/Tests/TreePathTests.cs
+++ b/src/ApiService/Tests/TreePathTests.cs
@@ -1,8 +1,8 @@
-using Xunit;
+﻿using System.Collections.Generic;
+using System.Linq;
 using Microsoft.OneFuzz.Service;
 using Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models;
-using System.Collections.Generic;
-using System.Linq;
+using Xunit;
 
 namespace Tests;
 

--- a/src/ApiService/Tests/TreePathTests.cs
+++ b/src/ApiService/Tests/TreePathTests.cs
@@ -1,0 +1,146 @@
+using Xunit;
+using Microsoft.OneFuzz.Service;
+using Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Tests;
+
+// This might be a good candidate for property based testing
+// https://fscheck.github.io/FsCheck//QuickStart.html
+public class TreePathTests {
+    private static IEnumerable<string> SplitPath(string path) {
+        return path.Split('\\');
+    }
+
+    private static WorkItemClassificationNode MockTreeNode(IEnumerable<string> path, TreeNodeStructureType structureType) {
+        var root = new WorkItemClassificationNode() {
+            Name = path.First(),
+            StructureType = structureType
+        };
+
+        var current = root;
+        foreach (var segment in path.Skip(1)) {
+            var child = new WorkItemClassificationNode {
+                Name = segment
+            };
+            current.Children = new[] { child };
+            current = child;
+        }
+
+        return root;
+    }
+
+
+    [Fact]
+    public void TestValidPath() {
+        var path = SplitPath(@"project\foo\bar\baz");
+        var root = MockTreeNode(path, TreeNodeStructureType.Area);
+
+        var result = Ado.ValidateTreePath(path, root);
+
+        Assert.True(result.IsOk);
+    }
+
+    [Fact]
+    public void TestNullTreeNode() { // A null tree node indicates an invalid ADO project was used in the query
+        var path = SplitPath(@"project\foo\bar\baz");
+
+        var result = Ado.ValidateTreePath(path, null);
+
+        Assert.False(result.IsOk);
+        Assert.Equal(ErrorCode.ADO_VALIDATION_INVALID_PROJECT, result.ErrorV!.Code);
+        Assert.Contains("ADO project doesn't exist", result.ErrorV!.Errors![0]);
+    }
+
+    [Fact]
+    public void TestPathPartTooLong() {
+        var path = SplitPath(@"project\foo\barbazquxquuxcorgegraultgarplywaldofredplughxyzzythudbarbazquxquuxcorgegraultgarplywaldofredplughxyzzythudbarbazquxquuxcorgegraultgarplywaldofredplughxyzzythudbarbazquxquuxcorgegraultgarplywaldofredplughxyzzythudbarbazquxquuxcorgegraultgarplywaldofredplughxyzzythud\baz");
+        var root = MockTreeNode(path, TreeNodeStructureType.Iteration);
+
+        var result = Ado.ValidateTreePath(path, root);
+
+        Assert.False(result.IsOk);
+        Assert.Equal(ErrorCode.ADO_VALIDATION_INVALID_PATH, result.ErrorV!.Code);
+        Assert.Contains("too long", result.ErrorV!.Errors![0]);
+    }
+
+    [Theory]
+    [InlineData("project/foo/bar/baz")]
+    [InlineData("project\\foo.\\bar\\baz")]
+    [InlineData("project\\foo\f\\bar\\baz")]
+    public void TestPathContainsInvalidChar(string invalidPath) {
+        var path = SplitPath(invalidPath);
+        var treePath = SplitPath(@"project\foo\bar\baz");
+        var root = MockTreeNode(treePath, TreeNodeStructureType.Area);
+
+        var result = Ado.ValidateTreePath(path, root);
+
+        Assert.False(result.IsOk);
+        Assert.Equal(ErrorCode.ADO_VALIDATION_INVALID_PATH, result.ErrorV!.Code);
+        Assert.Contains("invalid character", result.ErrorV!.Errors![0]);
+    }
+
+    [Fact]
+    public void TestPathContainsUnicodeControlChar() {
+        var path = SplitPath("project\\foo\\ba\u0005r\\baz");
+        var root = MockTreeNode(path, TreeNodeStructureType.Area);
+
+        var result = Ado.ValidateTreePath(path, root);
+
+        Assert.False(result.IsOk);
+        Assert.Equal(ErrorCode.ADO_VALIDATION_INVALID_PATH, result.ErrorV!.Code);
+        Assert.Contains("unicode control character", result.ErrorV!.Errors![0]);
+    }
+
+    [Fact]
+    public void TestPathTooDeep() {
+        var path = SplitPath(@"project\foo\bar\baz\qux\quux\corge\grault\garply\waldo\fred\plugh\xyzzy\thud");
+        var root = MockTreeNode(path, TreeNodeStructureType.Area);
+
+        var result = Ado.ValidateTreePath(path, root);
+
+        Assert.False(result.IsOk);
+        Assert.Equal(ErrorCode.ADO_VALIDATION_INVALID_PATH, result.ErrorV!.Code);
+        Assert.Contains("levels deep", result.ErrorV!.Errors![0]);
+    }
+
+    [Fact]
+    public void TestPathWithoutProjectName() {
+        var path = SplitPath(@"foo\bar\baz");
+        var treePath = SplitPath(@"project\foo\bar\baz");
+        var root = MockTreeNode(treePath, TreeNodeStructureType.Iteration);
+
+        var result = Ado.ValidateTreePath(path, root);
+
+        Assert.False(result.IsOk);
+        Assert.Equal(ErrorCode.ADO_VALIDATION_INVALID_PATH, result.ErrorV!.Code);
+        Assert.Contains("start with the project name", result.ErrorV!.Errors![0]);
+    }
+
+    [Fact]
+    public void TestPathWithInvalidChild() {
+        var path = SplitPath(@"project\foo\baz");
+        var treePath = SplitPath(@"project\foo\bar");
+        var root = MockTreeNode(treePath, TreeNodeStructureType.Iteration);
+
+        var result = Ado.ValidateTreePath(path, root);
+
+        Assert.False(result.IsOk);
+        Assert.Equal(ErrorCode.ADO_VALIDATION_INVALID_PATH, result.ErrorV!.Code);
+        Assert.Contains("not a valid child", result.ErrorV!.Errors![0]);
+    }
+
+    [Fact]
+    public void TestPathWithExtraChild() {
+        var path = SplitPath(@"project\foo\bar\baz");
+        var treePath = SplitPath(@"project\foo\bar");
+        var root = MockTreeNode(treePath, TreeNodeStructureType.Iteration);
+
+        var result = Ado.ValidateTreePath(path, root);
+
+        Assert.False(result.IsOk);
+        Assert.Equal(ErrorCode.ADO_VALIDATION_INVALID_PATH, result.ErrorV!.Code);
+        Assert.Contains("has no children", result.ErrorV!.Errors![0]);
+    }
+}

--- a/src/pytypes/onefuzztypes/enums.py
+++ b/src/pytypes/onefuzztypes/enums.py
@@ -303,6 +303,7 @@ class ErrorCode(Enum):
     ADO_VALIDATION_UNEXPECTED_ERROR = 491
     ADO_VALIDATION_MISSING_PAT_SCOPES = 492
     ADO_VALIDATION_INVALID_PATH = 495
+    ADO_VALIDATION_INVALID_PROJECT = 496
     # NB: if you update this enum, also update Enums.cs
 
 


### PR DESCRIPTION
## Summary of the Pull Request

Adds validation against the path naming restrictions defined in https://learn.microsoft.com/en-us/azure/devops/organizations/settings/about-areas-iterations?view=azure-devops#naming-restrictions

The newly added checks each have their own error message for their violation, so, for example, users that delimit their paths with a forward slash instead of a backslash will get a message saying:
"Area Path "Foo/Bar" is invalid. "Foo/Bar" contains an invalid character (\ / : * ? " < > | ; # $ * { } , + = [ ])."
"Make sure that the path is separated by backslashes (\\) and not forward slashes (/)."

## PR Checklist
* [ ] Applies to work item: #xxx
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/onefuzz) and sign the CLI.
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_

## Validation Steps Performed

_How does someone test & validate?_
