### PR TITLE
Add input_path to dotnet report task expander

### DIFF
--- a/src/agent/onefuzz-task/src/tasks/report/dotnet/generic.rs
+++ b/src/agent/onefuzz-task/src/tasks/report/dotnet/generic.rs
@@ -207,7 +207,7 @@ impl AsanProcessor {
         let mut args = vec![target_exe];
         args.extend(self.config.target_options.clone());
 
-        let expand = self.config.get_expand();
+        let expand = self.config.get_expand().input_path(input);
 
         let expanded_args = expand.evaluate(&args)?;
 


### PR DESCRIPTION
## Summary of the Pull Request

Forgot to run check-pr on my last change before merging. This adds the parameter that's causing the break.

## PR Checklist
* [ ] Applies to work item: #xxx
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/onefuzz) and sign the CLI.
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_

## Validation Steps Performed

_How does someone test & validate?_
