### PR TITLE
Add OneFuzz service version to job created events

### DIFF
--- a/src/ApiService/ApiService/Functions/Jobs.cs
+++ b/src/ApiService/ApiService/Functions/Jobs.cs
@@ -83,7 +83,7 @@ public class Jobs {
                 "job");
         }
 
-        await _context.Events.SendEvent(new EventJobCreated(job.JobId, job.Config, job.UserInfo));
+        await _context.Events.SendEvent(new EventJobCreated(job.JobId, job.Config, job.UserInfo, _context.ServiceConfiguration.OneFuzzVersion));
         return await RequestHandling.Ok(req, JobResponse.ForJob(job, taskInfo: null));
     }
 

--- a/src/ApiService/ApiService/OneFuzzTypes/Events.cs
+++ b/src/ApiService/ApiService/OneFuzzTypes/Events.cs
@@ -124,7 +124,8 @@ public record EventTaskFailed(
 public record EventJobCreated(
    Guid JobId,
    JobConfig Config,
-   StoredUserInfo? UserInfo
+   StoredUserInfo? UserInfo,
+   string OneFuzzVersion
    ) : BaseEvent();
 
 


### PR DESCRIPTION
## Summary of the Pull Request

Add this info so that developers and users can track which version of OneFuzz a job was submitted with.

## PR Checklist
* [ ] Applies to work item: #3350
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/onefuzz) and sign the CLI.
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_

## Validation Steps Performed

Logs don't indicate any failures after using the cli to create a new job against my own instance.
