### PR TITLE
Make `debug logs get` behave more intuitively

### DIFF
--- a/src/cli/onefuzz/debug.py
+++ b/src/cli/onefuzz/debug.py
@@ -712,7 +712,7 @@ class DebugLog(Command):
 
         if not all:
             # Don't want to say we're downloading 2 files right after saying only 1 was found
-            last = min(last, len(files))
+            last = min(last, len(files)) if last == None else len(files)
             files = files[:last]
             if granularity == "job":
                 self.logger.info(

--- a/src/cli/onefuzz/debug.py
+++ b/src/cli/onefuzz/debug.py
@@ -651,6 +651,10 @@ class DebugLog(Command):
         :param bool all: (DEPRECATED) This option is a no-op. Now that machines have just one log file, getting the most recent logs implies downloading all of the log files.
         """
 
+        # Appease mypy while these options are still part of the API
+        del last
+        del all
+
         from typing import cast
         from urllib import parse
 

--- a/src/cli/onefuzz/debug.py
+++ b/src/cli/onefuzz/debug.py
@@ -712,7 +712,7 @@ class DebugLog(Command):
 
         if not all:
             # Don't want to say we're downloading 2 files right after saying only 1 was found
-            last = min(last, len(files)) if last == None else len(files)
+            last = min(last, len(files)) if last != None else len(files)
             files = files[:last]
             if granularity == "job":
                 self.logger.info(

--- a/src/cli/onefuzz/debug.py
+++ b/src/cli/onefuzz/debug.py
@@ -712,7 +712,7 @@ class DebugLog(Command):
 
         if not all:
             # Don't want to say we're downloading 2 files right after saying only 1 was found
-            last = min(last, len(files)) if last != None else len(files)
+            last = min(last, len(files)) if last is not None else len(files)
             files = files[:last]
             if granularity == "job":
                 self.logger.info(

--- a/src/cli/onefuzz/debug.py
+++ b/src/cli/onefuzz/debug.py
@@ -667,11 +667,14 @@ class DebugLog(Command):
                 f"Job with id {job_id} does not have a logging location configured"
             )
 
+        granularity = "job"
         file_path = None
         if task_id is not None:
+            granularity = "task"
             file_path = f"{task_id}/"
 
             if machine_id is not None:
+                granularity = "machine"
                 file_path += f"{machine_id}/"
 
         container_name = parse.urlsplit(container_url).path[1:]
@@ -708,8 +711,34 @@ class DebugLog(Command):
             return None
 
         if not all:
-            self.logger.info(f"Downloading only the {last} most recent files")
+            # Don't want to say we're downloading 2 files right after saying only 1 was found
+            last = min(last, len(files))
             files = files[:last]
+            if granularity == "job":
+                self.logger.info(
+                    f"Downloading only the {last} most recent file(s) among the tasks associated with the job with id {job_id}"
+                )
+            elif granularity == "task":
+                self.logger.info(
+                    f"Downloading only the {last} most recent file(s) among the machines associated with the task with id {task_id}"
+                )
+            else:
+                self.logger.info(
+                    f"Downloading only the {last} most recent file(s) for the machine with id {machine_id}"
+                )
+        else:
+            if granularity == "job":
+                self.logger.info(
+                    f"Downloading all of the files for each task associated with the job with id {job_id}"
+                )
+            elif granularity == "task":
+                self.logger.info(
+                    f"Downloading all of the files for each machine associated with the task with id {task_id}"
+                )
+            else:
+                self.logger.info(
+                    f"Downloading all of the files for the machine with id {machine_id}"
+                )
 
         for f in files:
             self.logger.info(f"Downloading {f.name}")


### PR DESCRIPTION
## Summary of the Pull Request

A few facets to this PR:
1. Add an optional `--out_dir` parameter to specify where to download the logs.
2. Deprecate the `--last` and `--all` options, making them no-ops.
3. Update the behavior to now always download all available logs (see #3572).
4. Update the logs to the console to reflect the new behavior.

## PR Checklist
* [x] Applies to work item: #3490, #3572
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/onefuzz) and sign the CLI.
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_

## Validation Steps Performed

Local validation
