### PR TITLE
Add middleware for optional strict CLI version checking

### DIFF
--- a/src/ApiService/ApiService/ApiService.csproj
+++ b/src/ApiService/ApiService/ApiService.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="1.0.0-preview4" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />
     
-    <PackageReference Include="Semver" Version="2.1.0" />
+    <PackageReference Include="Semver" Version="2.3.0" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.3.0" />
     <PackageReference Include="Microsoft.Azure.AppConfiguration.Functions.Worker" Version="6.0.0" />
     <PackageReference Include="Microsoft.FeatureManagement" Version="2.5.1" />

--- a/src/ApiService/ApiService/OneFuzzTypes/Enums.cs
+++ b/src/ApiService/ApiService/OneFuzzTypes/Enums.cs
@@ -51,6 +51,7 @@ public enum ErrorCode {
     ADO_VALIDATION_INVALID_PATH = 495,
     ADO_VALIDATION_INVALID_PROJECT = 496,
     INVALID_RETENTION_PERIOD = 497,
+    INVALID_CLI_VERSION = 498,
     // NB: if you update this enum, also update enums.py
 }
 

--- a/src/ApiService/ApiService/Program.cs
+++ b/src/ApiService/ApiService/Program.cs
@@ -77,7 +77,7 @@ public class Program {
             _requestHandling = requestHandling;
         }
 
-        public Error? TestCliVersion(Azure.Functions.Worker.Http.HttpHeadersCollection headers) {
+        public Error? CheckCliVersion(Azure.Functions.Worker.Http.HttpHeadersCollection headers) {
             var doStrictVersionCheck =
                 headers.TryGetValues(StrictVersionHeader, out var strictVersion)
                 && strictVersion?.FirstOrDefault()?.Equals("true", StringComparison.InvariantCultureIgnoreCase) == true; // "== true" necessary here to avoid implicit null -> bool casting
@@ -107,7 +107,7 @@ public class Program {
         public async Async.Task Invoke(FunctionContext context, FunctionExecutionDelegate next) {
             var requestData = await context.GetHttpRequestDataAsync();
             if (requestData is not null) {
-                var error = TestCliVersion(requestData.Headers);
+                var error = CheckCliVersion(requestData.Headers);
                 if (error is not null) {
                     var response = await _requestHandling.NotOk(requestData, error, "version middleware");
                     context.GetInvocationResult().Value = response;

--- a/src/ApiService/ApiService/Program.cs
+++ b/src/ApiService/ApiService/Program.cs
@@ -62,6 +62,8 @@ public class Program {
     /// Represents a middleware that can optionally perform strict version checking based on data sent in request headers.
     /// </summary>
     public class VersionCheckingMiddleware : IFunctionsWorkerMiddleware {
+        private const string CliVersionHeader = "Cli-Version";
+        private const string StrictVersionHeader = "Strict-Version";
         private readonly Version _oneFuzzServiceVersion;
         private readonly IRequestHandling _requestHandling;
 
@@ -86,8 +88,8 @@ public class Program {
             var requestData = await context.GetHttpRequestDataAsync();
             if (requestData is not null) {
                 var doStrictVersionCheck =
-                    requestData.Headers.TryGetValues("Cli-Version", out var cliVersion) &&
-                    requestData.Headers.TryGetValues("Strict-Version", out var strictVersion)
+                    requestData.Headers.TryGetValues(CliVersionHeader, out var cliVersion) &&
+                    requestData.Headers.TryGetValues(StrictVersionHeader, out var strictVersion)
                     && strictVersion?.FirstOrDefault()?.Equals("true", StringComparison.InvariantCultureIgnoreCase) == true; // "== true" necessary here to avoid implicit null -> bool casting
 
                 if (doStrictVersionCheck) {

--- a/src/ApiService/ApiService/Program.cs
+++ b/src/ApiService/ApiService/Program.cs
@@ -59,27 +59,29 @@ public class Program {
     }
 
     /// <summary>
-    /// 
+    /// Represents a middleware that can optionally perform strict version checking based on data sent in request headers.
     /// </summary>
     public class VersionCheckingMiddleware : IFunctionsWorkerMiddleware {
         private readonly Version _oneFuzzServiceVersion;
         private readonly IRequestHandling _requestHandling;
 
         /// <summary>
-        /// 
+        /// Initializes an instance of <see cref="VersionCheckingMiddleware"/> with the provided config and request handling objects.
         /// </summary>
-        /// <param name="oneFuzzServiceVersion"></param>
+        /// <param name="config">The service config containing the service version.</param>
+        /// <param name="requestHandling">The request handling object to create HTTP responses with.</param>
         public VersionCheckingMiddleware(IServiceConfig config, IRequestHandling requestHandling) {
             _oneFuzzServiceVersion = Version.Parse(config.OneFuzzVersion);
             _requestHandling = requestHandling;
         }
 
         /// <summary>
-        /// 
+        /// Checks the request for two headers, cli version and one indicating whether to do strict version checking.
+        /// When both are present and the cli is out of date, a descriptive response is sent back.
         /// </summary>
-        /// <param name="context"></param>
-        /// <param name="next"></param>
-        /// <returns></returns>
+        /// <param name="context">The function context.</param>
+        /// <param name="next">The function execution delegate.</param>
+        /// <returns>A <seealso cref="Task"/> </returns>
         public async Async.Task Invoke(FunctionContext context, FunctionExecutionDelegate next) {
             var requestData = await context.GetHttpRequestDataAsync();
             if (requestData is not null) {

--- a/src/ApiService/ApiService/Program.cs
+++ b/src/ApiService/ApiService/Program.cs
@@ -77,7 +77,7 @@ public class Program {
             _requestHandling = requestHandling;
         }
 
-        public Error? CheckCliVersion(Azure.Functions.Worker.Http.HttpHeadersCollection headers) {
+        public OneFuzzResultVoid CheckCliVersion(Azure.Functions.Worker.Http.HttpHeadersCollection headers) {
             var doStrictVersionCheck =
                 headers.TryGetValues(StrictVersionHeader, out var strictVersion)
                 && strictVersion?.FirstOrDefault()?.Equals("true", StringComparison.InvariantCultureIgnoreCase) == true; // "== true" necessary here to avoid implicit null -> bool casting
@@ -94,7 +94,7 @@ public class Program {
                 }
             }
 
-            return null;
+            return OneFuzzResultVoid.Ok;
         }
 
         /// <summary>
@@ -108,8 +108,8 @@ public class Program {
             var requestData = await context.GetHttpRequestDataAsync();
             if (requestData is not null) {
                 var error = CheckCliVersion(requestData.Headers);
-                if (error is not null) {
-                    var response = await _requestHandling.NotOk(requestData, error, "version middleware");
+                if (!error.IsOk) {
+                    var response = await _requestHandling.NotOk(requestData, error.ErrorV, "version middleware");
                     context.GetInvocationResult().Value = response;
                     return;
                 }

--- a/src/ApiService/ApiService/onefuzzlib/Versions.cs
+++ b/src/ApiService/ApiService/onefuzzlib/Versions.cs
@@ -2,11 +2,11 @@
 
 namespace Microsoft.OneFuzz.Service;
 
-public class versions {
+public class Versions {
     public static bool IsMinimumVersion(string versionStr, string minimumStr) {
         var version = SemVersion.Parse(versionStr, SemVersionStyles.Any);
         var minimum = SemVersion.Parse(minimumStr, SemVersionStyles.Any);
 
-        return version >= minimum;
+        return version.ComparePrecedenceTo(minimum) >= 0;
     }
 }

--- a/src/ApiService/ApiService/packages.lock.json
+++ b/src/ApiService/ApiService/packages.lock.json
@@ -385,9 +385,9 @@
       },
       "Semver": {
         "type": "Direct",
-        "requested": "[2.1.0, )",
-        "resolved": "2.1.0",
-        "contentHash": "1jUT0PwgKO9d9F/X2n762qLp7v/30OpMtJPFRtmjPXUX2/J0lnqiGiSJNNsW3yYTj5StF0Z1yE36TrvtGpcbrg=="
+        "requested": "[2.3.0, )",
+        "resolved": "2.3.0",
+        "contentHash": "4vYo1zqn6pJ1YrhjuhuOSbIIm0CpM47grbpTJ5ABjOlfGt/EhMEM9ed4MRK5Jr6gVnntWDqOUzGeUJp68PZGjw=="
       },
       "SmartAnalyzers.CSharpExtensions.Annotations": {
         "type": "Direct",

--- a/src/ApiService/FunctionalTests/Auth.cs
+++ b/src/ApiService/FunctionalTests/Auth.cs
@@ -47,7 +47,7 @@ public class ServiceAuth : IServiceAuth, IDisposable {
             _token = await _app.AcquireTokenForClient(_authConfig.Scopes).ExecuteAsync(cancelationToken);
             return _token;
         } finally {
-            _lockObj.Release();
+            _ = _lockObj.Release();
         }
     }
 

--- a/src/ApiService/FunctionalTests/FunctionalTests.csproj
+++ b/src/ApiService/FunctionalTests/FunctionalTests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="..\ApiService\HttpClient.cs" Link="1f-api\HttpClient.cs" />
+    <ProjectReference Include="..\ApiService\ApiService.csproj" />
   </ItemGroup>
 
   <ItemGroup>
@@ -18,6 +18,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.13" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.52.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />

--- a/src/ApiService/FunctionalTests/TestContainer.cs
+++ b/src/ApiService/FunctionalTests/TestContainer.cs
@@ -19,27 +19,27 @@ namespace FunctionalTests {
         [Fact]
         public async Task DownloadNonExistentContainer() {
             var r1 = await _downloadApi.Get();
-            r1.IsOk.Should().BeFalse();
-            r1.ErrorV!.Item2!.ShouldBeProvided("container").Should().BeTrue();
+            _ = r1.IsOk.Should().BeFalse();
+            _ = r1.ErrorV!.Item2!.ShouldBeProvided("container").Should().BeTrue();
 
             var r2 = await _downloadApi.Get(container: Guid.NewGuid().ToString());
-            r2.IsOk.Should().BeFalse();
-            r2.ErrorV!.Item2!.ShouldBeProvided("filename").Should().BeTrue();
+            _ = r2.IsOk.Should().BeFalse();
+            _ = r2.ErrorV!.Item2!.ShouldBeProvided("filename").Should().BeTrue();
 
             var r3 = await _downloadApi.Get(filename: Guid.NewGuid().ToString());
-            r3.IsOk.Should().BeFalse();
-            r3.ErrorV!.Item2!.ShouldBeProvided("container").Should().BeTrue();
+            _ = r3.IsOk.Should().BeFalse();
+            _ = r3.ErrorV!.Item2!.ShouldBeProvided("container").Should().BeTrue();
 
             var r4 = await _downloadApi.Get(container: Guid.NewGuid().ToString(), filename: Guid.NewGuid().ToString());
-            r4.IsOk.Should().BeFalse();
-            r4.ErrorV!.Item1.Should().Be(System.Net.HttpStatusCode.NotFound);
+            _ = r4.IsOk.Should().BeFalse();
+            _ = r4.ErrorV!.Item1.Should().Be(System.Net.HttpStatusCode.NotFound);
         }
 
         [Fact]
         public async Task CreateGetDeleteContainer() {
             var containerName = Guid.NewGuid().ToString();
             var container = await _containerApi.Post(containerName);
-            container.IsOk.Should().BeTrue($"failed to create container due to {container.ErrorV}");
+            _ = container.IsOk.Should().BeTrue($"failed to create container due to {container.ErrorV}");
 
             var c = await _containerApi.Get(containerName);
 

--- a/src/ApiService/FunctionalTests/TestInfo.cs
+++ b/src/ApiService/FunctionalTests/TestInfo.cs
@@ -16,8 +16,8 @@ namespace FunctionalTests {
         [Fact]
         async Task GetInfo() {
             var info = await _infoApi.Get();
-            info.IsOk.Should().BeTrue();
-            info.OkV!.Versions.ContainsKey("onefuzz").Should().BeTrue();
+            _ = info.IsOk.Should().BeTrue();
+            _ = info.OkV!.Versions.ContainsKey("onefuzz").Should().BeTrue();
         }
     }
 }

--- a/src/ApiService/FunctionalTests/TestNode.cs
+++ b/src/ApiService/FunctionalTests/TestNode.cs
@@ -24,14 +24,14 @@ namespace FunctionalTests {
         async Task GetNonExistentNode() {
             var n = await _nodeApi.Get(Guid.NewGuid());
 
-            n.IsOk.Should().BeFalse();
-            n.ErrorV!.UnableToFindNode.Should().BeTrue();
+            _ = n.IsOk.Should().BeFalse();
+            _ = n.ErrorV!.UnableToFindNode.Should().BeTrue();
         }
 
         [Fact]
         async Task GetAllNodes() {
             var ns = await _nodeApi.Get();
-            ns.IsOk.Should().BeTrue("failed to get all nodes due to {0}", ns.ErrorV);
+            _ = ns.IsOk.Should().BeTrue("failed to get all nodes due to {0}", ns.ErrorV);
             foreach (var n in ns.OkV!) {
                 _output.WriteLine($"node machine id: {n.MachineId}, scaleset id: {n.ScalesetId}, poolName: {n.PoolName}, poolId: {n.PoolId} state: {n.State}, version: {n.Version}");
             }
@@ -41,8 +41,8 @@ namespace FunctionalTests {
         [Fact]
         async Task DeleteNonExistentNode() {
             var n = await _nodeApi.Delete(Guid.NewGuid());
-            n.IsError.Should().BeTrue();
-            n.Error!.UnableToFindNode.Should().BeTrue();
+            _ = n.IsError.Should().BeTrue();
+            _ = n.Error!.UnableToFindNode.Should().BeTrue();
         }
 
         [Fact]
@@ -51,25 +51,25 @@ namespace FunctionalTests {
             var (pool, scaleset) = await Helpers.CreatePoolAndScaleset(_poolApi, _scalesetApi, "linux");
 
             scaleset = await _scalesetApi.WaitWhile(scaleset.ScalesetId, sc => sc.State == "init" || sc.State == "setup");
-            scaleset.Nodes!.Should().NotBeEmpty();
+            _ = scaleset.Nodes!.Should().NotBeEmpty();
 
             var nodeState = scaleset.Nodes!.First();
             var nodeResult = await _nodeApi.Get(nodeState.MachineId);
 
-            nodeResult.IsOk.Should().BeTrue("failed to get node due to {0}", nodeResult.ErrorV);
+            _ = nodeResult.IsOk.Should().BeTrue("failed to get node due to {0}", nodeResult.ErrorV);
             var node = nodeResult.OkV!.First();
             node = await _nodeApi.WaitWhile(node.MachineId, n => n.State == "init" || n.State == "setup");
 
             var r = await _nodeApi.Patch(node.MachineId);
-            r.Result.Should().BeTrue();
+            _ = r.Result.Should().BeTrue();
 
             var rr = await _nodeApi.Update(node.MachineId, false);
 
             var d = await _nodeApi.Delete(node.MachineId);
-            d.Result.Should().BeTrue();
+            _ = d.Result.Should().BeTrue();
 
             var deletePool = await _poolApi.Delete(pool.Name);
-            deletePool.Result.Should().BeTrue();
+            _ = deletePool.Result.Should().BeTrue();
         }
     }
 }

--- a/src/ApiService/FunctionalTests/TestPool.cs
+++ b/src/ApiService/FunctionalTests/TestPool.cs
@@ -21,7 +21,7 @@ namespace FunctionalTests {
         [Fact]
         public async Task GetNonExistentPool() {
             var p = await _poolApi.Get(name: Guid.NewGuid().ToString());
-            p.ErrorV!.UnableToFindPoolError.Should().BeTrue("{0}", p.ErrorV!);
+            _ = p.ErrorV!.UnableToFindPoolError.Should().BeTrue("{0}", p.ErrorV!);
         }
 
 
@@ -34,7 +34,7 @@ namespace FunctionalTests {
         [Fact]
         public async Task GetPools() {
             var pools = await _poolApi.Get();
-            pools.IsOk.Should().BeTrue();
+            _ = pools.IsOk.Should().BeTrue();
 
             if (!pools.OkV!.Any()) {
                 _output.WriteLine("Got empty pools");
@@ -54,16 +54,16 @@ namespace FunctionalTests {
             _output.WriteLine($"creating pool {newPoolName}");
             var newPool = await _poolApi.Create(newPoolName, "linux");
 
-            newPool.IsOk.Should().BeTrue("failed to create new pool: {0}", newPool.ErrorV);
+            _ = newPool.IsOk.Should().BeTrue("failed to create new pool: {0}", newPool.ErrorV);
 
             var poolsCreated = await _poolApi.Get();
-            poolsCreated.IsOk.Should().BeTrue("failed to get pools: {0}", poolsCreated.ErrorV);
+            _ = poolsCreated.IsOk.Should().BeTrue("failed to get pools: {0}", poolsCreated.ErrorV);
 
             var newPools = poolsCreated.OkV!.Where(p => p.Name == newPoolName);
-            newPools.Count().Should().Be(1);
+            _ = newPools.Count().Should().Be(1);
 
             var deletedPoolResult = await _poolApi.Delete(newPoolName);
-            deletedPoolResult.Result.Should().BeTrue();
+            _ = deletedPoolResult.Result.Should().BeTrue();
         }
     }
 }

--- a/src/ApiService/FunctionalTests/TestProxy.cs
+++ b/src/ApiService/FunctionalTests/TestProxy.cs
@@ -26,7 +26,7 @@ namespace FunctionalTests {
         public async Task GetProxies() {
             var allProxiesResult = await _proxyApi.Get();
 
-            allProxiesResult.IsOk.Should().BeTrue("failed to get proxies due to {0}", allProxiesResult.ErrorV);
+            _ = allProxiesResult.IsOk.Should().BeTrue("failed to get proxies due to {0}", allProxiesResult.ErrorV);
 
             if (!allProxiesResult.OkV!.Any()) {
                 _output.WriteLine("Got empty list of proxies");
@@ -42,12 +42,12 @@ namespace FunctionalTests {
             var (newPool, newScaleset) = await Helpers.CreatePoolAndScaleset(_poolApi, _scalesetApi, "linux");
 
             newScaleset = await _scalesetApi.WaitWhile(newScaleset.ScalesetId, sc => sc.State == "init" || sc.State == "setup");
-            newScaleset.Nodes!.Should().NotBeEmpty();
+            _ = newScaleset.Nodes!.Should().NotBeEmpty();
 
             var firstNode = newScaleset.Nodes!.First();
 
             var nodeResult = await _nodeApi.Get(machineId: firstNode.MachineId);
-            nodeResult.IsOk.Should().BeTrue();
+            _ = nodeResult.IsOk.Should().BeTrue();
             var node = nodeResult.OkV!.First();
 
             node = await _nodeApi.WaitWhile(node.MachineId, n => n.State == "init" || n.State == "setup");
@@ -56,23 +56,23 @@ namespace FunctionalTests {
 
             var proxyAgain = await _proxyApi.Create(newScaleset.ScalesetId, node.MachineId, 2223, 1);
 
-            proxy.IsOk.Should().BeTrue("failed to create proxy due to {0}", proxy.ErrorV);
-            proxyAgain.IsOk.Should().BeTrue("failed to create proxy with same config due to {0}", proxyAgain.ErrorV);
+            _ = proxy.IsOk.Should().BeTrue("failed to create proxy due to {0}", proxy.ErrorV);
+            _ = proxyAgain.IsOk.Should().BeTrue("failed to create proxy with same config due to {0}", proxyAgain.ErrorV);
 
-            proxy.OkV!.Should().BeEquivalentTo(proxyAgain.OkV!);
+            _ = proxy.OkV!.Should().BeEquivalentTo(proxyAgain.OkV!);
             _output.WriteLine($"created proxy dst ip: {proxy.OkV!.Forward.DstIp}, srcPort: {proxy.OkV.Forward.SrcPort} dstport: {proxy.OkV!.Forward.DstPort}, ip: {proxy.OkV!.Ip}");
 
 
             var proxyReset = await _proxyApi.Reset(newScaleset.Region);
-            proxyReset.Result.Should().BeTrue();
+            _ = proxyReset.Result.Should().BeTrue();
 
             var deleteProxy = await _proxyApi.Delete(newScaleset.ScalesetId, node.MachineId);
-            deleteProxy.Result.Should().BeTrue();
+            _ = deleteProxy.Result.Should().BeTrue();
 
             _output.WriteLine($"deleted proxy");
 
             var deletePool = await _poolApi.Delete(newPool.Name);
-            deletePool.Result.Should().BeTrue();
+            _ = deletePool.Result.Should().BeTrue();
             _output.WriteLine($"deleted pool {newPool.Name}");
         }
     }

--- a/src/ApiService/FunctionalTests/TestScaleset.cs
+++ b/src/ApiService/FunctionalTests/TestScaleset.cs
@@ -21,7 +21,7 @@ namespace FunctionalTests {
         [Fact]
         public async Task GetScalesets() {
             var scalesets = await _scalesetApi.Get();
-            scalesets.IsOk.Should().BeTrue("failed to get scalesets due to {0}", scalesets.ErrorV);
+            _ = scalesets.IsOk.Should().BeTrue("failed to get scalesets due to {0}", scalesets.ErrorV);
             if (!scalesets.OkV!.Any()) {
                 _output.WriteLine("Got empty scalesets");
             } else {
@@ -44,16 +44,16 @@ namespace FunctionalTests {
                 _output.WriteLine($"New scale set info id: {newScaleset.ScalesetId}, pool: {newScaleset.PoolName}, state: {newScaleset.State}, error: {newScaleset.Error}");
 
                 var scalesetsCreated = await _scalesetApi.Get();
-                scalesetsCreated.IsOk.Should().BeTrue("failed to get scalesets: {0}", scalesetsCreated.ErrorV);
+                _ = scalesetsCreated.IsOk.Should().BeTrue("failed to get scalesets: {0}", scalesetsCreated.ErrorV);
 
                 var poolsCreated = await _poolApi.Get();
-                poolsCreated.IsOk.Should().BeTrue("failed to get pools: {0}", poolsCreated.ErrorV);
+                _ = poolsCreated.IsOk.Should().BeTrue("failed to get pools: {0}", poolsCreated.ErrorV);
 
                 var newPools = poolsCreated.OkV!.Where(p => p.Name == newPool.Name);
                 var newScalesets = scalesetsCreated.OkV!.Where(sc => sc.ScalesetId == newScaleset.ScalesetId);
 
-                newPools.Count().Should().Be(1);
-                newScalesets.Count().Should().Be(1);
+                _ = newPools.Count().Should().Be(1);
+                _ = newScalesets.Count().Should().Be(1);
 
                 Console.WriteLine($"Waiting for scaleset to move out from Init State");
                 newScaleset = await _scalesetApi.WaitWhile(newScaleset.ScalesetId, sc => sc.State == "init" || sc.State == "setup");
@@ -67,8 +67,8 @@ namespace FunctionalTests {
                 }
 
                 var patch0 = await _scalesetApi.Patch(newScaleset.ScalesetId, 0);
-                patch0.IsOk.Should().BeFalse();
-                patch0.ErrorV!.IsWrongSizeError.Should().BeTrue();
+                _ = patch0.IsOk.Should().BeFalse();
+                _ = patch0.ErrorV!.IsWrongSizeError.Should().BeTrue();
                 // https://github.com/microsoft/onefuzz/issues/2311
                 //var patch1 = await _scalesetApi.Patch(newScaleset.ScalesetId, 1);
                 //Assert.True(patch1.IsOk, $"scaleset patch failed due to: {patch1}");
@@ -89,9 +89,9 @@ namespace FunctionalTests {
                 var preDeleteScalesets = await _scalesetApi.Get();
                 var deletedPoolResult = await _poolApi.Delete(newPool.Name);
 
-                preDeleteScalesets.IsOk.Should().BeTrue("failed to get pre-deleted scalesets due to: {0}", preDeleteScalesets.ErrorV);
+                _ = preDeleteScalesets.IsOk.Should().BeTrue("failed to get pre-deleted scalesets due to: {0}", preDeleteScalesets.ErrorV);
                 var preDelete = preDeleteScalesets.OkV!.Where(sc => sc.PoolName == newPool.Name);
-                preDelete.Count().Should().Be(3);
+                _ = preDelete.Count().Should().Be(3);
 
                 Result<IEnumerable<Pool>, Error> deletedPool;
                 do {
@@ -100,17 +100,17 @@ namespace FunctionalTests {
 
                 } while (deletedPool.IsOk);
 
-                deletedPool.ErrorV!.UnableToFindPoolError.Should().BeTrue();
+                _ = deletedPool.ErrorV!.UnableToFindPoolError.Should().BeTrue();
                 var postDeleteScalesets = await _scalesetApi.Get();
-                postDeleteScalesets.IsOk.Should().BeTrue("failed to get scalesets after finishing pool deletion due to {0}", postDeleteScalesets.ErrorV);
+                _ = postDeleteScalesets.IsOk.Should().BeTrue("failed to get scalesets after finishing pool deletion due to {0}", postDeleteScalesets.ErrorV);
 
                 _output.WriteLine($"Pool is deleted {newPool.Name}");
 
                 var postDelete = postDeleteScalesets.OkV!.Where(sc => sc.PoolName == newPool.Name);
-                postDelete.Should().BeEmpty();
+                _ = postDelete.Should().BeEmpty();
                 var patch1 = await _scalesetApi.Patch(newScaleset.ScalesetId, 1);
-                patch1.IsOk.Should().BeFalse();
-                patch1.ErrorV!.UnableToFindScalesetError.Should().BeTrue();
+                _ = patch1.IsOk.Should().BeFalse();
+                _ = patch1.ErrorV!.UnableToFindScalesetError.Should().BeTrue();
             }
             return;
 

--- a/src/ApiService/FunctionalTests/TestTasks.cs
+++ b/src/ApiService/FunctionalTests/TestTasks.cs
@@ -18,13 +18,13 @@ namespace FunctionalTests {
         [Fact]
         public async Task GetNonExistentTask() {
             var t1 = await _taskApi.Get(Guid.NewGuid());
-            t1.IsOk.Should().BeTrue();
-            t1.OkV.Should().BeEmpty();
+            _ = t1.IsOk.Should().BeTrue();
+            _ = t1.OkV.Should().BeEmpty();
 
 
             var t2 = await _taskApi.Get(Guid.NewGuid(), Guid.NewGuid());
-            t2.IsOk.Should().BeFalse();
-            t2.ErrorV!.UnableToFindTask.Should().BeTrue();
+            _ = t2.IsOk.Should().BeFalse();
+            _ = t2.ErrorV!.UnableToFindTask.Should().BeTrue();
         }
 
 

--- a/src/ApiService/FunctionalTests/TestVersionCheckMiddleware.cs
+++ b/src/ApiService/FunctionalTests/TestVersionCheckMiddleware.cs
@@ -150,6 +150,7 @@ public class TestVersionCheckMiddleware {
 
     [Theory]
     [InlineData("0.9.1", ErrorCode.INVALID_CLI_VERSION, "cli is out of date")]
+    [InlineData("1.0.0-pre.release", ErrorCode.INVALID_CLI_VERSION, "cli is out of date")]
     [InlineData("Bad Format", ErrorCode.INVALID_CLI_VERSION, "not a valid sematic version")]
     public void VersionCheck_InvalidVersion_ReturnsInvalidRequest(string cliVersion, ErrorCode expectedCode, string expectedMessage) {
         var middleware = GetMiddleware();

--- a/src/ApiService/FunctionalTests/TestVersionCheckMiddleware.cs
+++ b/src/ApiService/FunctionalTests/TestVersionCheckMiddleware.cs
@@ -79,7 +79,7 @@ public class TestVersionCheckMiddleware {
         var middleware = GetMiddleware();
         var headers = GetHeaders();
 
-        var result = middleware.TestCliVersion(headers);
+        var result = middleware.CheckCliVersion(headers);
 
         Assert.Null(result);
     }
@@ -92,7 +92,7 @@ public class TestVersionCheckMiddleware {
         var middleware = GetMiddleware();
         var headers = GetHeaders(cliVersion);
 
-        var result = middleware.TestCliVersion(headers);
+        var result = middleware.CheckCliVersion(headers);
 
         Assert.Null(result);
     }
@@ -102,7 +102,7 @@ public class TestVersionCheckMiddleware {
         var middleware = GetMiddleware();
         var headers = GetHeaders(null, "True");
 
-        var result = middleware.TestCliVersion(headers);
+        var result = middleware.CheckCliVersion(headers);
 
         Assert.NotNull(result);
         Assert.Equal(ErrorCode.INVALID_REQUEST, result.Code);
@@ -116,7 +116,7 @@ public class TestVersionCheckMiddleware {
         var middleware = GetMiddleware();
         var headers = GetHeaders(null, strictVersion);
 
-        var result = middleware.TestCliVersion(headers);
+        var result = middleware.CheckCliVersion(headers);
 
         Assert.Null(result);
     }
@@ -129,7 +129,7 @@ public class TestVersionCheckMiddleware {
         var middleware = GetMiddleware();
         var headers = GetHeaders(cliVersion, strictVersion);
 
-        var result = middleware.TestCliVersion(headers);
+        var result = middleware.CheckCliVersion(headers);
 
         Assert.Null(result);
     }
@@ -139,7 +139,7 @@ public class TestVersionCheckMiddleware {
         var middleware = GetMiddleware();
         var headers = GetHeaders("1.0.0", "True");
 
-        var result = middleware.TestCliVersion(headers);
+        var result = middleware.CheckCliVersion(headers);
 
         Assert.Null(result);
     }
@@ -151,7 +151,7 @@ public class TestVersionCheckMiddleware {
         var middleware = GetMiddleware();
         var headers = GetHeaders(cliVersion, "True");
 
-        var result = middleware.TestCliVersion(headers);
+        var result = middleware.CheckCliVersion(headers);
 
         Assert.NotNull(result);
         Assert.Equal(expectedCode, result.Code);

--- a/src/ApiService/FunctionalTests/TestVersionCheckMiddleware.cs
+++ b/src/ApiService/FunctionalTests/TestVersionCheckMiddleware.cs
@@ -1,0 +1,40 @@
+using Xunit;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.OneFuzz.Service;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace FunctionalTests;
+
+[Trait("Category", "Live")]
+public class TestVersionCheckMiddleware {
+    private sealed class MockServiceConfiguration : ServiceConfiguration {
+        public new string OneFuzzVersion { get; } = "1.0.0";
+    }
+    private static Program.VersionCheckingMiddleware GetMiddleware() {
+        return new Program.VersionCheckingMiddleware(
+            new MockServiceConfiguration(),
+            new RequestHandling(NullLogger.Instance)
+        );
+    }
+
+    private static HttpHeadersCollection GetHeaders(string? cliVersion = null, string? strictVersionCheck = null) {
+        var headers = new HttpHeadersCollection();
+        if (cliVersion != null) {
+            headers.Add("cli-version", cliVersion);
+        }
+        if (strictVersionCheck != null) {
+            headers.Add("strict-version", strictVersionCheck);
+        }
+        return headers;
+    }
+
+    [Fact]
+    public void VersionCheck_NoHeaders_ReturnsNull() {
+        var middleware = GetMiddleware();
+        var headers = GetHeaders();
+
+        var result = middleware.TestCliVersion(headers);
+
+        Assert.Null(result);
+    }
+}

--- a/src/ApiService/FunctionalTests/TestVersionCheckMiddleware.cs
+++ b/src/ApiService/FunctionalTests/TestVersionCheckMiddleware.cs
@@ -1,9 +1,9 @@
-using Xunit;
-using Microsoft.Azure.Functions.Worker.Http;
-using Microsoft.OneFuzz.Service;
-using Microsoft.Extensions.Logging.Abstractions;
+﻿using Azure.Core;
 using Microsoft.ApplicationInsights.DataContracts;
-using Azure.Core;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.OneFuzz.Service;
+using Xunit;
 
 namespace FunctionalTests;
 

--- a/src/ApiService/FunctionalTests/TestVersionCheckMiddleware.cs
+++ b/src/ApiService/FunctionalTests/TestVersionCheckMiddleware.cs
@@ -81,7 +81,7 @@ public class TestVersionCheckMiddleware {
 
         var result = middleware.CheckCliVersion(headers);
 
-        Assert.Null(result);
+        Assert.True(result.IsOk);
     }
 
     [Theory]
@@ -94,7 +94,7 @@ public class TestVersionCheckMiddleware {
 
         var result = middleware.CheckCliVersion(headers);
 
-        Assert.Null(result);
+        Assert.True(result.IsOk);
     }
 
     [Fact]
@@ -104,9 +104,9 @@ public class TestVersionCheckMiddleware {
 
         var result = middleware.CheckCliVersion(headers);
 
-        Assert.NotNull(result);
-        Assert.Equal(ErrorCode.INVALID_REQUEST, result.Code);
-        Assert.Contains("is set to true without a corresponding", result.Errors?.First());
+        Assert.False(result.IsOk);
+        Assert.Equal(ErrorCode.INVALID_REQUEST, result.ErrorV.Code);
+        Assert.Contains("is set to true without a corresponding", result.ErrorV.Errors?.First());
     }
 
     [Theory]
@@ -118,7 +118,7 @@ public class TestVersionCheckMiddleware {
 
         var result = middleware.CheckCliVersion(headers);
 
-        Assert.Null(result);
+        Assert.True(result.IsOk);
     }
 
     [Theory]
@@ -131,7 +131,7 @@ public class TestVersionCheckMiddleware {
 
         var result = middleware.CheckCliVersion(headers);
 
-        Assert.Null(result);
+        Assert.True(result.IsOk);
     }
 
     [Fact]
@@ -141,7 +141,7 @@ public class TestVersionCheckMiddleware {
 
         var result = middleware.CheckCliVersion(headers);
 
-        Assert.Null(result);
+        Assert.True(result.IsOk);
     }
 
     [Theory]
@@ -153,8 +153,8 @@ public class TestVersionCheckMiddleware {
 
         var result = middleware.CheckCliVersion(headers);
 
-        Assert.NotNull(result);
-        Assert.Equal(expectedCode, result.Code);
-        Assert.Contains(expectedMessage, result.Errors?.First());
+        Assert.False(result.IsOk);
+        Assert.Equal(expectedCode, result.ErrorV.Code);
+        Assert.Contains(expectedMessage, result.ErrorV.Errors?.First());
     }
 }

--- a/src/ApiService/FunctionalTests/packages.lock.json
+++ b/src/ApiService/FunctionalTests/packages.lock.json
@@ -1399,8 +1399,8 @@
       },
       "Semver": {
         "type": "Transitive",
-        "resolved": "2.1.0",
-        "contentHash": "1jUT0PwgKO9d9F/X2n762qLp7v/30OpMtJPFRtmjPXUX2/J0lnqiGiSJNNsW3yYTj5StF0Z1yE36TrvtGpcbrg=="
+        "resolved": "2.3.0",
+        "contentHash": "4vYo1zqn6pJ1YrhjuhuOSbIIm0CpM47grbpTJ5ABjOlfGt/EhMEM9ed4MRK5Jr6gVnntWDqOUzGeUJp68PZGjw=="
       },
       "SmartAnalyzers.CSharpExtensions.Annotations": {
         "type": "Transitive",
@@ -2412,7 +2412,7 @@
           "Polly": "[8.0.0-alpha.2, )",
           "Polly.Extensions.Http": "[3.0.0, )",
           "Scriban": "[5.5.0, )",
-          "Semver": "[2.1.0, )",
+          "Semver": "[2.3.0, )",
           "SmartAnalyzers.CSharpExtensions.Annotations": "[4.2.7, )",
           "System.Diagnostics.DiagnosticSource": "[8.0.0-preview.4.23259.5, )",
           "System.IdentityModel.Tokens.Jwt": "[6.29.0, )",

--- a/src/ApiService/FunctionalTests/packages.lock.json
+++ b/src/ApiService/FunctionalTests/packages.lock.json
@@ -23,6 +23,15 @@
         "resolved": "0.21.0",
         "contentHash": "5CprzHStF627DqPytBnjRMXT2dvmXrP4XwVK4+jRllU5JH8SC6tytyyuOOd06tzjDPHU8YbDZ7/JtgJSiMb8RA=="
       },
+      "Microsoft.Azure.Functions.Worker.Extensions.Http": {
+        "type": "Direct",
+        "requested": "[3.0.13, )",
+        "resolved": "3.0.13",
+        "contentHash": "GX41psGbjLSPKuFnBcGGB7PAAdhfLsgxvGVsyGq/jQwgGwjAVRRx2UbSl35+imKwCPZdT5vGjq6YV1rgXIeEvA==",
+        "dependencies": {
+          "Microsoft.Azure.Functions.Worker.Extensions.Abstractions": "1.0.0"
+        }
+      },
       "Microsoft.Identity.Client": {
         "type": "Direct",
         "requested": "[4.52.0, )",
@@ -111,25 +120,983 @@
         "resolved": "2.5.0",
         "contentHash": "+Gp9vuC2431yPyKB15YrOTxCuEAErBQUTIs6CquumX1F073UaPHGW0VE/XVJLMh9W4sXdz3TBkcHdFWZrRn2Hw=="
       },
+      "Azure.Core": {
+        "type": "Transitive",
+        "resolved": "1.32.0",
+        "contentHash": "NmnJxaNqKjPwnHXngVg63SrkwbJXrkT0mcK8uCx9rSq0nK6Q3Q+/GZRCaTWcdcECoRP5XK0lr3Ce8PZkHkuHNg==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "1.1.1",
+          "System.Diagnostics.DiagnosticSource": "4.6.0",
+          "System.Memory.Data": "1.0.2",
+          "System.Numerics.Vectors": "4.5.0",
+          "System.Text.Encodings.Web": "4.7.2",
+          "System.Text.Json": "4.7.2",
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        }
+      },
+      "Azure.Data.AppConfiguration": {
+        "type": "Transitive",
+        "resolved": "1.2.0",
+        "contentHash": "KA1dAM9TuDsq0CRFd+3cJTYUAzA2z9N8t9/xKdDbP9URuReq/NDFcKYr7GW2W9xzVGDtCHlD5j5am/+zLLBdSg==",
+        "dependencies": {
+          "Azure.Core": "1.20.0",
+          "Microsoft.Bcl.AsyncInterfaces": "1.0.0",
+          "System.Text.Json": "4.6.0"
+        }
+      },
+      "Azure.Data.Tables": {
+        "type": "Transitive",
+        "resolved": "12.8.0",
+        "contentHash": "jBNOUXoANEv66mIyR+rzC7toogo48pYciH4n5xsb8nHRz6lfjX9jwsOjC8sdR1Zl75Z6MZvaZjajqVwCt3JqVw==",
+        "dependencies": {
+          "Azure.Core": "1.27.0",
+          "System.Text.Json": "4.7.2"
+        }
+      },
+      "Azure.Identity": {
+        "type": "Transitive",
+        "resolved": "1.8.2",
+        "contentHash": "ywnpn9MLhNTtBG12WOxSaomx0Dwu5HK5PyhHH/CApGrd1BCrhgEwdy4Uwy5IfAznJzVJKZRyKR9cp4aa61xYvA==",
+        "dependencies": {
+          "Azure.Core": "1.25.0",
+          "Microsoft.Identity.Client": "4.49.1",
+          "Microsoft.Identity.Client.Extensions.Msal": "2.25.3",
+          "System.Memory": "4.5.4",
+          "System.Security.Cryptography.ProtectedData": "4.7.0",
+          "System.Text.Json": "4.7.2",
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        }
+      },
+      "Azure.Messaging.EventGrid": {
+        "type": "Transitive",
+        "resolved": "4.15.0",
+        "contentHash": "ydVq99LruKcWiH+BJK82sfnBPZH82BM1qr49WNUXRb4nB/jlNBnam8Ay3z010bC5v1nDdLDDW+GsVTuE6SnEmQ==",
+        "dependencies": {
+          "Azure.Core": "1.31.0",
+          "System.Memory.Data": "1.0.2",
+          "System.Text.Json": "4.7.2"
+        }
+      },
+      "Azure.ResourceManager": {
+        "type": "Transitive",
+        "resolved": "1.6.0",
+        "contentHash": "pd7DRK7UpsQagSwgkXiWl6k5v3aXTcEwLvyjAtozd/pr86bsmaWEtcA2aa+kt82wMH2L8nw1ByfRIY0hQQSIVg==",
+        "dependencies": {
+          "Azure.Core": "1.32.0",
+          "System.Text.Json": "4.7.2"
+        }
+      },
+      "Azure.ResourceManager.Compute": {
+        "type": "Transitive",
+        "resolved": "1.0.0-beta.8",
+        "contentHash": "rYYjjmEdmcOa8O4UgO/bdJ/qQclNZjuHdalxRJ0AhUHCORcM1f1BbIKR9CoN83IpfuEE+X+n5XY9QZcKvfrGVA==",
+        "dependencies": {
+          "Azure.Core": "1.24.0",
+          "Azure.ResourceManager": "1.0.0",
+          "System.Text.Json": "4.7.2"
+        }
+      },
+      "Azure.ResourceManager.Monitor": {
+        "type": "Transitive",
+        "resolved": "1.0.0-beta.2",
+        "contentHash": "yPaVtBPI3OTxAXQ+I+lxMPalrJ/YsM6rlunqFA9NIYBzRQkVFZvn013RkHY5SZUD7icKXTbanP6Nefc8vosqMg==",
+        "dependencies": {
+          "Azure.Core": "1.24.0",
+          "Azure.ResourceManager": "1.0.0",
+          "System.Text.Json": "4.7.2"
+        }
+      },
+      "Azure.ResourceManager.Network": {
+        "type": "Transitive",
+        "resolved": "1.0.0",
+        "contentHash": "BhN2ULPSgi7vPmllXycYbGUBF/r9fI4zklGbuCBWPCNm2hJrFRQOwUy1NYy2UmLBRHtcAK7zp376n+lylsyjAg==",
+        "dependencies": {
+          "Azure.Core": "1.25.0",
+          "Azure.ResourceManager": "1.2.0",
+          "System.Text.Json": "4.7.2"
+        }
+      },
+      "Azure.ResourceManager.Resources": {
+        "type": "Transitive",
+        "resolved": "1.6.0",
+        "contentHash": "QC1DAa8X1pQTJRC5clCWX+mfV0DJDE4hPTrgnGmBniLxLDOv9Bd143ydUliiBEYDp5u3QsQNth3O0VXIMG/b8A==",
+        "dependencies": {
+          "Azure.Core": "1.32.0",
+          "Azure.ResourceManager": "1.6.0",
+          "System.Text.Json": "4.7.2"
+        }
+      },
+      "Azure.ResourceManager.Storage": {
+        "type": "Transitive",
+        "resolved": "1.0.0-beta.11",
+        "contentHash": "w7hOgG4yUFTRrJ65FzHeIQH8wFPczSJG12SnFiA9HrcvoceD/8CflIk5aPHzqc6moB3A1od0lwGciluovsHMbg==",
+        "dependencies": {
+          "Azure.Core": "1.25.0",
+          "Azure.ResourceManager": "1.2.0",
+          "System.Text.Json": "4.7.2"
+        }
+      },
+      "Azure.Security.KeyVault.Secrets": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "GRnmQzTXDVABry1rC8PwuVOHSDCUGn4Om1ABTCzWfHdDSOwRydtQ13ucJ1Z0YtdajklNwxEL6lhHGhFCI0diAw==",
+        "dependencies": {
+          "Azure.Core": "1.23.0",
+          "System.Memory": "4.5.4",
+          "System.Text.Json": "4.7.2",
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        }
+      },
+      "Azure.Storage.Blobs": {
+        "type": "Transitive",
+        "resolved": "12.13.0",
+        "contentHash": "h5ZxRwmS/U1NOFwd+MuHJe4To1hEPu/yeBIKS1cbAHTDc+7RBZEjPf1VFeUZsIIuHvU/AzXtcRaph9BHuPRNMQ==",
+        "dependencies": {
+          "Azure.Storage.Common": "12.12.0",
+          "System.Text.Json": "4.7.2"
+        }
+      },
+      "Azure.Storage.Common": {
+        "type": "Transitive",
+        "resolved": "12.12.0",
+        "contentHash": "Ms0XsZ/D9Pcudfbqj+rWeCkhx/ITEq8isY0jkor9JFmDAEHsItFa2XrWkzP3vmJU6EsXQrk4snH63HkW/Jksvg==",
+        "dependencies": {
+          "Azure.Core": "1.25.0",
+          "System.IO.Hashing": "6.0.0"
+        }
+      },
+      "Azure.Storage.Queues": {
+        "type": "Transitive",
+        "resolved": "12.11.0",
+        "contentHash": "qpe1Gs1/2t18FoZORF3TgPTaF31RJhN5DQFgZ6ay6qKak9IztaqwKG8Lv2eZ/yhRKJNrOVnaZF4iqf7a4N57BA==",
+        "dependencies": {
+          "Azure.Storage.Common": "12.12.0",
+          "System.Memory.Data": "1.0.2",
+          "System.Text.Json": "4.7.2"
+        }
+      },
+      "Faithlife.Utility": {
+        "type": "Transitive",
+        "resolved": "0.12.2",
+        "contentHash": "JgMAGj8ekeAzKkagubXqf1UqgfHq89GyA1UQYWbkAe441uRr2Rh2rktkx5Z0LPwmD/aOqu9cxjekD2GZjP8rbw=="
+      },
+      "Google.Protobuf": {
+        "type": "Transitive",
+        "resolved": "3.23.3",
+        "contentHash": "CH/9X2w7zTYyZjGCMDlfi3ZaB1HZ3BM35XUm4WADcNWQuT5QttjE2BQ+ydSROaZ1JEJ5p7gh1LKIbf9hoWrFNA=="
+      },
+      "Grpc.Core.Api": {
+        "type": "Transitive",
+        "resolved": "2.55.0",
+        "contentHash": "qtJauqAZ4jAM6A2TQyenhpZWPfJBow7/HV/KiRbxJvYHo9jVtUL7SBIs3cjvBh5DXIUaNFIFfBQ3QGyv3nLKCw==",
+        "dependencies": {
+          "System.Memory": "4.5.3"
+        }
+      },
+      "Grpc.Net.Client": {
+        "type": "Transitive",
+        "resolved": "2.55.0",
+        "contentHash": "cQyNEAIVs/5npjSHuCKCT5kQJm3AyOnUw7h7s2lXt9rSWC/bhCGPbNAtiFGNvKiQAYgIt4zV13BS983viZP9pg==",
+        "dependencies": {
+          "Grpc.Net.Common": "2.55.0",
+          "Microsoft.Extensions.Logging.Abstractions": "3.0.3"
+        }
+      },
+      "Grpc.Net.ClientFactory": {
+        "type": "Transitive",
+        "resolved": "2.55.0",
+        "contentHash": "D8yiJjFxK2mwy0LqNlT8BhZ2nyKWds+Vh44tL2Ilub8evL/98Zt2m5D/xqteO87Ml8S4vyjXrWgSVEyH00mPSw==",
+        "dependencies": {
+          "Grpc.Net.Client": "2.55.0",
+          "Microsoft.Extensions.Http": "3.0.3"
+        }
+      },
+      "Grpc.Net.Common": {
+        "type": "Transitive",
+        "resolved": "2.55.0",
+        "contentHash": "s1tzY9Z3jKq+mcYGSkZSTTs8Gwi9M5zfXltSDIx7XvFIdSbh+QtfWiV/4n+vP8yDvFDQASaW+6BzkGUbHEftRA==",
+        "dependencies": {
+          "Grpc.Core.Api": "2.55.0"
+        }
+      },
+      "Microsoft.ApplicationInsights": {
+        "type": "Transitive",
+        "resolved": "2.21.0",
+        "contentHash": "btZEDWAFNo9CoYliMCriSMTX3ruRGZTtYw4mo2XyyfLlowFicYVM2Xszi5evDG95QRYV7MbbH3D2RqVwfZlJHw==",
+        "dependencies": {
+          "System.Diagnostics.DiagnosticSource": "5.0.0"
+        }
+      },
+      "Microsoft.ApplicationInsights.DependencyCollector": {
+        "type": "Transitive",
+        "resolved": "2.21.0",
+        "contentHash": "XArm5tBEUdWs05eDKxnsUUQBduJ45DEQOMnpL7wNWxBpgxn+dbl8nObA2jzExbQhbw6P74lc/1f+RdV4iPaOgg==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.21.0",
+          "System.Diagnostics.DiagnosticSource": "5.0.0"
+        }
+      },
+      "Microsoft.ApplicationInsights.EventCounterCollector": {
+        "type": "Transitive",
+        "resolved": "2.21.0",
+        "contentHash": "MfF9IKxx9UhaYHVFQ1VKw0LYvBhkjZtPNUmCTYlGws0N7D2EaupmeIj/EWalqP47sQRedR9+VzARsONcwH8OCA==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.21.0"
+        }
+      },
+      "Microsoft.ApplicationInsights.PerfCounterCollector": {
+        "type": "Transitive",
+        "resolved": "2.21.0",
+        "contentHash": "RcckSVkfu+NkDie6/HyM6AVLHmTMVZrUrYnDeJdvRByOc2a+DqTM6KXMtsTHW/5+K7DT9QK5ZrZdi0YbBW8PVA==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.21.0",
+          "Microsoft.Extensions.Caching.Memory": "1.0.0",
+          "System.Diagnostics.PerformanceCounter": "4.7.0"
+        }
+      },
+      "Microsoft.ApplicationInsights.WindowsServer": {
+        "type": "Transitive",
+        "resolved": "2.21.0",
+        "contentHash": "Xbhss7dqbKyE5PENm1lRA9oxzhKEouKGMzgNqJ9xTHPZiogDwKVMK02qdbVhvaXKf9zG8RvvIpM5tnGR5o+Onw==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.21.0",
+          "Microsoft.ApplicationInsights.DependencyCollector": "2.21.0",
+          "Microsoft.ApplicationInsights.PerfCounterCollector": "2.21.0",
+          "Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel": "2.21.0",
+          "System.Diagnostics.DiagnosticSource": "5.0.0"
+        }
+      },
+      "Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel": {
+        "type": "Transitive",
+        "resolved": "2.21.0",
+        "contentHash": "7D4oq+9YyagEPx+0kNNOXdG6c7IDM/2d+637nAYKFqdWhNN0IqHZEed0DuG28waj7hBSLM9lBO+B8qQqgfE4rw==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.21.0",
+          "System.IO.FileSystem.AccessControl": "4.7.0"
+        }
+      },
+      "Microsoft.ApplicationInsights.WorkerService": {
+        "type": "Transitive",
+        "resolved": "2.21.0",
+        "contentHash": "Y/KcaQf+Jy92vdHTd2P8zoaW/IIUl4VkzGkvmBqi1IFQ0JXR4f6LXB73/2GMGhWMc7+QMVHeqW0QDjbLU6Fw5g==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.21.0",
+          "Microsoft.ApplicationInsights.DependencyCollector": "2.21.0",
+          "Microsoft.ApplicationInsights.EventCounterCollector": "2.21.0",
+          "Microsoft.ApplicationInsights.PerfCounterCollector": "2.21.0",
+          "Microsoft.ApplicationInsights.WindowsServer": "2.21.0",
+          "Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel": "2.21.0",
+          "Microsoft.Extensions.DependencyInjection": "2.1.1",
+          "Microsoft.Extensions.Logging.ApplicationInsights": "2.21.0"
+        }
+      },
+      "Microsoft.AspNet.WebApi.Client": {
+        "type": "Transitive",
+        "resolved": "5.2.7",
+        "contentHash": "/76fAHknzvFqbznS6Uj2sOyE9rJB3PltY+f53TH8dX9RiGhk02EhuFCWljSj5nnqKaTsmma8DFR50OGyQ4yJ1g==",
+        "dependencies": {
+          "Newtonsoft.Json": "10.0.1",
+          "Newtonsoft.Json.Bson": "1.0.1"
+        }
+      },
+      "Microsoft.AspNetCore.Cryptography.Internal": {
+        "type": "Transitive",
+        "resolved": "7.0.4",
+        "contentHash": "DmdKVBQCY34nO9pm1CijbT+AZc8tndD1uGXLUySaznl63i+xTe4PB0Gl5hQY+XMdEpjGN1ShER1ULYuAnOl6Fw=="
+      },
+      "Microsoft.AspNetCore.DataProtection": {
+        "type": "Transitive",
+        "resolved": "7.0.4",
+        "contentHash": "Al30Iak4d469xpa90w0otzv7zj893K0+YbZe/ot4hnah82MSaHkaVw5rPi5csPlQKsc6Iwznw/bH56tI1u61zg==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Cryptography.Internal": "7.0.4",
+          "Microsoft.AspNetCore.DataProtection.Abstractions": "7.0.4",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "7.0.0",
+          "Microsoft.Extensions.Hosting.Abstractions": "7.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "7.0.0",
+          "Microsoft.Extensions.Options": "7.0.1",
+          "System.Security.Cryptography.Xml": "7.0.1"
+        }
+      },
+      "Microsoft.AspNetCore.DataProtection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "7.0.4",
+        "contentHash": "LrTtzEkC28PBGDpohPtMOf26a8Sg5yvQyEtlG7z2YB93qloK2u8sqG6BDzj0rBiz/mpyVlkc8Nj36IJCvqWtPg=="
+      },
+      "Microsoft.Azure.AppConfiguration.Functions.Worker": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "cwj73rhjH27VOg5pGB7mlTkX6do96u733T8m8int62RuxcQRKQVTuzh91hpQYFsf9IFAgS/RAwdO7fTAPJ7vOA==",
+        "dependencies": {
+          "Microsoft.Azure.Functions.Worker": "1.6.0",
+          "Microsoft.Extensions.Configuration.AzureAppConfiguration": "6.0.0"
+        }
+      },
+      "Microsoft.Azure.Functions.Extensions": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "zYKtQQoS1fdzufxFApuMFiFtoi9QAGH6McXxntpylwLKgKjmCMWdgUd1dcekzTKNR9DPSDPRLiulvukqXnpWrQ==",
+        "dependencies": {
+          "Microsoft.Azure.WebJobs": "3.0.18",
+          "Microsoft.Extensions.DependencyInjection": "2.1.0"
+        }
+      },
+      "Microsoft.Azure.Functions.Worker": {
+        "type": "Transitive",
+        "resolved": "1.18.0",
+        "contentHash": "TN7OwMjHbsEX0xejRbuA/qkz0uLCoXyuhr/XoZIAcOEbj9vzRPjXD5VuTgwhFffUygkDIkLnnaGzP4peGOThAA==",
+        "dependencies": {
+          "Azure.Core": "1.10.0",
+          "Microsoft.Azure.Functions.Worker.Core": "1.14.0",
+          "Microsoft.Azure.Functions.Worker.Grpc": "1.13.0",
+          "Microsoft.Extensions.Hosting": "5.0.0",
+          "Microsoft.Extensions.Hosting.Abstractions": "5.0.0"
+        }
+      },
+      "Microsoft.Azure.Functions.Worker.ApplicationInsights": {
+        "type": "Transitive",
+        "resolved": "1.0.0-preview4",
+        "contentHash": "oX3LX4gOQr8kLoWVbNrXJFldDs3m0YKW2CKu7Nt96BMBThmSx8PdGTwfNX42tDmZ71G6dghoilhXH1oZGiUJfw==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights.WorkerService": "2.21.0",
+          "Microsoft.Azure.Functions.Worker.Core": "1.11.0",
+          "Microsoft.Bcl.AsyncInterfaces": "5.0.0"
+        }
+      },
+      "Microsoft.Azure.Functions.Worker.Core": {
+        "type": "Transitive",
+        "resolved": "1.14.0",
+        "contentHash": "9vqbGwRb7mmsplbCFWH4Yf8oco4fkypAZnNU4h3ZZSL4y1Vna/XJ2J9TwCEWc4M6nkillvQkD6zq9hhHSnLtRQ==",
+        "dependencies": {
+          "Azure.Core": "1.10.0",
+          "Microsoft.Extensions.Hosting": "5.0.0",
+          "Microsoft.Extensions.Hosting.Abstractions": "5.0.0",
+          "System.Collections.Immutable": "5.0.0",
+          "System.Diagnostics.DiagnosticSource": "7.0.0"
+        }
+      },
+      "Microsoft.Azure.Functions.Worker.Extensions.Abstractions": {
+        "type": "Transitive",
+        "resolved": "1.3.0",
+        "contentHash": "+6+/Yb/ouWUweaSQhesbbiIVSmwYEzkSfjIHrBnNqIiCYnx2iLeoYyWjN/wHP3Fnn5COtyDXRDwHKr5A/tCL9Q=="
+      },
+      "Microsoft.Azure.Functions.Worker.Extensions.EventGrid": {
+        "type": "Transitive",
+        "resolved": "2.1.0",
+        "contentHash": "8Kjhxaj2gK2Bi5K5jiNAG/e9tTlRItFNCINj+kfUDMBbf5lsiZUBChyAQCxrnITeHKkwAtgXB7GBX4W1Xcoc0A==",
+        "dependencies": {
+          "Microsoft.Azure.Functions.Worker.Extensions.Abstractions": "1.0.0"
+        }
+      },
+      "Microsoft.Azure.Functions.Worker.Extensions.SignalRService": {
+        "type": "Transitive",
+        "resolved": "1.7.0",
+        "contentHash": "mgk7ZnrXLPCI70cYgqxi+TJMJJgRMPYzZwIFMpxP2cto3D6XSxbF8eGj46T4DwopBBqWpfJ4Y2QFB93hNb4Yxg==",
+        "dependencies": {
+          "Microsoft.Azure.Functions.Worker.Extensions.Abstractions": "1.1.0",
+          "Microsoft.Extensions.Primitives": "5.0.1",
+          "System.Text.Json": "5.0.2"
+        }
+      },
+      "Microsoft.Azure.Functions.Worker.Extensions.Storage": {
+        "type": "Transitive",
+        "resolved": "5.0.1",
+        "contentHash": "jz2cF1BfkIrWzOUr73vPKtgTi6jnwv0hkKPcOYTO9fUbgc7Jehfo5Rny+W/f01yEIAF6j5oouqa4Bn+XsAFa6Q==",
+        "dependencies": {
+          "Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs": "5.0.1",
+          "Microsoft.Azure.Functions.Worker.Extensions.Storage.Queues": "5.0.0"
+        }
+      },
+      "Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs": {
+        "type": "Transitive",
+        "resolved": "5.0.1",
+        "contentHash": "b8+cj8YWiEGKMHyQvt3+Ynf3u8zy99uIHzOmUX8FAl+OVRfAe9k8uexih0uXXA+ZR6y+zOT8SarrVRQMxhnKtg==",
+        "dependencies": {
+          "Microsoft.Azure.Functions.Worker.Extensions.Abstractions": "1.1.0"
+        }
+      },
+      "Microsoft.Azure.Functions.Worker.Extensions.Storage.Queues": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "cF95kiiU6PD9sptrV3GKQKzRv2DYATYNTpOtvUtbAYQ4xPFKgF4ke3fDBcu+cu2O1/C8FQ7MhzkEQv00bx552A==",
+        "dependencies": {
+          "Microsoft.Azure.Functions.Worker.Extensions.Abstractions": "1.1.0"
+        }
+      },
+      "Microsoft.Azure.Functions.Worker.Extensions.Timer": {
+        "type": "Transitive",
+        "resolved": "4.1.0",
+        "contentHash": "8HvZaChaw40EKBfBew0XG132YhO6bEw0nznvey7gkhm9thUe6wkA2LXTXHXxcYefbx0rlh57WedSiJgKTG7MvQ==",
+        "dependencies": {
+          "Microsoft.Azure.Functions.Worker.Extensions.Abstractions": "1.0.0"
+        }
+      },
+      "Microsoft.Azure.Functions.Worker.Grpc": {
+        "type": "Transitive",
+        "resolved": "1.13.0",
+        "contentHash": "ZSd916dFjEqFUJ1Rfe/T5t3MHCnPXt/cefJ2YdN3zjufMp2ImD7KBnoROTOJ0NniNMd8Ais/MX1kFGpULfPpWg==",
+        "dependencies": {
+          "Azure.Core": "1.10.0",
+          "Google.Protobuf": "3.23.3",
+          "Grpc.Net.Client": "2.55.0",
+          "Grpc.Net.ClientFactory": "2.55.0",
+          "Microsoft.Azure.Functions.Worker.Core": "1.14.0",
+          "Microsoft.Azure.Functions.Worker.Extensions.Abstractions": "1.3.0",
+          "Microsoft.Extensions.Hosting": "5.0.0",
+          "Microsoft.Extensions.Hosting.Abstractions": "5.0.0"
+        }
+      },
+      "Microsoft.Azure.Functions.Worker.Sdk": {
+        "type": "Transitive",
+        "resolved": "1.10.0",
+        "contentHash": "U5N4c87aUvwfhjkox6A97MxM/PfXn3MctegV3VnaMPlVva/gnVMna4e3p2oGaOp/XDvJ1UmnPTcgj50yaKiZpg==",
+        "dependencies": {
+          "Microsoft.Azure.Functions.Worker.Sdk.Analyzers": "1.1.2",
+          "Microsoft.Azure.Functions.Worker.Sdk.Generators": "1.1.0-preview2"
+        }
+      },
+      "Microsoft.Azure.Functions.Worker.Sdk.Analyzers": {
+        "type": "Transitive",
+        "resolved": "1.1.2",
+        "contentHash": "e/7MOc5Tf40eiJgOBkg3O2LVtZZlqbh07Mldf/QKtNJ3JkFHHZNq8sMy5M/Ji6JOCOemSNpOwVtfSue7rJTp6Q=="
+      },
+      "Microsoft.Azure.Functions.Worker.Sdk.Generators": {
+        "type": "Transitive",
+        "resolved": "1.1.0-preview2",
+        "contentHash": "9mbUbe5AYkj8bvx2GNl4H1CzMS01nAhE/uCsjeSvQFEJs5mREQk6FafSbpVOXAaQ7JMgEZ3aGUfmwdCI94NoOw=="
+      },
+      "Microsoft.Azure.Management.Monitor": {
+        "type": "Transitive",
+        "resolved": "0.28.0-preview",
+        "contentHash": "XgWDDtop/1/uvO76GJ5vyjwvhkvnsLPgouqf7i9EU2QavWP8AL+Vu/aEL2wgPkGml6an+JSrrCKtI8eFjPCyGA==",
+        "dependencies": {
+          "Microsoft.Rest.ClientRuntime": "[2.3.20, 3.0.0)",
+          "Microsoft.Rest.ClientRuntime.Azure": "[3.3.19, 4.0.0)",
+          "Newtonsoft.Json": "10.0.3",
+          "System.Net.Http": "4.3.0"
+        }
+      },
+      "Microsoft.Azure.Management.OperationalInsights": {
+        "type": "Transitive",
+        "resolved": "0.24.0-preview",
+        "contentHash": "wPDI5PLv/whYHPArcmDOaemdhNBEgDfCUZbJcmuXy7TjNujp4ibwyCpbnyA6uwoeyhmsW/1tp9LnTQ5WnT4HuQ==",
+        "dependencies": {
+          "Microsoft.Rest.ClientRuntime": "[2.3.20, 3.0.0)",
+          "Microsoft.Rest.ClientRuntime.Azure": "[3.3.19, 4.0.0)",
+          "Newtonsoft.Json": "10.0.3",
+          "System.Net.Http": "4.3.0"
+        }
+      },
+      "Microsoft.Azure.WebJobs": {
+        "type": "Transitive",
+        "resolved": "3.0.18",
+        "contentHash": "aYJ76yjPkIpsafqFp1Xz1sA06RvhUwqJnk4AqX4I0teuRjPyig9Sv7LTzxUMAppKXc4JyR/Asos2At/LMiblqg==",
+        "dependencies": {
+          "Microsoft.Azure.WebJobs.Core": "3.0.18",
+          "Microsoft.Extensions.Configuration": "2.1.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "2.1.0",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "2.1.0",
+          "Microsoft.Extensions.Configuration.Json": "2.1.0",
+          "Microsoft.Extensions.Hosting": "2.1.0",
+          "Microsoft.Extensions.Logging": "2.1.0",
+          "Microsoft.Extensions.Logging.Abstractions": "2.1.0",
+          "Microsoft.Extensions.Logging.Configuration": "2.1.0",
+          "Newtonsoft.Json": "11.0.2",
+          "System.Threading.Tasks.Dataflow": "4.8.0"
+        }
+      },
+      "Microsoft.Azure.WebJobs.Core": {
+        "type": "Transitive",
+        "resolved": "3.0.18",
+        "contentHash": "ajYI8pPzPn4qq7FL8C2tz9WmFEG5PorUlkw8W9CF5M+5egnFJaF7yH48WYC+zBoQIzv2vHmFq0zhQpnv+O8v5Q==",
+        "dependencies": {
+          "System.ComponentModel.Annotations": "4.4.0",
+          "System.Diagnostics.TraceSource": "4.3.0"
+        }
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg=="
+      },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
         "resolved": "17.6.2",
         "contentHash": "t+DjPlq7GIxIkOK/jiTmNeiEMVkfVCynBEZyV+IMg2ro43NugKExng+7a04R1fBLi+d6voxjeDxL2ozdl+XyVg=="
       },
+      "Microsoft.CSharp": {
+        "type": "Transitive",
+        "resolved": "4.5.0",
+        "contentHash": "kaj6Wb4qoMuH3HySFJhxwQfe8R/sJsNJnANrvv8WdFPMoNbKY5htfNscv+LHCu5ipz+49m2e+WQXpLXr9XYemQ=="
+      },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "Transitive",
+        "resolved": "7.0.0",
+        "contentHash": "IeimUd0TNbhB4ded3AbgBLQv2SnsiVugDyGV1MvspQFVlA07nDC7Zul7kcwH5jWN3JiTcp/ySE83AIJo8yfKjg==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "7.0.0"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "Transitive",
+        "resolved": "7.0.0",
+        "contentHash": "xpidBs2KCE2gw1JrD0quHE72kvCaI3xFql5/Peb2GRtUuZX+dYPoK/NTdVMiM67Svym0M0Df9A3xyU0FbMQhHw==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "7.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "7.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "7.0.0",
+          "Microsoft.Extensions.Options": "7.0.0",
+          "Microsoft.Extensions.Primitives": "7.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "LN322qEKHjuVEhhXueTUe7RNePooZmS8aGid5aK2woX3NPjSnONFyKUc6+JknOS6ce6h2tCLfKPTBXE3mN/6Ag==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "5.0.0",
+          "Microsoft.Extensions.Primitives": "5.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "7.0.0",
+        "contentHash": "f34u2eaqIjNO9YLHBz8rozVZ+TcFiFs0F3r7nUJd7FRkVSxk8u4OpoK226mi49MwexHOR2ibP9MFvRUaLilcQQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "7.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.AzureAppConfiguration": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "oRCr8qqBp/37CXttfgbEWnPznHy0/ZCkgNVFFQ5cnXGvG8TBWicnAK032opyrbGIH3n2jYSg/PvIw7aLoOTy3Q==",
+        "dependencies": {
+          "Azure.Data.AppConfiguration": "1.2.0",
+          "Azure.Messaging.EventGrid": "4.7.0",
+          "Azure.Security.KeyVault.Secrets": "4.3.0",
+          "Microsoft.Extensions.Configuration": "3.1.18",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.18",
+          "Microsoft.Extensions.Logging": "3.1.18",
+          "System.Text.Json": "4.7.2"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "Of1Irt1+NzWO+yEYkuDh5TpT4On7LKl98Q9iLqCdOZps6XXEWDj3AKtmyvzJPVXZe4apmkJJIiDL7rR1yC+hjQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "5.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.CommandLine": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "OelM+VQdhZ0XMXsEQBq/bt3kFzD+EBGqR4TAgFDRAye0JfvHAaRi+3BxCRcwqUAwDhV0U0HieljBGHlTgYseRA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "5.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "5.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.EnvironmentVariables": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "fqh6y6hAi0Z0fRsb4B/mP9OkKkSlifh5osa+N/YSQ+/S2a//+zYApZMUC1XeP9fdjlgZoPQoZ72Q2eLHyKLddQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "5.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "5.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.FileExtensions": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "rRdspYKA18ViPOISwAihhCMbusHsARCOtDMwa23f+BGEdIjpKPlhs3LLjmKlxfhpGXBjIsS0JpXcChjRUN+PAw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "5.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "5.0.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "5.0.0",
+          "Microsoft.Extensions.FileProviders.Physical": "5.0.0",
+          "Microsoft.Extensions.Primitives": "5.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Json": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "Pak8ymSUfdzPfBTLHxeOwcR32YDbuVfhnH2hkfOLnJNQd19ItlBdpMjIDY9C5O/nS2Sn9bzDMai0ZrvF7KyY/Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "5.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "5.0.0",
+          "Microsoft.Extensions.Configuration.FileExtensions": "5.0.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "5.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.UserSecrets": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "+tK3seG68106lN277YWQvqmfyI/89w0uTu/5Gz5VYSUu5TI4mqwsaWLlSmT9Bl1yW/i1Nr06gHJxqaqB5NU9Tw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "5.0.0",
+          "Microsoft.Extensions.Configuration.Json": "5.0.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "5.0.0",
+          "Microsoft.Extensions.FileProviders.Physical": "5.0.0"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Transitive",
+        "resolved": "7.0.0",
+        "contentHash": "elNeOmkeX3eDVG6pYVeV82p29hr+UKDaBhrZyWvWLw/EVZSYEkZlQdkp0V39k/Xehs2Qa0mvoCvkVj3eQxNQ1Q==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "7.0.0"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "7.0.0",
+        "contentHash": "h3j/QfmFN4S0w4C2A6X7arXij/M/OVw3uQHSOFxnND4DyAzO1F9eMX7Eti7lU/OkSthEE0WzRsfT/Dmx86jzCw=="
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "7.0.0",
+        "contentHash": "NyawiW9ZT/liQb34k9YqBSNPLuuPkrjMgQZ24Y/xXX1RoiBkLUdPMaQTmxhZ5TYu8ZKZ9qayzil75JX95vGQUg==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "7.0.0"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Physical": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "1rkd8UO2qf21biwO7X0hL9uHP7vtfmdv/NLvKgCRHkdz1XnW8zVQJXyEYiN68WYpExgtVWn55QF0qBzgfh1mGg==",
+        "dependencies": {
+          "Microsoft.Extensions.FileProviders.Abstractions": "5.0.0",
+          "Microsoft.Extensions.FileSystemGlobbing": "5.0.0",
+          "Microsoft.Extensions.Primitives": "5.0.0"
+        }
+      },
+      "Microsoft.Extensions.FileSystemGlobbing": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "ArliS8lGk8sWRtrWpqI8yUVYJpRruPjCDT+EIjrgkA/AAPRctlAkRISVZ334chAKktTLzD1+PK8F5IZpGedSqA=="
+      },
+      "Microsoft.Extensions.Hosting": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "hiokSU1TOVfcqpQAnpiOzP2rE9p+niq92g5yeAnwlbSrUlIdIS6M8emCknZvhdOagQA9x5YWNwe1n0kFUwE0NQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "5.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "5.0.0",
+          "Microsoft.Extensions.Configuration.Binder": "5.0.0",
+          "Microsoft.Extensions.Configuration.CommandLine": "5.0.0",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "5.0.0",
+          "Microsoft.Extensions.Configuration.FileExtensions": "5.0.0",
+          "Microsoft.Extensions.Configuration.Json": "5.0.0",
+          "Microsoft.Extensions.Configuration.UserSecrets": "5.0.0",
+          "Microsoft.Extensions.DependencyInjection": "5.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "5.0.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "5.0.0",
+          "Microsoft.Extensions.FileProviders.Physical": "5.0.0",
+          "Microsoft.Extensions.Hosting.Abstractions": "5.0.0",
+          "Microsoft.Extensions.Logging": "5.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "5.0.0",
+          "Microsoft.Extensions.Logging.Configuration": "5.0.0",
+          "Microsoft.Extensions.Logging.Console": "5.0.0",
+          "Microsoft.Extensions.Logging.Debug": "5.0.0",
+          "Microsoft.Extensions.Logging.EventLog": "5.0.0",
+          "Microsoft.Extensions.Logging.EventSource": "5.0.0",
+          "Microsoft.Extensions.Options": "5.0.0"
+        }
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "Transitive",
+        "resolved": "7.0.0",
+        "contentHash": "43n9Je09z0p/7ViPxfRqs5BUItRLNVh5b6JH40F2Agkh2NBsY/jpNYTtbCcxrHCsA3oRmbR6RJBzUutB4VZvNQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "7.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "7.0.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "7.0.0"
+        }
+      },
+      "Microsoft.Extensions.Http": {
+        "type": "Transitive",
+        "resolved": "3.0.3",
+        "contentHash": "dcyB8szIcSynjVZRuFgqkZpPgTc5zeRSj1HMXSmNqWbHYKiPYJl8ZQgBHz6wmZNSUUNGpCs5uxUg8DZHHDC1Ew==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.0.3",
+          "Microsoft.Extensions.Logging": "3.0.3",
+          "Microsoft.Extensions.Options": "3.0.3"
+        }
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "7.0.0",
+        "contentHash": "Nw2muoNrOG5U5qa2ZekXwudUn2BJcD41e65zwmDHb1fQegTX66UokLWZkJRpqSSHXDOWZ5V0iqhbxOEky91atA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "7.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "7.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "7.0.0",
+          "Microsoft.Extensions.Options": "7.0.0"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "Transitive",
+        "resolved": "7.0.0",
+        "contentHash": "kmn78+LPVMOWeITUjIlfxUPDsI0R6G0RkeAMBmQxAJ7vBJn4q2dTva7pWi65ceN5vPGjJ9q/Uae2WKgvfktJAw=="
+      },
+      "Microsoft.Extensions.Logging.ApplicationInsights": {
+        "type": "Transitive",
+        "resolved": "2.21.0",
+        "contentHash": "tjzErt5oaLs1caaThu6AbtJuHH0oIGDG/rYCXDruHVGig3m8MyCDuwDsGQwzimY7g4aFyLOKfHc3unBN2G96gw==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.21.0",
+          "Microsoft.Extensions.Logging": "2.1.1"
+        }
+      },
+      "Microsoft.Extensions.Logging.Configuration": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "N3/d0HeMRnBekadbZlmbp+In8EvNNkQHSdbtRzjrGVckdZWpYs5GNrAfaYqVplDFW0WUedSaFJ3khB50BWYGsw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "5.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "5.0.0",
+          "Microsoft.Extensions.Configuration.Binder": "5.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "5.0.0",
+          "Microsoft.Extensions.Logging": "5.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "5.0.0",
+          "Microsoft.Extensions.Options": "5.0.0",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "5.0.0"
+        }
+      },
+      "Microsoft.Extensions.Logging.Console": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "jH0wbWhfvXjOVmCkbra4vbiovDtTUIWLQjCeJ7Xun3h4AHvwfzm7V7wlsXKs3tNnPrsCxZ9oaV0vUAgGY1JxOA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "5.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "5.0.0",
+          "Microsoft.Extensions.Logging": "5.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "5.0.0",
+          "Microsoft.Extensions.Logging.Configuration": "5.0.0",
+          "Microsoft.Extensions.Options": "5.0.0",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "5.0.0"
+        }
+      },
+      "Microsoft.Extensions.Logging.Debug": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "9dvt0xqRrClvhaPNpfyS39WxnW9G55l5lrV5ZX7IrEgwo4VwtmJKtoPiKVYKbhAuOBGUI5WY3hWLvF+PSbJp5A==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "5.0.0",
+          "Microsoft.Extensions.Logging": "5.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "5.0.0"
+        }
+      },
+      "Microsoft.Extensions.Logging.EventLog": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "CYzsgF2lqgahGl/HuErsIDaZZ9ueN+MBjGfO/0jVDLPaXLaywxlGKFpDgXMaB053DRYZwD1H2Lb1I60mTXS3jg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "5.0.0",
+          "Microsoft.Extensions.Logging": "5.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "5.0.0",
+          "Microsoft.Extensions.Options": "5.0.0",
+          "System.Diagnostics.EventLog": "5.0.0"
+        }
+      },
+      "Microsoft.Extensions.Logging.EventSource": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "hF+D6PJkrM0qXcSEGs1BwZwgP8c0BRkj26P/5wmYTcHKOp52GRey/Z/YKRmRIHIrXxj9tz/JgIjU9oWmiJ5HMw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "5.0.0",
+          "Microsoft.Extensions.Logging": "5.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "5.0.0",
+          "Microsoft.Extensions.Options": "5.0.0",
+          "Microsoft.Extensions.Primitives": "5.0.0"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "Transitive",
+        "resolved": "7.0.1",
+        "contentHash": "pZRDYdN1FpepOIfHU62QoBQ6zdAoTvnjxFfqAzEd9Jhb2dfhA5i6jeTdgGgcgTWFRC7oT0+3XrbQu4LjvgX1Nw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "7.0.0",
+          "Microsoft.Extensions.Primitives": "7.0.0"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "280RxNJqOeQqq47aJLy5D9LN61CAWeuRA83gPToQ8B9jl9SNdQ5EXjlfvF66zQI5AXMl+C/3hGnbtIEN+X3mqA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "5.0.0",
+          "Microsoft.Extensions.Configuration.Binder": "5.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "5.0.0",
+          "Microsoft.Extensions.Options": "5.0.0",
+          "Microsoft.Extensions.Primitives": "5.0.0"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "7.0.0",
+        "contentHash": "um1KU5kxcRp3CNuI8o/GrZtD4AIOXDk+RLsytjZ9QPok3ttLUelLKpilVPuaFT3TFjOhSibUAso0odbOaCDj3Q=="
+      },
+      "Microsoft.FeatureManagement": {
+        "type": "Transitive",
+        "resolved": "2.5.1",
+        "contentHash": "ERbRjk0etZs4d5Pv17unfogO4iBwV2c/HoBt4jqIJmfbKbmTLV+GbjBPYzidIg2RgYIFi8yA+EoEapSAIOp19g==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Binder": "2.1.10",
+          "Microsoft.Extensions.Logging": "2.1.1"
+        }
+      },
+      "Microsoft.Graph": {
+        "type": "Transitive",
+        "resolved": "4.37.0",
+        "contentHash": "XfbRLmmyJkNcNFbjC+FP+LgeFiOk2cNn7TeLh9A2T24UXCwy8Kz4rKTvfmdgYUAO8fcSe4kkGNOmfG1H6Myktg==",
+        "dependencies": {
+          "Microsoft.Graph.Core": "2.0.12"
+        }
+      },
+      "Microsoft.Graph.Core": {
+        "type": "Transitive",
+        "resolved": "2.0.12",
+        "contentHash": "3a6vQADJMDJX0ZrU+lVYjlJxpsDAJNUmgB8vXodwrlGHkHJP7TqsQZ43MeU35XkoPfWtEj06+Hed3SLFlkoqAg==",
+        "dependencies": {
+          "Azure.Core": "1.25.0",
+          "Microsoft.Identity.Client": "4.46.1",
+          "Microsoft.IdentityModel.Protocols.OpenIdConnect": "6.22.0",
+          "System.Diagnostics.DiagnosticSource": "4.7.1",
+          "System.Net.Http": "4.3.4",
+          "System.Security.Claims": "4.3.0",
+          "System.Text.Json": "6.0.5"
+        }
+      },
+      "Microsoft.Identity.Client.Extensions.Msal": {
+        "type": "Transitive",
+        "resolved": "2.25.3",
+        "contentHash": "I6/Od0d3OMD9b7RPxW1l25A8oA94H+r9ZtrOe4Ogk49Ftxhs9RS+pbzPE5dLe0i7nQy+1aob7mR22YsNcc0BiQ==",
+        "dependencies": {
+          "Microsoft.Identity.Client": "4.49.1",
+          "System.IO.FileSystem.AccessControl": "5.0.0",
+          "System.Security.Cryptography.ProtectedData": "4.5.0"
+        }
+      },
+      "Microsoft.Identity.Web.Diagnostics": {
+        "type": "Transitive",
+        "resolved": "2.7.0",
+        "contentHash": "SOY9upekrafFvrVToTXMX8hLUtvJM/OSIXTirq4/LkU6I7IlNRmZ7ULddD4D/r4mS6JoV3lWcLYAkcfnS2JGQg=="
+      },
+      "Microsoft.Identity.Web.TokenCache": {
+        "type": "Transitive",
+        "resolved": "2.7.0",
+        "contentHash": "lyPG8/zAfMETuynAGX3xC3ZlSfs8BoFoJ+3aqOxl8CdGYsHkB+faSHo/m1Qi5Snq08MQ8Ld6tx6rY8h7Pf31xQ==",
+        "dependencies": {
+          "Microsoft.AspNetCore.DataProtection": "7.0.4",
+          "Microsoft.Extensions.Caching.Memory": "7.0.0",
+          "Microsoft.Extensions.Logging": "7.0.0",
+          "Microsoft.Identity.Client": "4.51.0",
+          "Microsoft.Identity.Web.Diagnostics": "2.7.0",
+          "System.Drawing.Common": "4.7.2",
+          "System.Security.Cryptography.Xml": "7.0.1",
+          "System.Text.Encodings.Web": "7.0.0"
+        }
+      },
       "Microsoft.IdentityModel.Abstractions": {
         "type": "Transitive",
+        "resolved": "6.29.0",
+        "contentHash": "qBEGruUGU5YkqV58ykpbtT5oUWzChe+xVy/siPFPzB4KydqDv6r91ElbiifIn9ncAceFtuEkIUQWav76lg7e0A=="
+      },
+      "Microsoft.IdentityModel.JsonWebTokens": {
+        "type": "Transitive",
+        "resolved": "6.29.0",
+        "contentHash": "lJRNpOKsPqCSf1DRDlWUsM272DQKhfLtU7dKAVOnJBsN5z1wP5lncdY1RqC5uAMdGspsyjSLe0qs1aWl+lIGZQ==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "6.29.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Text.Encodings.Web": "4.7.2",
+          "System.Text.Json": "4.7.2"
+        }
+      },
+      "Microsoft.IdentityModel.Logging": {
+        "type": "Transitive",
+        "resolved": "6.29.0",
+        "contentHash": "71GkXXyBNnIzs2Ybgi7FamQSrieVNPo+FLKECnFQOOgfIZdJ4jz5O3kBY7wIj4l8GbD+nKZkWYvcl6/Yk5up5g==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Abstractions": "6.29.0"
+        }
+      },
+      "Microsoft.IdentityModel.Protocols": {
+        "type": "Transitive",
         "resolved": "6.22.0",
-        "contentHash": "iI+9V+2ciCrbheeLjpmjcqCnhy+r6yCoEcid3nkoFWerHgjVuT6CPM4HODUTtUPe1uwks4wcnAujJ8u+IKogHQ=="
+        "contentHash": "DZ9yTL2xSk2C3i6QjOgQvNhfSnQ3ZnmOEVlmL2i4ZQHw3jigZmioE8XGv59Ba7rnk6xAl+Oo8DxlkZv4qU/4rQ==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Logging": "6.22.0",
+          "Microsoft.IdentityModel.Tokens": "6.22.0"
+        }
+      },
+      "Microsoft.IdentityModel.Protocols.OpenIdConnect": {
+        "type": "Transitive",
+        "resolved": "6.22.0",
+        "contentHash": "Ig+zgdXT5rbzhN71TkjeHd7HMWO+wq89V5KecXWgJvNrWKTp2xVerDsWqM5SUz7UU3d1m6aotq4ABKZuNn71qA==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Protocols": "6.22.0",
+          "System.IdentityModel.Tokens.Jwt": "6.22.0"
+        }
+      },
+      "Microsoft.IdentityModel.Tokens": {
+        "type": "Transitive",
+        "resolved": "6.29.0",
+        "contentHash": "llkQIhO3E/+7iXjGywJmBUe+kdyygsFo2RGlzFEGxPQRN7sgZDGk9pM6aJ/aFM3oQeugKWfM30wPFMgT69FXeQ==",
+        "dependencies": {
+          "Microsoft.CSharp": "4.5.0",
+          "Microsoft.IdentityModel.Logging": "6.29.0",
+          "System.Security.Cryptography.Cng": "4.5.0"
+        }
       },
       "Microsoft.NETCore.Platforms": {
         "type": "Transitive",
-        "resolved": "1.1.1",
-        "contentHash": "TMBuzAHpTenGbGgk0SMTwyEkyijY/Eae4ZGsFNYJvAr/LDn1ku3Etp3FPxChmDp5HHF3kzJuoaa08N0xjqAJfQ=="
+        "resolved": "5.0.0",
+        "contentHash": "VyPlqzH2wavqquTcYpkIIAQ6WdenuKoFN0BdYBbCWsclXacSOHNQn66Gt4z5NBqEYW0FAPm5rlvki9ZiCij5xQ=="
       },
       "Microsoft.NETCore.Targets": {
         "type": "Transitive",
         "resolved": "1.1.3",
         "contentHash": "3Wrmi0kJDzClwAC+iBdUBpEKmEle8FQNsCs77fkiOIw/9oYA07bL1EZNX0kQ2OMN3xpwvl0vAtOCYY3ndDNlhQ=="
+      },
+      "Microsoft.Rest.ClientRuntime": {
+        "type": "Transitive",
+        "resolved": "2.3.24",
+        "contentHash": "hZH7XgM3eV2jFrnq7Yf0nBD4WVXQzDrer2gEY7HMNiwio2hwDsTHO6LWuueNQAfRpNp4W7mKxcXpwXUiuVIlYw==",
+        "dependencies": {
+          "Newtonsoft.Json": "10.0.3"
+        }
+      },
+      "Microsoft.Rest.ClientRuntime.Azure": {
+        "type": "Transitive",
+        "resolved": "3.3.19",
+        "contentHash": "+NVBWvRXNwaAPTZUxjUlQggsrf3X0GbiRoxYfgc3kG9E55ZxZxvZPT3nIfC4DNqzGSXUEvmLbckdXgBBzGdUaA==",
+        "dependencies": {
+          "Microsoft.Rest.ClientRuntime": "[2.3.19, 3.0.0)",
+          "Newtonsoft.Json": "10.0.3"
+        }
+      },
+      "Microsoft.TeamFoundation.DistributedTask.Common.Contracts": {
+        "type": "Transitive",
+        "resolved": "19.219.0-preview",
+        "contentHash": "+LYJnc0rlPNJg2T5TgVkjPOypJxslwxbD/ALl3DM7c3UB0Ttmqx546A1VXJeab9ofxgHnaxzElNIOlmJEPY6rQ==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Services.Client": "[19.219.0-preview]"
+        }
+      },
+      "Microsoft.TeamFoundationServer.Client": {
+        "type": "Transitive",
+        "resolved": "19.219.0-preview",
+        "contentHash": "0Jkm+SOVEW7W9ym/C4v3P1CUJ0E50/dFXjOeRyAYwnKqxG22VliDZgpAlnQ0M7vDk2M2Tldo6mKsKWZebX9d0g==",
+        "dependencies": {
+          "Microsoft.AspNet.WebApi.Client": "5.2.7",
+          "Microsoft.TeamFoundation.DistributedTask.Common.Contracts": "[19.219.0-preview]",
+          "Microsoft.VisualStudio.Services.Client": "[19.219.0-preview]",
+          "Newtonsoft.Json": "13.0.2",
+          "System.ComponentModel.Annotations": "5.0.0"
+        }
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
@@ -149,6 +1116,22 @@
           "Newtonsoft.Json": "13.0.1"
         }
       },
+      "Microsoft.VisualStudio.Services.Client": {
+        "type": "Transitive",
+        "resolved": "19.219.0-preview",
+        "contentHash": "RGtUL3Q/qSxJZtcRZApB91W2vAGTNwaO7nzAyN86vtAzm8u/pEVlBvoEZ1wx6HF4JRvFlyWvUHN+Z6kAj6nk8w==",
+        "dependencies": {
+          "Microsoft.AspNet.WebApi.Client": "5.2.7",
+          "Newtonsoft.Json": "13.0.2",
+          "System.Configuration.ConfigurationManager": "6.0.1",
+          "System.Data.SqlClient": "4.8.5",
+          "System.Security.Cryptography.Cng": "5.0.0",
+          "System.Security.Cryptography.OpenSsl": "5.0.0",
+          "System.Security.Cryptography.ProtectedData": "6.0.0",
+          "System.Security.Principal.Windows": "5.0.0",
+          "System.Xml.XPath.XmlDocument": "4.3.0"
+        }
+      },
       "Microsoft.Win32.Primitives": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -158,6 +1141,20 @@
           "Microsoft.NETCore.Targets": "1.1.0",
           "System.Runtime": "4.3.0"
         }
+      },
+      "Microsoft.Win32.Registry": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "dDoKi0PnDz31yAyETfRntsLArTlVAVzUzCIvvEDsDsucrl33Dl8pIJG06ePTJTI3tGpeyHS9Cq7Foc/s4EeKcg==",
+        "dependencies": {
+          "System.Security.AccessControl": "5.0.0",
+          "System.Security.Principal.Windows": "5.0.0"
+        }
+      },
+      "Microsoft.Win32.SystemEvents": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "hqTM5628jSsQiv+HGpiq3WKBl2c8v1KZfby2J6Pr7pEPlK9waPdgEO6b8A/+/xn/yZ9ulv8HuqK71ONy2tg67A=="
       },
       "NETStandard.Library": {
         "type": "Transitive",
@@ -212,13 +1209,56 @@
       },
       "Newtonsoft.Json": {
         "type": "Transitive",
-        "resolved": "13.0.1",
-        "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
+        "resolved": "13.0.2",
+        "contentHash": "R2pZ3B0UjeyHShm9vG+Tu0EBb2lC8b0dFzV9gVn50ofHXh9Smjk6kTn7A/FdAsC8B5cKib1OnGYOXxRBz5XQDg=="
+      },
+      "Newtonsoft.Json.Bson": {
+        "type": "Transitive",
+        "resolved": "1.0.1",
+        "contentHash": "5PYT/IqQ+UK31AmZiSS102R6EsTo+LGTSI8bp7WAUqDKaF4wHXD8U9u4WxTI1vc64tYi++8p3dk3WWNqPFgldw==",
+        "dependencies": {
+          "NETStandard.Library": "1.6.1",
+          "Newtonsoft.Json": "10.0.1"
+        }
       },
       "NuGet.Frameworks": {
         "type": "Transitive",
         "resolved": "6.5.0",
         "contentHash": "QWINE2x3MbTODsWT1Gh71GaGb5icBz4chS8VYvTgsBnsi8esgN6wtHhydd7fvToWECYGq7T4cgBBDiKD/363fg=="
+      },
+      "Octokit": {
+        "type": "Transitive",
+        "resolved": "2.0.1",
+        "contentHash": "JVlfUY+sfItl6RSyVKDJTutuy28cDydUwKKfzcelwNMor2Sa18pYVKna6phO8lug1b+ep+pcuFh/FPayuImsQw=="
+      },
+      "OpenTelemetry.Api": {
+        "type": "Transitive",
+        "resolved": "1.5.0-rc.1",
+        "contentHash": "KQYeO/UgV1WoaxOh9l4qV15T1FVow7Aflz1yplSgdnJPqji62hD9+hCe2tQ001iJ9l/mv1/x0xfVEZlRfwDaUA==",
+        "dependencies": {
+          "System.Diagnostics.DiagnosticSource": "7.0.0"
+        }
+      },
+      "Polly": {
+        "type": "Transitive",
+        "resolved": "8.0.0-alpha.2",
+        "contentHash": "CrZqfioV2FG4ip7622CKk7B0Jey6fttRzVGu7Md6MVcIotQxZqR/zy8FW8dUL0B15whoCW5U0t1JBd27Pm1GXw==",
+        "dependencies": {
+          "Polly.Core": "8.0.0-alpha.2"
+        }
+      },
+      "Polly.Core": {
+        "type": "Transitive",
+        "resolved": "8.0.0-alpha.2",
+        "contentHash": "X58/YFxm15uRJyA1Bo1ZPNSYOXmu1MD4CQD4BJr/a0qVOGPkqJOucSQVP6bcQSGgrZXLgPEGZbgSHtJx9qE0VQ=="
+      },
+      "Polly.Extensions.Http": {
+        "type": "Transitive",
+        "resolved": "3.0.0",
+        "contentHash": "drrG+hB3pYFY7w1c3BD+lSGYvH2oIclH8GRSehgfyP5kjnFnHKQuuBhuHLv+PWyFuaTDyk/vfRpnxOzd11+J8g==",
+        "dependencies": {
+          "Polly": "7.1.0"
+        }
       },
       "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
         "type": "Transitive",
@@ -242,6 +1282,16 @@
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.1.0",
           "Microsoft.NETCore.Targets": "1.1.0"
+        }
+      },
+      "runtime.native.System.Data.SqlClient.sni": {
+        "type": "Transitive",
+        "resolved": "4.7.0",
+        "contentHash": "9kyFSIdN3T0qjDQ2R0HRXYIhS3l5psBzQi6qqhdLz+SzFyEy4sVxNOke+yyYv8Cu8rPER12c3RDjLT8wF3WBYQ==",
+        "dependencies": {
+          "runtime.win-arm64.runtime.native.System.Data.SqlClient.sni": "4.4.0",
+          "runtime.win-x64.runtime.native.System.Data.SqlClient.sni": "4.4.0",
+          "runtime.win-x86.runtime.native.System.Data.SqlClient.sni": "4.4.0"
         }
       },
       "runtime.native.System.IO.Compression": {
@@ -327,6 +1377,36 @@
         "resolved": "4.3.2",
         "contentHash": "leXiwfiIkW7Gmn7cgnNcdtNAU70SjmKW3jxGj1iKHOvdn0zRWsgv/l2OJUO5zdGdiv2VRFnAsxxhDgMzofPdWg=="
       },
+      "runtime.win-arm64.runtime.native.System.Data.SqlClient.sni": {
+        "type": "Transitive",
+        "resolved": "4.4.0",
+        "contentHash": "LbrynESTp3bm5O/+jGL8v0Qg5SJlTV08lpIpFesXjF6uGNMWqFnUQbYBJwZTeua6E/Y7FIM1C54Ey1btLWupdg=="
+      },
+      "runtime.win-x64.runtime.native.System.Data.SqlClient.sni": {
+        "type": "Transitive",
+        "resolved": "4.4.0",
+        "contentHash": "38ugOfkYJqJoX9g6EYRlZB5U2ZJH51UP8ptxZgdpS07FgOEToV+lS11ouNK2PM12Pr6X/PpT5jK82G3DwH/SxQ=="
+      },
+      "runtime.win-x86.runtime.native.System.Data.SqlClient.sni": {
+        "type": "Transitive",
+        "resolved": "4.4.0",
+        "contentHash": "YhEdSQUsTx+C8m8Bw7ar5/VesXvCFMItyZF7G1AUY+OM0VPZUOeAVpJ4Wl6fydBGUYZxojTDR3I6Bj/+BPkJNA=="
+      },
+      "Scriban": {
+        "type": "Transitive",
+        "resolved": "5.5.0",
+        "contentHash": "e6n2qpSPlOx43+y1PeEukwu5n4i0slIUIMaFSndiIydfNuVqRbqL2QLd4y+BzFWDfN349YT71N/J38CH2IYb+w=="
+      },
+      "Semver": {
+        "type": "Transitive",
+        "resolved": "2.1.0",
+        "contentHash": "1jUT0PwgKO9d9F/X2n762qLp7v/30OpMtJPFRtmjPXUX2/J0lnqiGiSJNNsW3yYTj5StF0Z1yE36TrvtGpcbrg=="
+      },
+      "SmartAnalyzers.CSharpExtensions.Annotations": {
+        "type": "Transitive",
+        "resolved": "4.2.7",
+        "contentHash": "9fRFxTUwPmH7lukckwEvvKawMcP8ObwnOngN8kx5Bx773WHSku1EGa5BIteV07th5553il76fPX7U1xz2bFmuQ=="
+      },
       "System.AppContext": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -374,12 +1454,23 @@
           "System.Threading.Tasks": "4.3.0"
         }
       },
+      "System.Collections.Immutable": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "FXkLXiK0sVVewcso0imKQoOxjoPAj42R8HtjjbSjVPAzwDfzoyoznWxgA3c38LDbN9SJux1xXoXYAhz98j7r2g=="
+      },
+      "System.ComponentModel.Annotations": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "dMkqfy2el8A8/I76n2Hi1oBFEbG1SfxD2l5nhwXV3XjlnOmwxJlQbYpJH4W51odnU9sARCSAgv7S3CyAFMkpYg=="
+      },
       "System.Configuration.ConfigurationManager": {
         "type": "Transitive",
-        "resolved": "4.4.0",
-        "contentHash": "gWwQv/Ug1qWJmHCmN17nAbxJYmQBM/E94QxKLksvUiiKB1Ld3Sc/eK1lgmbSjDFxkQhVuayI/cGFZhpBSodLrg==",
+        "resolved": "6.0.1",
+        "contentHash": "jXw9MlUu/kRfEU0WyTptAVueupqIeE3/rl0EZDMlf8pcvJnitQ8HeVEp69rZdaStXwTV72boi/Bhw8lOeO+U2w==",
         "dependencies": {
-          "System.Security.Cryptography.ProtectedData": "4.4.0"
+          "System.Security.Cryptography.ProtectedData": "6.0.0",
+          "System.Security.Permissions": "6.0.0"
         }
       },
       "System.Console": {
@@ -394,6 +1485,16 @@
           "System.Text.Encoding": "4.3.0"
         }
       },
+      "System.Data.SqlClient": {
+        "type": "Transitive",
+        "resolved": "4.8.5",
+        "contentHash": "fRqxut4lrndPHrXD+ht1XRmCL3obuKldm4XjCRYS9p5f7FSR7shBxAwTkDrpFMsHC9BhNgjjmUtiIjvehn5zkg==",
+        "dependencies": {
+          "Microsoft.Win32.Registry": "4.7.0",
+          "System.Security.Principal.Windows": "4.7.0",
+          "runtime.native.System.Data.SqlClient.sni": "4.7.0"
+        }
+      },
       "System.Diagnostics.Debug": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -406,14 +1507,28 @@
       },
       "System.Diagnostics.DiagnosticSource": {
         "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "tD6kosZnTAGdrEa0tZSuFyunMbt/5KYDnHdndJYGqZoNy00XVXyACd5d6KnE1YgYv3ne2CjtAfNXo/fwEhnKUA==",
+        "resolved": "8.0.0-preview.4.23259.5",
+        "contentHash": "p7bkTixVHLOALaNlqX+8uBMT68Fbo0yoEigLQ6ya9wNRPThGx5V14et7kf9pVQbR9gN1H2zqSPbX0y8nrXTq+g=="
+      },
+      "System.Diagnostics.EventLog": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "FHkCwUfsTs+/5tsK+c0egLfacUgbhvcwi3wUFWSEEArSXao343mYqcpOVVFMlcCkdNtjU4YwAWaKYwal6f02og==",
         "dependencies": {
-          "System.Collections": "4.3.0",
-          "System.Diagnostics.Tracing": "4.3.0",
-          "System.Reflection": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Threading": "4.3.0"
+          "Microsoft.NETCore.Platforms": "5.0.0",
+          "Microsoft.Win32.Registry": "5.0.0",
+          "System.Security.Principal.Windows": "5.0.0"
+        }
+      },
+      "System.Diagnostics.PerformanceCounter": {
+        "type": "Transitive",
+        "resolved": "4.7.0",
+        "contentHash": "kE9szT4i3TYT9bDE/BPfzg9/BL6enMiZlcUmnUEBrhRtxWvurKoa8qhXkLTRhrxMzBqaDleWlRfIPE02tulU+w==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "3.1.0",
+          "Microsoft.Win32.Registry": "4.7.0",
+          "System.Configuration.ConfigurationManager": "4.7.0",
+          "System.Security.Principal.Windows": "4.7.0"
         }
       },
       "System.Diagnostics.Tools": {
@@ -426,6 +1541,22 @@
           "System.Runtime": "4.3.0"
         }
       },
+      "System.Diagnostics.TraceSource": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "VnYp1NxGx8Ww731y2LJ1vpfb/DKVNKEZ8Jsh5SgQTZREL/YpWRArgh9pI8CDLmgHspZmLL697CaLvH85qQpRiw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Threading": "4.3.0",
+          "runtime.native.System": "4.3.0"
+        }
+      },
       "System.Diagnostics.Tracing": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -434,6 +1565,14 @@
           "Microsoft.NETCore.Platforms": "1.1.0",
           "Microsoft.NETCore.Targets": "1.1.0",
           "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Drawing.Common": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "NfuoKUiP2nUWwKZN6twGqXioIe1zVD0RIj2t976A+czLHr2nY454RwwXs6JU9Htc6mwqL6Dn/nEL3dpVf2jOhg==",
+        "dependencies": {
+          "Microsoft.Win32.SystemEvents": "6.0.0"
         }
       },
       "System.Formats.Asn1": {
@@ -473,6 +1612,15 @@
           "System.Runtime": "4.3.0",
           "System.Runtime.Extensions": "4.3.0",
           "System.Runtime.InteropServices": "4.3.0"
+        }
+      },
+      "System.IdentityModel.Tokens.Jwt": {
+        "type": "Transitive",
+        "resolved": "6.29.0",
+        "contentHash": "2WwptlYJQffT6z7V0WVoChznOBjacAIByLSoXp5fZ8kK33heAAqn/aX50xB+cQNfKFYRGVbqiVrzz+m80Q2zcA==",
+        "dependencies": {
+          "Microsoft.IdentityModel.JsonWebTokens": "6.29.0",
+          "Microsoft.IdentityModel.Tokens": "6.29.0"
         }
       },
       "System.IO": {
@@ -540,6 +1688,15 @@
           "System.Threading.Tasks": "4.3.0"
         }
       },
+      "System.IO.FileSystem.AccessControl": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "SxHB3nuNrpptVk+vZ/F+7OHEpoHUIKKMl02bUmYHQr1r+glbZQxs7pRtsf4ENO29TVm2TH3AEeep2fJcy92oYw==",
+        "dependencies": {
+          "System.Security.AccessControl": "5.0.0",
+          "System.Security.Principal.Windows": "5.0.0"
+        }
+      },
       "System.IO.FileSystem.Primitives": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -547,6 +1704,11 @@
         "dependencies": {
           "System.Runtime": "4.3.0"
         }
+      },
+      "System.IO.Hashing": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "Rfm2jYCaUeGysFEZjDe7j1R4x6Z6BzumS/vUT5a1AA/AWJuGX71PoGB0RmpyX3VmrGqVnAwtfMn39OHR8Y/5+g=="
       },
       "System.Linq": {
         "type": "Transitive",
@@ -558,6 +1720,14 @@
           "System.Resources.ResourceManager": "4.3.0",
           "System.Runtime": "4.3.0",
           "System.Runtime.Extensions": "4.3.0"
+        }
+      },
+      "System.Linq.Async": {
+        "type": "Transitive",
+        "resolved": "6.0.1",
+        "contentHash": "0YhHcaroWpQ9UCot3Pizah7ryAzQhNvobLMSxeDIGmnXfkQn8u5owvpOH0K6EVB+z9L7u6Cc4W17Br/+jyttEQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "6.0.0"
         }
       },
       "System.Linq.Expressions": {
@@ -584,6 +1754,20 @@
           "System.Threading": "4.3.0"
         }
       },
+      "System.Memory": {
+        "type": "Transitive",
+        "resolved": "4.5.4",
+        "contentHash": "1MbJTHS1lZ4bS4FmsJjnuGJOu88ZzTT2rLvrhW7Ygic+pC0NWA+3hgAen0HRdsocuQXCkUTdFn9yHJJhsijDXw=="
+      },
+      "System.Memory.Data": {
+        "type": "Transitive",
+        "resolved": "1.0.2",
+        "contentHash": "JGkzeqgBsiZwKJZ1IxPNsDFZDhUvuEdX8L8BDC8N3KOj+6zMcNU28CNN59TpZE/VJYy9cP+5M+sbxtWJx3/xtw==",
+        "dependencies": {
+          "System.Text.Encodings.Web": "4.7.2",
+          "System.Text.Json": "4.6.0"
+        }
+      },
       "System.Net.Primitives": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -607,6 +1791,11 @@
           "System.Runtime": "4.3.0",
           "System.Threading.Tasks": "4.3.0"
         }
+      },
+      "System.Numerics.Vectors": {
+        "type": "Transitive",
+        "resolved": "4.5.0",
+        "contentHash": "QQTlPTl06J/iiDbJCiepZ4H//BVraReU4O4EoRw1U02H5TLUIT7xn3GnDp9AXPSlJUDyFs4uWjWafNX6WrAojQ=="
       },
       "System.ObjectModel": {
         "type": "Transitive",
@@ -721,6 +1910,11 @@
           "Microsoft.NETCore.Targets": "1.1.3"
         }
       },
+      "System.Runtime.CompilerServices.Unsafe": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "/iUeP3tq1S0XdNNoMz5C9twLSrM/TH+qElHkXWaPvuNOt+99G75NrV0OS2EqHx5wMN7popYjpc8oTjC1y16DLg=="
+      },
       "System.Runtime.Extensions": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -779,6 +1973,25 @@
           "System.Runtime.Extensions": "4.3.0"
         }
       },
+      "System.Security.AccessControl": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "AUADIc0LIEQe7MzC+I0cl0rAT8RrTAKFHl53yHjEUzNVIaUlhFY11vc2ebiVJzVBuOzun6F7FBA+8KAbGTTedQ=="
+      },
+      "System.Security.Claims": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "P/+BR/2lnc4PNDHt/TPBAWHVMLMRHsyYZbU1NphW4HIWzCggz8mJbTQQ3MKljFE7LS3WagmVFuBgoLcFzYXlkA==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Security.Principal": "4.3.0"
+        }
+      },
       "System.Security.Cryptography.Algorithms": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -802,20 +2015,10 @@
       },
       "System.Security.Cryptography.Cng": {
         "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "03idZOqFlsKRL4W+LuCpJ6dBYDUWReug6lZjBa3uJWnk5sPCUXckocevTaUA8iT/MFSrY/2HXkOt753xQ/cf8g==",
+        "resolved": "5.0.0",
+        "contentHash": "jIMXsKn94T9JY7PvPq/tMfqa6GAaHpElRDpmG+SuL+D3+sTw2M8VhnibKnN8Tq+4JqbPJ/f+BwtLeDMEnzAvRg==",
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.1.0",
-          "System.IO": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Runtime.Extensions": "4.3.0",
-          "System.Runtime.Handles": "4.3.0",
-          "System.Runtime.InteropServices": "4.3.0",
-          "System.Security.Cryptography.Algorithms": "4.3.0",
-          "System.Security.Cryptography.Encoding": "4.3.0",
-          "System.Security.Cryptography.Primitives": "4.3.0",
-          "System.Text.Encoding": "4.3.0"
+          "System.Formats.Asn1": "5.0.0"
         }
       },
       "System.Security.Cryptography.Csp": {
@@ -859,22 +2062,10 @@
       },
       "System.Security.Cryptography.OpenSsl": {
         "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "h4CEgOgv5PKVF/HwaHzJRiVboL2THYCou97zpmhjghx5frc7fIvlkY1jL+lnIQyChrJDMNEXS6r7byGif8Cy4w==",
+        "resolved": "5.0.0",
+        "contentHash": "D3aDrPOPBORUl6V/WJ2AtN3Ae48aSH0W7yChBIecvu1lyoAhopPORmMpNTjv5/Kay7Z+h3KXpfbvteIm7x7miA==",
         "dependencies": {
-          "System.Collections": "4.3.0",
-          "System.IO": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Runtime.Extensions": "4.3.0",
-          "System.Runtime.Handles": "4.3.0",
-          "System.Runtime.InteropServices": "4.3.0",
-          "System.Runtime.Numerics": "4.3.0",
-          "System.Security.Cryptography.Algorithms": "4.3.0",
-          "System.Security.Cryptography.Encoding": "4.3.0",
-          "System.Security.Cryptography.Primitives": "4.3.0",
-          "System.Text.Encoding": "4.3.0",
-          "runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0"
+          "System.Formats.Asn1": "5.0.0"
         }
       },
       "System.Security.Cryptography.Primitives": {
@@ -893,8 +2084,8 @@
       },
       "System.Security.Cryptography.ProtectedData": {
         "type": "Transitive",
-        "resolved": "4.4.0",
-        "contentHash": "cJV7ScGW7EhatRsjehfvvYVBvtiSMKgN8bOVI0bQhnF5bU7vnHVIsH49Kva7i7GWaWYvmEzkYVk1TC+gZYBEog=="
+        "resolved": "6.0.0",
+        "contentHash": "rp1gMNEZpvx9vP0JW0oHLxlf8oSiQgtno77Y4PLUBjSiDYoD77Y8uXHr1Ea5XG4/pIKhqAdxZ8v8OTUtqo9PeQ=="
       },
       "System.Security.Cryptography.X509Certificates": {
         "type": "Transitive",
@@ -928,6 +2119,36 @@
           "runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0"
         }
       },
+      "System.Security.Cryptography.Xml": {
+        "type": "Transitive",
+        "resolved": "7.0.1",
+        "contentHash": "MCxBCtH0GrDuvU63ZODwQHQZPchb24pUAX3MfZ6b13qg246ZD10PRdOvay8C9HBPfCXkymUNwFPEegud7ax2zg==",
+        "dependencies": {
+          "System.Security.Cryptography.Pkcs": "7.0.0"
+        }
+      },
+      "System.Security.Permissions": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "T/uuc7AklkDoxmcJ7LGkyX1CcSviZuLCa4jg3PekfJ7SU0niF0IVTXwUiNVP9DSpzou2PpxJ+eNY2IfDM90ZCg==",
+        "dependencies": {
+          "System.Security.AccessControl": "6.0.0",
+          "System.Windows.Extensions": "6.0.0"
+        }
+      },
+      "System.Security.Principal": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "I1tkfQlAoMM2URscUtpcRo/hX0jinXx6a/KUtEQoz3owaYwl3qwsO8cbzYVVnjxrzxjHo3nJC+62uolgeGIS9A==",
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Security.Principal.Windows": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "t0MGLukB5WAVU9bO3MGzvlGnyJPgUlcwerXn1kzBRjwLKixT96XV0Uza41W49gVd8zEMFu9vQEFlv0IOrytICA=="
+      },
       "System.Text.Encoding": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -949,6 +2170,20 @@
           "System.Text.Encoding": "4.3.0"
         }
       },
+      "System.Text.Encodings.Web": {
+        "type": "Transitive",
+        "resolved": "7.0.0",
+        "contentHash": "OP6umVGxc0Z0MvZQBVigj4/U31Pw72ITihDWP9WiWDm+q5aoe0GaJivsfYGq53o6dxH7DcXWiCTl7+0o2CGdmg=="
+      },
+      "System.Text.Json": {
+        "type": "Transitive",
+        "resolved": "6.0.5",
+        "contentHash": "SSH+YYrMpvLcy7Orzb5K1tSyffnFacWahyxCCjYH1PbSHdAF4dekmIetBurFKgtTHDmwEe/J2Csi/7niRH6d/g==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0",
+          "System.Text.Encodings.Web": "6.0.0"
+        }
+      },
       "System.Threading": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -968,15 +2203,15 @@
           "System.Runtime": "4.3.0"
         }
       },
+      "System.Threading.Tasks.Dataflow": {
+        "type": "Transitive",
+        "resolved": "4.8.0",
+        "contentHash": "PSIdcgbyNv7FZvZ1I9Mqy6XZOwstYYMdZiXuHvIyc0gDyPjEhrrP9OvTGDHp+LAHp1RNSLjPYssyqox9+Kt9Ug=="
+      },
       "System.Threading.Tasks.Extensions": {
         "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "npvJkVKl5rKXrtl1Kkm6OhOUaYGEiF9wFbppFRWSMoApKzt2PiPHT2Bb8a5sAWxprvdOAtvaARS9QYMznEUtug==",
-        "dependencies": {
-          "System.Collections": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Threading.Tasks": "4.3.0"
-        }
+        "resolved": "4.5.4",
+        "contentHash": "zteT+G8xuGu6mS+mzDzYXbzS7rd3K6Fjb9RiZlYlJPam2/hU7JCBZBVEcywNuR+oZ1ncTvc/cq0faRr3P01OVg=="
       },
       "System.Threading.Timer": {
         "type": "Transitive",
@@ -986,6 +2221,14 @@
           "Microsoft.NETCore.Platforms": "1.1.0",
           "Microsoft.NETCore.Targets": "1.1.0",
           "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Windows.Extensions": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "IXoJOXIqc39AIe+CIR7koBtRGMiCt/LPM3lI+PELtDIy9XdyeSrwXFdWV9dzJ2Awl0paLWUaknLxFQ5HpHZUog==",
+        "dependencies": {
+          "System.Drawing.Common": "6.0.0"
         }
       },
       "System.Xml.ReaderWriter": {
@@ -1028,6 +2271,61 @@
           "System.Threading": "4.3.0",
           "System.Xml.ReaderWriter": "4.3.0"
         }
+      },
+      "System.Xml.XmlDocument": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "lJ8AxvkX7GQxpC6GFCeBj8ThYVyQczx2+f/cWHJU8tjS7YfI6Cv6bon70jVEgs2CiFbmmM8b9j1oZVx0dSI2Ww==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Xml.ReaderWriter": "4.3.0"
+        }
+      },
+      "System.Xml.XPath": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "v1JQ5SETnQusqmS3RwStF7vwQ3L02imIzl++sewmt23VGygix04pEH+FCj1yWb+z4GDzKiljr1W7Wfvrx0YwgA==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Xml.ReaderWriter": "4.3.0"
+        }
+      },
+      "System.Xml.XPath.XmlDocument": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "A/uxsWi/Ifzkmd4ArTLISMbfFs6XpRPsXZonrIqyTY70xi8t+mDtvSM5Os0RqyRDobjMBwIDHDL4NOIbkDwf7A==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Xml.ReaderWriter": "4.3.0",
+          "System.Xml.XPath": "4.3.0",
+          "System.Xml.XmlDocument": "4.3.0"
+        }
+      },
+      "TaskTupleAwaiter": {
+        "type": "Transitive",
+        "resolved": "2.0.3",
+        "contentHash": "RUdwpeaZpj98w1dQw295V950qGGtoVdPbhxU1UBazR9pOAX6YpK9qc17u9swRhlKTDY2PvHIXODrNwFXGC/jvw=="
       },
       "xunit.abstractions": {
         "type": "Transitive",
@@ -1072,6 +2370,56 @@
         "dependencies": {
           "NETStandard.Library": "1.6.1",
           "xunit.extensibility.core": "[2.5.0]"
+        }
+      },
+      "apiservice": {
+        "type": "Project",
+        "dependencies": {
+          "Azure.Data.Tables": "[12.8.0, )",
+          "Azure.Identity": "[1.8.2, )",
+          "Azure.Messaging.EventGrid": "[4.15.0, )",
+          "Azure.ResourceManager": "[1.6.0, )",
+          "Azure.ResourceManager.Compute": "[1.0.0-beta.8, )",
+          "Azure.ResourceManager.Monitor": "[1.0.0-beta.2, )",
+          "Azure.ResourceManager.Network": "[1.0.0, )",
+          "Azure.ResourceManager.Resources": "[1.6.0, )",
+          "Azure.ResourceManager.Storage": "[1.0.0-beta.11, )",
+          "Azure.Security.KeyVault.Secrets": "[4.3.0, )",
+          "Azure.Storage.Blobs": "[12.13.0, )",
+          "Azure.Storage.Queues": "[12.11.0, )",
+          "Faithlife.Utility": "[0.12.2, )",
+          "Microsoft.Azure.AppConfiguration.Functions.Worker": "[6.0.0, )",
+          "Microsoft.Azure.Functions.Extensions": "[1.1.0, )",
+          "Microsoft.Azure.Functions.Worker": "[1.18.0, )",
+          "Microsoft.Azure.Functions.Worker.ApplicationInsights": "[1.0.0-preview4, )",
+          "Microsoft.Azure.Functions.Worker.Extensions.EventGrid": "[2.1.0, )",
+          "Microsoft.Azure.Functions.Worker.Extensions.Http": "[3.0.13, )",
+          "Microsoft.Azure.Functions.Worker.Extensions.SignalRService": "[1.7.0, )",
+          "Microsoft.Azure.Functions.Worker.Extensions.Storage": "[5.0.1, )",
+          "Microsoft.Azure.Functions.Worker.Extensions.Timer": "[4.1.0, )",
+          "Microsoft.Azure.Functions.Worker.Sdk": "[1.10.0, )",
+          "Microsoft.Azure.Management.Monitor": "[0.28.0-preview, )",
+          "Microsoft.Azure.Management.OperationalInsights": "[0.24.0-preview, )",
+          "Microsoft.Extensions.Logging.ApplicationInsights": "[2.21.0, )",
+          "Microsoft.FeatureManagement": "[2.5.1, )",
+          "Microsoft.Graph": "[4.37.0, )",
+          "Microsoft.Identity.Client": "[4.52.0, )",
+          "Microsoft.Identity.Web.TokenCache": "[2.7.0, )",
+          "Microsoft.Rest.ClientRuntime": "[2.3.24, )",
+          "Microsoft.TeamFoundationServer.Client": "[19.219.0-preview, )",
+          "Octokit": "[2.0.1, )",
+          "OpenTelemetry.Api": "[1.5.0-rc.1, )",
+          "Polly": "[8.0.0-alpha.2, )",
+          "Polly.Extensions.Http": "[3.0.0, )",
+          "Scriban": "[5.5.0, )",
+          "Semver": "[2.1.0, )",
+          "SmartAnalyzers.CSharpExtensions.Annotations": "[4.2.7, )",
+          "System.Diagnostics.DiagnosticSource": "[8.0.0-preview.4.23259.5, )",
+          "System.IdentityModel.Tokens.Jwt": "[6.29.0, )",
+          "System.Linq.Async": "[6.0.1, )",
+          "System.Security.Cryptography.Pkcs": "[7.0.2, )",
+          "System.Text.RegularExpressions": "[4.3.1, )",
+          "TaskTupleAwaiter": "[2.0.3, )"
         }
       }
     }

--- a/src/ApiService/IntegrationTests/packages.lock.json
+++ b/src/ApiService/IntegrationTests/packages.lock.json
@@ -1417,8 +1417,8 @@
       },
       "Semver": {
         "type": "Transitive",
-        "resolved": "2.1.0",
-        "contentHash": "1jUT0PwgKO9d9F/X2n762qLp7v/30OpMtJPFRtmjPXUX2/J0lnqiGiSJNNsW3yYTj5StF0Z1yE36TrvtGpcbrg=="
+        "resolved": "2.3.0",
+        "contentHash": "4vYo1zqn6pJ1YrhjuhuOSbIIm0CpM47grbpTJ5ABjOlfGt/EhMEM9ed4MRK5Jr6gVnntWDqOUzGeUJp68PZGjw=="
       },
       "SmartAnalyzers.CSharpExtensions.Annotations": {
         "type": "Transitive",
@@ -2544,7 +2544,7 @@
           "Polly": "[8.0.0-alpha.2, )",
           "Polly.Extensions.Http": "[3.0.0, )",
           "Scriban": "[5.5.0, )",
-          "Semver": "[2.1.0, )",
+          "Semver": "[2.3.0, )",
           "SmartAnalyzers.CSharpExtensions.Annotations": "[4.2.7, )",
           "System.Diagnostics.DiagnosticSource": "[8.0.0-preview.4.23259.5, )",
           "System.IdentityModel.Tokens.Jwt": "[6.29.0, )",

--- a/src/ApiService/Tests/packages.lock.json
+++ b/src/ApiService/Tests/packages.lock.json
@@ -1420,8 +1420,8 @@
       },
       "Semver": {
         "type": "Transitive",
-        "resolved": "2.1.0",
-        "contentHash": "1jUT0PwgKO9d9F/X2n762qLp7v/30OpMtJPFRtmjPXUX2/J0lnqiGiSJNNsW3yYTj5StF0Z1yE36TrvtGpcbrg=="
+        "resolved": "2.3.0",
+        "contentHash": "4vYo1zqn6pJ1YrhjuhuOSbIIm0CpM47grbpTJ5ABjOlfGt/EhMEM9ed4MRK5Jr6gVnntWDqOUzGeUJp68PZGjw=="
       },
       "SmartAnalyzers.CSharpExtensions.Annotations": {
         "type": "Transitive",
@@ -2547,7 +2547,7 @@
           "Polly": "[8.0.0-alpha.2, )",
           "Polly.Extensions.Http": "[3.0.0, )",
           "Scriban": "[5.5.0, )",
-          "Semver": "[2.1.0, )",
+          "Semver": "[2.3.0, )",
           "SmartAnalyzers.CSharpExtensions.Annotations": "[4.2.7, )",
           "System.Diagnostics.DiagnosticSource": "[8.0.0-preview.4.23259.5, )",
           "System.IdentityModel.Tokens.Jwt": "[6.29.0, )",

--- a/src/cli/onefuzz/backend.py
+++ b/src/cli/onefuzz/backend.py
@@ -41,8 +41,8 @@ from tenacity.retry import retry_if_exception_type
 from tenacity.stop import stop_after_attempt
 from tenacity.wait import wait_random
 
-from .azcopy import azcopy_copy, azcopy_sync
 from .__version__ import __version__
+from .azcopy import azcopy_copy, azcopy_sync
 
 _ACCESSTOKENCACHE_UMASK = 0o077
 

--- a/src/cli/onefuzz/backend.py
+++ b/src/cli/onefuzz/backend.py
@@ -374,7 +374,7 @@ class Backend:
         ):
             self.config_params()
         headers = self.headers()
-        if str.lower(os.environ.get("ONEFUZZ_STRICT_VERSIONING")) == "true":
+        if str.lower(os.environ.get("ONEFUZZ_STRICT_VERSIONING") or "") == "true":
             headers["Strict-Version"] = "true"
         json_data = serialize(json_data)
 

--- a/src/cli/onefuzz/backend.py
+++ b/src/cli/onefuzz/backend.py
@@ -42,6 +42,7 @@ from tenacity.stop import stop_after_attempt
 from tenacity.wait import wait_random
 
 from .azcopy import azcopy_copy, azcopy_sync
+from .__version__ import __version__
 
 _ACCESSTOKENCACHE_UMASK = 0o077
 
@@ -191,7 +192,9 @@ class Backend:
             os.unlink(self.token_path)
 
     def headers(self) -> Dict[str, str]:
-        value = {}
+        value = {
+            "Cli-Version": __version__,
+        }
         if self.config.client_id is not None:
             access_token = self.get_access_token()
             value["Authorization"] = "%s %s" % (
@@ -371,6 +374,8 @@ class Backend:
         ):
             self.config_params()
         headers = self.headers()
+        if str.lower(os.environ.get("ONEFUZZ_STRICT_VERSIONING")) == "true":
+            headers["Strict-Version"] = "true"
         json_data = serialize(json_data)
 
         # 401 errors with IDX10501: Signature validation failed occur

--- a/src/pytypes/onefuzztypes/enums.py
+++ b/src/pytypes/onefuzztypes/enums.py
@@ -305,6 +305,7 @@ class ErrorCode(Enum):
     ADO_VALIDATION_INVALID_PATH = 495
     ADO_VALIDATION_INVALID_PROJECT = 496
     INVALID_RETENTION_PERIOD = 497
+    INVALID_CLI_VERSION = 498
     # NB: if you update this enum, also update Enums.cs
 
 


### PR DESCRIPTION
## Summary of the Pull Request

Adds middleware to the ApiService that checks for two headers: `cli-version` and `strict-version`
If both headers are present _and_ the `strict-version` is set to true, then the middleware will compare the supplied version with the service version and immediately send back a 400 response to requests with out of date versions.

On the CLI end, this feature is opted into by setting the `ONEFUZZ_STRICT_VERSIONING` environment variable to true (case insensitive).

## PR Checklist
* [ ] Applies to work item: #xxx
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/onefuzz) and sign the CLI.
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_

## Validation Steps Performed

Added unit tests for the following cases:
* [x] neither header provided
* [x] one header provided but not the other
* [x] both headers, but `strict-version` != true
* [x] both headers and `strict-version` == true

(Both valid and invalid values are tested for each case, where applicable)
