### PR TITLE
Parallelize some timer work

### DIFF
--- a/src/ApiService/ApiService/Functions/TimerTasks.cs
+++ b/src/ApiService/ApiService/Functions/TimerTasks.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Azure.Functions.Worker;
+﻿using System.Threading.Tasks;
+using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 namespace Microsoft.OneFuzz.Service.Functions;
 
@@ -22,35 +23,34 @@ public class TimerTasks {
 
     [Function("TimerTasks")]
     public async Async.Task Run([TimerTrigger("00:00:15")] TimerInfo myTimer) {
-        var expriredTasks = _taskOperations.SearchExpired();
-        await foreach (var task in expriredTasks) {
+        // perform up to 10 updates in parallel for each entity type
+        var parallelOptions = new ParallelOptions { MaxDegreeOfParallelism = 10 };
+
+        var expiredTasks = _taskOperations.SearchExpired();
+        await Parallel.ForEachAsync(expiredTasks, parallelOptions, async (task, _cancel) => {
             _logger.LogInformation("stopping expired task. job_id:{JobId} task_id:{TaskId}", task.JobId, task.TaskId);
             await _taskOperations.MarkStopping(task, "task is expired");
-        }
-
+        });
 
         var expiredJobs = _jobOperations.SearchExpired();
-
-        await foreach (var job in expiredJobs) {
+        await Parallel.ForEachAsync(expiredJobs, parallelOptions, async (job, _cancel) => {
             _logger.LogInformation("stopping expired job. job_id:{JobId}", job.JobId);
             _ = await _jobOperations.Stopping(job);
-        }
+        });
 
         var jobs = _jobOperations.SearchState(states: JobStateHelper.NeedsWork);
-
-        await foreach (var job in jobs) {
+        await Parallel.ForEachAsync(jobs, parallelOptions, async (job, _cancel) => {
             _logger.LogInformation("update job: {JobId}", job.JobId);
             _ = await _jobOperations.ProcessStateUpdates(job);
-        }
+        });
 
         var tasks = _taskOperations.SearchStates(states: TaskStateHelper.NeedsWorkStates);
-        await foreach (var task in tasks) {
+        await Parallel.ForEachAsync(tasks, parallelOptions, async (task, _cancel) => {
             _logger.LogInformation("update task: {TaskId}", task.TaskId);
             _ = await _taskOperations.ProcessStateUpdate(task);
-        }
+        });
 
         await _scheduler.ScheduleTasks();
-
         await _jobOperations.StopNeverStartedJobs();
     }
 }


### PR DESCRIPTION
When we update distinct entities we can perform the updates in parallel. Do this in `TimerTasks` and `TimerWorkers`.