### PR TITLE
Fixup onefuzz-task dependencies

### DIFF
--- a/src/agent/onefuzz-task/src/check_for_update.rs
+++ b/src/agent/onefuzz-task/src/check_for_update.rs
@@ -1,6 +1,7 @@
 use std::process::Stdio;
 
-use anyhow::Result;
+use anyhow::{bail, Result};
+use onefuzz_telemetry::info;
 use serde_json::Value;
 
 pub fn run(onefuzz_built_version: &str) -> Result<()> {

--- a/src/agent/onefuzz-task/src/main.rs
+++ b/src/agent/onefuzz-task/src/main.rs
@@ -1,23 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#[macro_use]
-extern crate anyhow;
-#[macro_use]
-extern crate clap;
-#[macro_use]
-extern crate onefuzz_telemetry;
-extern crate onefuzz;
-
 use anyhow::Result;
-use clap::{ArgMatches, Command};
+use clap::{crate_version, ArgMatches, Command};
 
 use std::io::{stdout, Write};
 
 mod check_for_update;
-mod local;
 mod managed;
-mod tasks;
 
 const LICENSE_CMD: &str = "licenses";
 const LOCAL_CMD: &str = "local";
@@ -37,7 +27,7 @@ fn main() -> Result<()> {
     let app = Command::new("onefuzz-task")
         .version(built_version)
         .subcommand(managed::cmd::args(MANAGED_CMD))
-        .subcommand(local::cmd::args(LOCAL_CMD))
+        .subcommand(onefuzz_task_lib::local::cmd::args(LOCAL_CMD))
         .subcommand(Command::new(LICENSE_CMD).about("display third-party licenses"))
         .subcommand(
             Command::new(CHECK_FOR_UPDATE)
@@ -62,7 +52,7 @@ async fn run(args: ArgMatches) -> Result<()> {
 
     match args.subcommand() {
         Some((LICENSE_CMD, _)) => licenses(),
-        Some((LOCAL_CMD, sub)) => local::cmd::run(sub.to_owned()).await,
+        Some((LOCAL_CMD, sub)) => onefuzz_task_lib::local::cmd::run(sub.to_owned()).await,
         Some((MANAGED_CMD, sub)) => managed::cmd::run(sub).await,
         Some((CHECK_FOR_UPDATE, _)) => check_for_update::run(ONEFUZZ_BUILT_VERSION),
         _ => anyhow::bail!("No command provided. Run with 'help' to see available commands."),

--- a/src/agent/onefuzz-task/src/managed/cmd.rs
+++ b/src/agent/onefuzz-task/src/managed/cmd.rs
@@ -3,7 +3,7 @@
 use std::path::PathBuf;
 
 use anyhow::{bail, Result};
-use clap::{Arg, Command, value_parser};
+use clap::{value_parser, Arg, Command};
 use ipc_channel::ipc::{self, IpcReceiver, IpcSender};
 
 use flexi_logger::{Duplicate, FileSpec, Logger, WriteMode};

--- a/src/agent/onefuzz-task/src/managed/cmd.rs
+++ b/src/agent/onefuzz-task/src/managed/cmd.rs
@@ -2,16 +2,17 @@
 // Licensed under the MIT License.
 use std::path::PathBuf;
 
-use anyhow::Result;
-use clap::{Arg, Command};
+use anyhow::{bail, Result};
+use clap::{Arg, Command, value_parser};
 use ipc_channel::ipc::{self, IpcReceiver, IpcSender};
 
 use flexi_logger::{Duplicate, FileSpec, Logger, WriteMode};
 use onefuzz::ipc::IpcMessageKind;
+use onefuzz_telemetry::{error, info, warn};
 use std::time::Duration;
 use tokio::task;
 
-use crate::tasks::config::{CommonConfig, Config};
+use onefuzz_task_lib::tasks::config::{CommonConfig, Config};
 
 const OOM_CHECK_INTERVAL: Duration = Duration::from_secs(5);
 
@@ -56,7 +57,7 @@ pub async fn run(args: &clap::ArgMatches) -> Result<()> {
         IpcSender<IpcMessageKind>,
         IpcReceiver<IpcMessageKind>,
     ) = ipc::channel()?;
-    info!("Conecting...");
+    info!("Connecting...");
     let oneshot_sender = IpcSender::connect(config.common().from_agent_to_task_endpoint.clone())?;
     info!("Sending sender to agent");
     oneshot_sender.send(agent_sender)?;
@@ -104,7 +105,7 @@ pub async fn run(args: &clap::ArgMatches) -> Result<()> {
         // Ignore this task if it returns due to a querying error.
         Ok(oom) = check_oom => {
             // Convert the OOM notification to an error, so we can log it below.
-            let err = format_err!("out of memory: {} bytes available, {} required", oom.available_bytes, oom.min_bytes);
+            let err = anyhow::format_err!("out of memory: {} bytes available, {} required", oom.available_bytes, oom.min_bytes);
             Err(err)
         },
 


### PR DESCRIPTION
Both the bin and lib for `onefuzz-task` include the same modules, which means some code is being compiled twice, and this leads to confusing errors if you update the bin code and not the lib code (e.g. adding new modules or something similar).

Instead, make the bin code depend on the lib code.

Also remove `extern crate` and `macro_use`, which are an older way of doing things. Macros are simply imported now.