### PR TITLE
Shortcut file-added earlier

### DIFF
--- a/src/ApiService/ApiService/Functions/QueueFileChanges.cs
+++ b/src/ApiService/ApiService/Functions/QueueFileChanges.cs
@@ -76,6 +76,11 @@ public class QueueFileChanges {
         var container = Container.Parse(parts[0]);
         var path = string.Join('/', parts.Skip(1));
 
+        // We don't want to store file added events for the events container because that causes an infinite loop
+        if (container == WellKnownContainers.Events) {
+            return Result.Ok();
+        }
+
         _log.LogInformation("file added : {Container} - {Path}", container.String, path);
 
         var (_, result) = await (

--- a/src/ApiService/ApiService/onefuzzlib/NotificationOperations.cs
+++ b/src/ApiService/ApiService/onefuzzlib/NotificationOperations.cs
@@ -22,11 +22,6 @@ public class NotificationOperations : Orm<Notification>, INotificationOperations
 
     }
     public async Async.Task<OneFuzzResultVoid> NewFiles(Container container, string filename) {
-        // We don't want to store file added events for the events container because that causes an infinite loop
-        if (container == WellKnownContainers.Events) {
-            return Result.Ok();
-        }
-
         var result = OneFuzzResultVoid.Ok;
         var notifications = GetNotifications(container);
         var hasNotifications = await notifications.AnyAsync();


### PR DESCRIPTION
Move event-skipping behaviour earlier so it is also performed for the retention policy handler. This will help churn through these events faster.